### PR TITLE
fix: handle duplicate participant_id in participants.tsv

### DIFF
--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -599,7 +599,11 @@ class EEGBIDSDataset:
         if subject not in participants_tsv.index:
             return {}
 
-        row_dict = participants_tsv.loc[subject].to_dict()
+        row = participants_tsv.loc[subject]
+        # Handle duplicate participant_id entries (e.g., multi-session datasets)
+        if isinstance(row, pd.DataFrame):
+            row = row.iloc[0]
+        row_dict = row.to_dict()
         # Convert NaN values to None for JSON compatibility
         return {k: (None if pd.isna(v) else v) for k, v in row_dict.items()}
 

--- a/tests/unit_tests/dataset/test_bids_dataset.py
+++ b/tests/unit_tests/dataset/test_bids_dataset.py
@@ -800,3 +800,32 @@ def test_bids_dataset_more_coverage(tmp_path):
 
     # it uses EPHY_ALLOWED_DATATYPES
     assert _find_bids_files(d, ".none_ext") == []
+
+
+def test_subject_participant_tsv_duplicate_participant_id(tmp_path):
+    """Test that duplicate participant_id rows (e.g., multi-session) return a flat dict."""
+    from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+    d = tmp_path / "ds_dup"
+    d.mkdir()
+    (d / "dataset_description.json").touch()
+    (d / "sub-01" / "eeg").mkdir(parents=True)
+    f = d / "sub-01" / "eeg" / "sub-01_task-rest_eeg.set"
+    f.touch()
+
+    # participants.tsv with duplicate entries for sub-01 (multi-session dataset)
+    p_file = d / "participants.tsv"
+    p_file.write_text(
+        "participant_id\tage\tsex\nsub-01\t25\tM\nsub-01\t25\tM\nsub-02\t30\tF\n"
+    )
+
+    ds = EEGBIDSDataset(data_dir=str(d), dataset="ds_dup")
+    result = ds.subject_participant_tsv(str(f))
+
+    # Should return a flat dict (not nested), taking the first row
+    assert isinstance(result, dict)
+    assert result["age"] == "25"
+    assert result["sex"] == "M"
+    # Values should be scalars, not arrays or dicts
+    for v in result.values():
+        assert not isinstance(v, (dict, list))


### PR DESCRIPTION
## Summary

- Fixes `'numpy.ndarray' object has no attribute 'get'` error when loading dataset ds003522 (multi-session longitudinal study with 96 subjects x 3 sessions)
- When `participants.tsv` contains duplicate `participant_id` entries, `pandas .loc[]` returns a DataFrame instead of a Series — `.to_dict()` then produces nested dicts instead of flat scalars, crashing downstream code
- Takes the first row when duplicates are detected in `subject_participant_tsv()`

## Test plan

- [x] New test `test_subject_participant_tsv_duplicate_participant_id` verifies flat dict is returned for duplicate entries
- [x] All 525 existing unit tests continue to pass