### PR TITLE
fix: dynamic cumulative_sizes, accurate nchans, and case-insensitive BIDS matching

### DIFF
--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -494,13 +494,29 @@ class EEGBIDSDataset:
         json_filename = f"{modality}.json"
         modality_json = self._get_json_with_inheritance(data_filepath, json_filename)
 
+        # Sum all channel type counts from the JSON for a more accurate total.
+        # BIDS sidecars report per-type counts (MEGChannelCount,
+        # MEGREFChannelCount, etc.) but no single total field.
+        _channel_count_keys = [
+            "EEGChannelCount",
+            "MEGChannelCount",
+            "MEGREFChannelCount",
+            "iEEGChannelCount",
+            "NIRSChannelCount",
+            "EOGChannelCount",
+            "ECGChannelCount",
+            "EMGChannelCount",
+            "MiscChannelCount",
+            "TriggerChannelCount",
+        ]
+        nchans_total = sum(
+            modality_json.get(k, 0) or 0 for k in _channel_count_keys
+        )
+
         json_attrs = {
             "sfreq": modality_json.get("SamplingFrequency"),
             "duration": modality_json.get("RecordingDuration"),
-            "nchans": modality_json.get("EEGChannelCount")
-            or modality_json.get("MEGChannelCount")
-            or modality_json.get("iEEGChannelCount")
-            or modality_json.get("NIRSChannelCount"),
+            "nchans": nchans_total or None,
         }
 
         if attribute == "ntimes":

--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -509,9 +509,7 @@ class EEGBIDSDataset:
             "MiscChannelCount",
             "TriggerChannelCount",
         ]
-        nchans_total = sum(
-            modality_json.get(k, 0) or 0 for k in _channel_count_keys
-        )
+        nchans_total = sum(modality_json.get(k, 0) or 0 for k in _channel_count_keys)
 
         json_attrs = {
             "sfreq": modality_json.get("SamplingFrequency"),

--- a/tests/unit_tests/dataset/conftest.py
+++ b/tests/unit_tests/dataset/conftest.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+
+from eegdash.paths import get_default_cache_dir
+
+
+@pytest.fixture(scope="session")
+def cache_dir():
+    """Provide a shared cache directory for dataset tests.
+
+    Re-exports the same fixture from tests/conftest.py so that tests
+    under unit_tests/dataset/ can be collected with ``--noconftest``
+    or when run in isolation.
+    """
+    cache_dir = Path(get_default_cache_dir())
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir

--- a/tests/unit_tests/dataset/test_bids_dataset.py
+++ b/tests/unit_tests/dataset/test_bids_dataset.py
@@ -928,7 +928,7 @@ def test_find_channels_tsv_case_insensitive(tmp_path):
 
     types = ds.channel_types(str(data_file))
     assert types == ["EEG", "EEG"]
-    
+
 
 def test_subject_participant_tsv_duplicate_participant_id(tmp_path):
     """Test that duplicate participant_id rows (e.g., multi-session) return a flat dict."""


### PR DESCRIPTION
## Summary

- **Dynamic `cumulative_sizes`**: Override `cumulative_sizes` property and `_ensure_cumulative_sizes()` in `EEGDashDataset` so that dataset lengths are always recomputed. Before this fix, `BaseConcatDataset` cached cumulative sizes at init time, but `EEGDashRaw.__len__` returns estimated `ntimes` (from JSON metadata) before lazy loading and actual `n_times` after — causing stale values and wrong sample routing at dataset boundaries.
- **Accurate `nchans`**: Sum all BIDS channel type counts (`MEGChannelCount`, `MEGREFChannelCount`, `EOGChannelCount`, etc.) instead of using `or`-chaining that only returned the primary modality count. Fixes undercounting for datasets like ds002908 (CTF MEG: 270 MEG + 29 REF + extras = 306 total).
- **Case-insensitive BIDS sidecar matching**: Use `.lower()` comparison for task entity prefixes in `_get_json_with_inheritance` and `_find_channels_tsv`. Fixes metadata extraction for datasets like ds003751 where data files use `task-Emotion` but sidecars use `task-emotion`.
- **Generalized suffix key**: Replace hardcoded `_eeg` split with dynamic suffix derived from the JSON filename, enabling correct matching for MEG/iEEG/NIRS modalities.

## Test plan

- [x] `test_cumulative_sizes_recomputes_after_length_change` — verifies `cumulative_sizes` and `len(ds)` update when sub-dataset lengths change
- [x] `test_nchans_sums_all_channel_type_counts` — verifies nchans = sum of all channel type counts from JSON
- [x] `test_json_inheritance_case_insensitive_task` — verifies case-insensitive task entity matching (ds003751 scenario)
- [x] `test_json_inheritance_generalized_suffix` — verifies dynamic suffix key for MEG modality
- [x] `test_find_channels_tsv_case_insensitive` — verifies case-insensitive channels.tsv lookup
- [x] All 209 existing dataset tests pass