### PR TITLE
fix: case-insensitive BIDS sidecar matching for task entity mismatches

### DIFF
--- a/tests/unit_tests/dataset/test_bids_dataset.py
+++ b/tests/unit_tests/dataset/test_bids_dataset.py
@@ -886,6 +886,8 @@ def test_find_channels_tsv_case_insensitive(tmp_path):
 
     types = ds.channel_types(str(data_file))
     assert types == ["EEG", "EEG"]
+
+
 def test_subject_participant_tsv_duplicate_participant_id(tmp_path):
     """Test that duplicate participant_id rows (e.g., multi-session) return a flat dict."""
     from eegdash.dataset.bids_dataset import EEGBIDSDataset


### PR DESCRIPTION
## Summary
- Fix case-sensitive prefix comparison in `_get_json_with_inheritance()` that caused metadata extraction (sfreq, nchans, ntimes) to silently fail when data files and sidecar files differ in task entity casing (e.g., `task-Emotion` vs `task-emotion`, as in ds003751)
- Generalize the hardcoded `_eeg` suffix split to use the actual modality suffix, so JSON inheritance works correctly for MEG, iEEG, and NIRS datasets
- Apply the same case-insensitive fix to `_find_channels_tsv()` for consistency

## Test plan
- [x] Verified ds003751 (EEGLAB .set/.fdt) loads successfully with correct metadata (sfreq=250, nchans=128, ntimes=674089)
- [x] All 58 existing unit tests pass (`test_io.py`, `test_bids_dataset.py`)