### PR TITLE
Require pandas>=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "tabulate",
   "rich",
   "pyarrow",
+  "pandas>=2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I got this error in `eegdash/dataset/registry.py:270`:
```
TypeError: NDFrame.infer_objects() got an unexpected keyword argument 'copy'
```
The copy parameter was introduced in pandas 2.0.0. See [release notes](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html)