### PR TITLE
fix: resolve dataset loading errors from encoding, coordsystem, and task discovery

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -28,6 +28,7 @@ from .io import (
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
     _repair_snirf_bids_metadata,
+    _repair_tsv_encoding,
     _repair_vhdr_pointers,
 )
 
@@ -167,6 +168,7 @@ class EEGDashRaw(RawDataset):
         # Helper: Fix MNE-BIDS strictness regarding coordsystem.json location
         if self.filecache and self.filecache.parent.exists():
             _ensure_coordsystem_symlink(self.filecache.parent)
+            _repair_tsv_encoding(self.filecache.parent)
 
         # Helper: Handle VHDR files - generate if missing, repair if broken
         if self.filecache and self.filecache.suffix == ".vhdr":

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -201,7 +201,9 @@ class EEGDashRaw(RawDataset):
         """
         try:
             # First attempt: standard MNE-BIDS loading
-            return mne_bids.read_raw_bids(bids_path=self.bidspath, verbose="ERROR")
+            return mne_bids.read_raw_bids(
+                bids_path=self.bidspath, verbose="ERROR", on_ch_mismatch="rename"
+            )
         except Exception as first_error:
             # For SNIRF files, try to fix and retry
             if self.filecache and self.filecache.suffix.lower() == ".snirf":
@@ -212,7 +214,9 @@ class EEGDashRaw(RawDataset):
                     # Retry after fix
                     try:
                         return mne_bids.read_raw_bids(
-                            bids_path=self.bidspath, verbose="ERROR"
+                            bids_path=self.bidspath,
+                            verbose="ERROR",
+                            on_ch_mismatch="rename",
                         )
                     except Exception as retry_error:
                         logger.error(f"Retry also failed: {retry_error}")

--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -32,6 +32,20 @@ _MODALITY_DIR_ALIASES = {
     "fnirs": ["nirs", "fnirs"],
 }
 
+_TSV_ENCODINGS = ("utf-8", "cp1252", "latin-1")
+
+
+def _read_tsv_column(tsv_path: Path, column: str) -> list[str]:
+    """Read a column from a TSV file, trying multiple encodings."""
+    for encoding in _TSV_ENCODINGS:
+        try:
+            return pd.read_csv(tsv_path, sep="\t", encoding=encoding)[column].tolist()
+        except UnicodeDecodeError:
+            continue
+        except Exception:
+            return []
+    return []
+
 
 class EEGBIDSDataset:
     """An interface to a local BIDS dataset containing electrophysiology recordings.
@@ -496,85 +510,29 @@ class EEGBIDSDataset:
 
         return json_attrs.get(attribute)
 
-    def channel_labels(self, data_filepath: str) -> list[str]:
-        """Get a list of channel labels from channels.tsv.
-
-        Parameters
-        ----------
-        data_filepath : str
-            The path to the data file.
-
-        Returns
-        -------
-        list of str
-            A list of channel names.
-
-        """
-        # Find channels.tsv in the same directory as the data file
-        # It can be named either "channels.tsv" or "*_channels.tsv"
+    def _find_channels_tsv(self, data_filepath: str) -> Path:
+        """Find channels.tsv for a data file."""
         filepath = Path(data_filepath)
-        parent_dir = filepath.parent
-
-        # Try the standard channels.tsv first
-        channels_tsv_path = parent_dir / "channels.tsv"
+        channels_tsv_path = filepath.parent / "channels.tsv"
         if not channels_tsv_path.exists():
-            # Try to find *_channels.tsv matching the filename prefix
-            base_name = filepath.stem  # filename without extension
-            for tsv_file in parent_dir.glob("*_channels.tsv"):
-                # Check if it matches by looking at task/run components
-                tsv_name = tsv_file.stem.replace("_channels", "")
-                if base_name.startswith(tsv_name):
-                    channels_tsv_path = tsv_file
-                    break
+            for tsv_file in filepath.parent.glob("*_channels.tsv"):
+                if filepath.stem.startswith(tsv_file.stem.replace("_channels", "")):
+                    return tsv_file
+        return channels_tsv_path
 
+    def channel_labels(self, data_filepath: str) -> list[str]:
+        """Get a list of channel labels from channels.tsv."""
+        channels_tsv_path = self._find_channels_tsv(data_filepath)
         if not channels_tsv_path.exists():
             raise FileNotFoundError(f"No channels.tsv found for {data_filepath}")
-
-        try:
-            channels_tsv = pd.read_csv(channels_tsv_path, sep="\t")
-            return channels_tsv["name"].tolist()
-        except Exception:
-            return []
+        return _read_tsv_column(channels_tsv_path, "name")
 
     def channel_types(self, data_filepath: str) -> list[str]:
-        """Get a list of channel types from channels.tsv.
-
-        Parameters
-        ----------
-        data_filepath : str
-            The path to the data file.
-
-        Returns
-        -------
-        list of str
-            A list of channel types.
-
-        """
-        # Find channels.tsv in the same directory as the data file
-        # It can be named either "channels.tsv" or "*_channels.tsv"
-        filepath = Path(data_filepath)
-        parent_dir = filepath.parent
-
-        # Try the standard channels.tsv first
-        channels_tsv_path = parent_dir / "channels.tsv"
-        if not channels_tsv_path.exists():
-            # Try to find *_channels.tsv matching the filename prefix
-            base_name = filepath.stem  # filename without extension
-            for tsv_file in parent_dir.glob("*_channels.tsv"):
-                # Check if it matches by looking at task/run components
-                tsv_name = tsv_file.stem.replace("_channels", "")
-                if base_name.startswith(tsv_name):
-                    channels_tsv_path = tsv_file
-                    break
-
+        """Get a list of channel types from channels.tsv."""
+        channels_tsv_path = self._find_channels_tsv(data_filepath)
         if not channels_tsv_path.exists():
             raise FileNotFoundError(f"No channels.tsv found for {data_filepath}")
-
-        try:
-            channels_tsv = pd.read_csv(channels_tsv_path, sep="\t")
-            return channels_tsv["type"].tolist()
-        except Exception:
-            return []
+        return _read_tsv_column(channels_tsv_path, "type")
 
     def num_times(self, data_filepath: str) -> int:
         """Get the number of time points in the recording.

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -323,7 +323,9 @@ def _repair_tsv_encoding(data_dir: Path) -> bool:
                 try:
                     content = tsv_path.read_text(encoding=encoding)
                     tsv_path.write_text(content, encoding="utf-8")
-                    logger.info(f"Repaired TSV encoding: {tsv_path.name} ({encoding} -> UTF-8)")
+                    logger.info(
+                        f"Repaired TSV encoding: {tsv_path.name} ({encoding} -> UTF-8)"
+                    )
                     repaired_any = True
                     break
                 except Exception:

--- a/eegdash/local_bids.py
+++ b/eegdash/local_bids.py
@@ -114,6 +114,12 @@ def discover_local_bids_records(
         if final_ext not in valid_raw_extensions:
             continue
 
+        # Skip files without a task entity — these are typically auxiliary
+        # BIDS files (calibration, crosstalk, empty-room) that are not
+        # actual recordings and will fail in read_raw_bids.
+        if not bids_path.task:
+            continue
+
         try:
             bids_relpath = file_path.resolve().relative_to(dataset_root_path.resolve())
         except ValueError:

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -7,6 +7,7 @@ from eegdash.dataset.io import (
     _find_best_matching_file,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
+    _repair_tsv_encoding,
     _repair_vhdr_pointers,
 )
 
@@ -283,3 +284,33 @@ def test_generate_file_write_error(tmp_path, func, args):
     )
     with patch("pathlib.Path.write_text", side_effect=Exception("Write error")):
         assert func(path, *args) is False
+
+
+# Tests for TSV encoding repair
+
+
+@pytest.mark.parametrize(
+    "encoding,expected_repair",
+    [("latin-1", True), ("cp1252", True), ("utf-8", False)],
+    ids=["latin1", "cp1252", "utf8_no_repair"],
+)
+def test_repair_tsv_encoding(tmp_path, encoding, expected_repair):
+    """Test TSV encoding repair for various encodings."""
+    tsv_path = tmp_path / "channels.tsv"
+    content = "name\ttype\tunits\nFp1\tEEG\tµV\n"
+    tsv_path.write_bytes(content.encode(encoding))
+
+    assert _repair_tsv_encoding(tmp_path) is expected_repair
+    assert tsv_path.read_text(encoding="utf-8") == content
+
+
+def test_repair_tsv_encoding_edge_cases(tmp_path):
+    """Test edge cases: non-existent dir, no TSV files, multiple files."""
+    assert _repair_tsv_encoding(tmp_path / "nonexistent") is False
+
+    (tmp_path / "data.json").write_text("{}")
+    assert _repair_tsv_encoding(tmp_path) is False
+
+    (tmp_path / "participants.tsv").write_text("id\nsub-01\n", encoding="utf-8")
+    (tmp_path / "channels.tsv").write_bytes("name\nFp1\n".encode("latin-1"))
+    assert _repair_tsv_encoding(tmp_path) is True

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -312,5 +312,5 @@ def test_repair_tsv_encoding_edge_cases(tmp_path):
     assert _repair_tsv_encoding(tmp_path) is False
 
     (tmp_path / "participants.tsv").write_text("id\nsub-01\n", encoding="utf-8")
-    (tmp_path / "channels.tsv").write_bytes("name\nFp1\n".encode("latin-1"))
+    (tmp_path / "channels.tsv").write_bytes("name\tunits\nFp1\tµV\n".encode("latin-1"))
     assert _repair_tsv_encoding(tmp_path) is True


### PR DESCRIPTION
## Summary
- **Fix encoding fallback order**: swap cp1252 before latin-1 in `_repair_tsv_encoding` and `_TSV_ENCODINGS` — latin-1 never raises `UnicodeDecodeError` (maps every byte 0x00–0xFF), making cp1252 unreachable when listed after it
- **Add `_repair_tsv_encoding`** utility to auto-fix non-UTF-8 TSV files (e.g., channels.tsv with `µ` for microvolts) at load time
- **Add `on_ch_mismatch="rename"`** to `read_raw_bids` calls to handle channel name mismatches between raw files and channels.tsv gracefully
- **Fix edge case test** that used pure ASCII content for encoding repair assertion
- **Generate minimal `coordsystem.json`** when missing from BIDS dataset — some OpenNeuro datasets (e.g. ds004324) include electrodes.tsv but omit the required coordsystem.json
- **Skip BIDS files without task entity** in local discovery — auxiliary files like calibration/crosstalk recordings lack a task entity and cause RuntimeError in read_raw_bids (e.g. ds004229)
- **Refactor `channel_labels`/`channel_types`** into shared `_find_channels_tsv` and `_read_tsv_column` helpers with multi-encoding support

## Tested with
- `ds004324` (EDF, EEG, 38ch/500Hz) — required coordsystem.json generation
- `ds004229` (FIF, MEG, 332ch/1200Hz) — required task entity filtering

## Test plan
- [x] All 58 unit tests pass in `test_io.py` and `test_bids_dataset.py`
- [x] `test_repair_tsv_encoding_edge_cases` now correctly uses non-ASCII content
- [x] Encoding fallback tests exercise cp1252, latin-1, and utf-8 paths
- [x] Both OpenNeuro datasets load successfully with `EEGDashDataset`