### PR TITLE
fix: robust BIDSPath entity extraction and FIF digestion for git-annex datasets

### DIFF
--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -232,17 +232,30 @@ class EEGBIDSDataset:
                     break
 
             # Extract entities from filename using BIDS pattern
-            # Expected format: sub-<label>[_ses-<label>][_task-<label>][_run-<label>]_<modality>.<ext>
-            subject = re.search(r"sub-([^_/.]*)", filename)
-            session = re.search(r"ses-([^_/.]*)", filename)
-            task = re.search(r"task-([^_/.]*)", filename)
-            run = re.search(r"run-([^_/.]*)", filename)
+            # Expected format: sub-<label>[_ses-<label>][_task-<label>][_acq-<label>][_run-<label>]_<modality>.<ext>
+            _entity = r"([^_/.]*)"
+            subject = re.search(rf"sub-{_entity}", filename)
+            session = re.search(rf"ses-{_entity}", filename)
+            task = re.search(rf"task-{_entity}", filename)
+            acquisition = re.search(rf"acq-{_entity}", filename)
+            run = re.search(rf"run-{_entity}", filename)
+            processing = re.search(rf"proc-{_entity}", filename)
+            recording = re.search(rf"rec-{_entity}", filename)
+            space = re.search(rf"space-{_entity}", filename)
+            split = re.search(rf"split-{_entity}", filename)
+            description = re.search(rf"desc-{_entity}", filename)
 
             # Extract raw values
             subject_val = subject.group(1) if subject else None
             session_val = session.group(1) if session else None
             task_val = task.group(1) if task else None
+            acquisition_val = acquisition.group(1) if acquisition else None
             run_val = run.group(1) if run else None
+            processing_val = processing.group(1) if processing else None
+            recording_val = recording.group(1) if recording else None
+            space_val = space.group(1) if space else None
+            split_val = split.group(1) if split else None
+            description_val = description.group(1) if description else None
 
             # Sanitize task if it incorrectly absorbed 'run-' due to missing separator
             # e.g., "task-ECONrun-1" -> task="ECON"
@@ -262,7 +275,13 @@ class EEGBIDSDataset:
                 subject=subject_val,
                 session=session_val,
                 task=task_val,
+                acquisition=acquisition_val,
                 run=run_value_for_bidspath,
+                processing=processing_val,
+                recording=recording_val,
+                space=space_val,
+                split=split_val,
+                description=description_val,
                 datatype=modality,
                 extension=filepath.suffix,
                 root=self.bidsdir,
@@ -272,7 +291,13 @@ class EEGBIDSDataset:
                 "subject": subject_val,
                 "session": session_val,
                 "task": task_val,
+                "acquisition": acquisition_val,
                 "run": run_val,
+                "processing": processing_val,
+                "recording": recording_val,
+                "space": space_val,
+                "split": split_val,
+                "description": description_val,
                 "modality": modality,
             }
 

--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from mne_bids import BIDSPath, find_matching_paths
+from mne_bids import BIDSPath, find_matching_paths, get_entities_from_fname
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS, EPHY_ALLOWED_DATATYPES, reader
 
 # Known companion/sidecar files for specific formats (BIDS spec requirement)
@@ -217,87 +217,70 @@ class EEGBIDSDataset:
 
         """
         if data_filepath not in self._bids_path_cache:
-            # Parse the filename to extract BIDS entities
             filepath = Path(data_filepath)
-            filename = filepath.name
 
             # Detect modality from the directory path
             # BIDS structure: .../sub-XX/[ses-YY/]<modality>/sub-XX_...
-            path_parts = filepath.parts
             modality = "eeg"  # default
-            for part in path_parts:
+            for part in filepath.parts:
                 if part in ["eeg", "meg", "ieeg", "emg", "nirs", "fnirs"]:
                     # Normalize fnirs -> nirs for MNE-BIDS compatibility
                     modality = "nirs" if part == "fnirs" else part
                     break
 
-            # Extract entities from filename using BIDS pattern
-            # Expected format: sub-<label>[_ses-<label>][_task-<label>][_acq-<label>][_run-<label>]_<modality>.<ext>
-            _entity = r"([^_/.]*)"
-            subject = re.search(rf"sub-{_entity}", filename)
-            session = re.search(rf"ses-{_entity}", filename)
-            task = re.search(rf"task-{_entity}", filename)
-            acquisition = re.search(rf"acq-{_entity}", filename)
-            run = re.search(rf"run-{_entity}", filename)
-            processing = re.search(rf"proc-{_entity}", filename)
-            recording = re.search(rf"rec-{_entity}", filename)
-            space = re.search(rf"space-{_entity}", filename)
-            split = re.search(rf"split-{_entity}", filename)
-            description = re.search(rf"desc-{_entity}", filename)
+            # Use MNE-BIDS to parse all standard entities from the filename.
+            # on_error="warn" tolerates non-standard entity keys that appear
+            # in some real-world datasets.
+            entities = get_entities_from_fname(filepath.name, on_error="warn")
 
-            # Extract raw values
-            subject_val = subject.group(1) if subject else None
-            session_val = session.group(1) if session else None
-            task_val = task.group(1) if task else None
-            acquisition_val = acquisition.group(1) if acquisition else None
-            run_val = run.group(1) if run else None
-            processing_val = processing.group(1) if processing else None
-            recording_val = recording.group(1) if recording else None
-            space_val = space.group(1) if space else None
-            split_val = split.group(1) if split else None
-            description_val = description.group(1) if description else None
+            task_val = entities.get("task")
+            run_val = entities.get("run")
 
-            # Sanitize task if it incorrectly absorbed 'run-' due to missing separator
-            # e.g., "task-ECONrun-1" -> task="ECON"
-            if task_val and "run-" in task_val:
-                task_parts = task_val.split("run-")
-                task_val = task_parts[0]
+            # Sanitize task if it incorrectly absorbed 'run' due to missing
+            # underscore separator in the original filename.
+            # get_entities_from_fname("task-ECONrun-1_eeg.set") -> task="ECONrun"
+            # We want task="ECON", run="1".
+            if task_val and re.search(r"run\d*$", task_val):
+                task_val = re.split(r"run\d*$", task_val)[0]
+                if run_val is None:
+                    run_match = re.search(r"run-([^_/.]*)", filepath.name)
+                    if run_match:
+                        run_val = run_match.group(1)
 
-            # BIDSPath enforces "run" to be an index; accept numeric strings, but
-            # drop non-numeric runs (e.g., "5F") while preserving them in the cache.
-            run_value_for_bidspath = None
-            if run_val is not None:
-                run_str = str(run_val)
-                if run_str.isdigit():
-                    run_value_for_bidspath = run_str
+            # BIDSPath enforces "run" to be an index; accept numeric strings,
+            # but drop non-numeric runs (e.g., "5F") while preserving them
+            # in the entity cache.
+            run_for_bidspath = None
+            if run_val is not None and str(run_val).isdigit():
+                run_for_bidspath = run_val
 
             bids_path = BIDSPath(
-                subject=subject_val,
-                session=session_val,
+                subject=entities.get("subject"),
+                session=entities.get("session"),
                 task=task_val,
-                acquisition=acquisition_val,
-                run=run_value_for_bidspath,
-                processing=processing_val,
-                recording=recording_val,
-                space=space_val,
-                split=split_val,
-                description=description_val,
+                acquisition=entities.get("acquisition"),
+                run=run_for_bidspath,
+                processing=entities.get("processing"),
+                recording=entities.get("recording"),
+                space=entities.get("space"),
+                split=entities.get("split"),
+                description=entities.get("description"),
                 datatype=modality,
                 extension=filepath.suffix,
                 root=self.bidsdir,
             )
             self._bids_path_cache[data_filepath] = bids_path
             self._bids_entity_cache[data_filepath] = {
-                "subject": subject_val,
-                "session": session_val,
+                "subject": entities.get("subject"),
+                "session": entities.get("session"),
                 "task": task_val,
-                "acquisition": acquisition_val,
+                "acquisition": entities.get("acquisition"),
                 "run": run_val,
-                "processing": processing_val,
-                "recording": recording_val,
-                "space": space_val,
-                "split": split_val,
-                "description": description_val,
+                "processing": entities.get("processing"),
+                "recording": entities.get("recording"),
+                "space": entities.get("space"),
+                "split": entities.get("split"),
+                "description": entities.get("description"),
                 "modality": modality,
             }
 

--- a/tests/unit_tests/dataset/test_bids_dataset.py
+++ b/tests/unit_tests/dataset/test_bids_dataset.py
@@ -926,6 +926,8 @@ def test_bids_path_nonstandard_entity_warns(tmp_path):
 
     assert bp.subject == "01"
     assert bp.task == "rest"
+
+
 def test_json_inheritance_case_insensitive_task(tmp_path):
     """Test that JSON sidecar matching is case-insensitive for task entity.
 

--- a/tests/unit_tests/dataset/test_bids_dataset.py
+++ b/tests/unit_tests/dataset/test_bids_dataset.py
@@ -800,3 +800,129 @@ def test_bids_dataset_more_coverage(tmp_path):
 
     # it uses EPHY_ALLOWED_DATATYPES
     assert _find_bids_files(d, ".none_ext") == []
+
+
+def test_bids_path_extracts_acquisition_entity(tmp_path):
+    """BIDSPath correctly resolves files with acq- entity (e.g. ds000248)."""
+    from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+    d = tmp_path / "ds_acq"
+    d.mkdir()
+    (d / "dataset_description.json").touch()
+    meg_dir = d / "sub-01" / "meg"
+    meg_dir.mkdir(parents=True)
+
+    # Two files for the same subject — only distinguishable by acq/task
+    f_task = meg_dir / "sub-01_task-audiovisual_run-01_meg.fif"
+    f_acq = meg_dir / "sub-01_acq-crosstalk_meg.fif"
+    f_task.touch()
+    f_acq.touch()
+
+    ds = EEGBIDSDataset(data_dir=str(d), dataset="ds_acq", allow_symlinks=True)
+
+    # Both files should resolve without ambiguity errors
+    bp_task = ds._get_bids_path_from_file(str(f_task))
+    bp_acq = ds._get_bids_path_from_file(str(f_acq))
+
+    assert bp_task.task == "audiovisual"
+    assert bp_task.acquisition is None
+    assert bp_task.run == "01"
+
+    assert bp_acq.task is None
+    assert bp_acq.acquisition == "crosstalk"
+    assert bp_acq.run is None
+
+    # Entity cache should contain acquisition
+    entities = ds._bids_entity_cache[str(f_acq)]
+    assert entities["acquisition"] == "crosstalk"
+    assert entities["modality"] == "meg"
+
+
+def test_bids_path_extracts_all_entities(tmp_path):
+    """All standard BIDS entities are extracted via get_entities_from_fname."""
+    from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+    d = tmp_path / "ds_ents"
+    d.mkdir()
+    (d / "dataset_description.json").touch()
+    meg_dir = d / "sub-01" / "ses-02" / "meg"
+    meg_dir.mkdir(parents=True)
+
+    # Use a valid space for MEG (ElektaNeuromag) per MNE-BIDS validation
+    f = (
+        meg_dir
+        / "sub-01_ses-02_task-rest_acq-full_run-03_proc-sss_space-ElektaNeuromag_split-01_desc-preproc_meg.fif"
+    )
+    f.touch()
+
+    ds = EEGBIDSDataset(data_dir=str(d), dataset="ds_ents", allow_symlinks=True)
+    bp = ds._get_bids_path_from_file(str(f))
+
+    assert bp.subject == "01"
+    assert bp.session == "02"
+    assert bp.task == "rest"
+    assert bp.acquisition == "full"
+    assert bp.run == "03"
+    assert bp.processing == "sss"
+    assert bp.space == "ElektaNeuromag"
+    assert bp.split == "01"
+    assert bp.description == "preproc"
+    assert bp.datatype == "meg"
+
+
+@pytest.mark.parametrize(
+    "modality_dir,suffix,ext,expected",
+    [
+        ("eeg", "eeg", ".set", "eeg"),
+        ("meg", "meg", ".fif", "meg"),
+        ("ieeg", "ieeg", ".edf", "ieeg"),
+        ("nirs", "nirs", ".snirf", "nirs"),
+        ("fnirs", "nirs", ".snirf", "nirs"),  # fnirs normalizes to nirs
+    ],
+    ids=["eeg", "meg", "ieeg", "nirs", "fnirs_normalized"],
+)
+def test_bids_path_modality_from_directory(
+    tmp_path, modality_dir, suffix, ext, expected
+):
+    """Modality is detected from directory path, including fnirs normalization."""
+    from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+    d = tmp_path / f"ds_{modality_dir}"
+    d.mkdir()
+    (d / "dataset_description.json").touch()
+
+    sub_dir = d / "sub-01" / modality_dir
+    sub_dir.mkdir(parents=True)
+    f = sub_dir / f"sub-01_task-rest_{suffix}{ext}"
+    f.touch()
+
+    ds = EEGBIDSDataset(data_dir=str(d), dataset=d.name, allow_symlinks=True)
+    ds._get_bids_path_from_file(str(f))
+    assert ds._bids_entity_cache[str(f)]["modality"] == expected
+
+
+def test_bids_path_nonstandard_entity_warns(tmp_path):
+    """Non-standard entities in filenames produce a warning, not an error."""
+    import warnings
+
+    from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+    d = tmp_path / "ds_warn"
+    d.mkdir()
+    (d / "dataset_description.json").touch()
+    eeg_dir = d / "sub-01" / "eeg"
+    eeg_dir.mkdir(parents=True)
+
+    # rec- is not standard in MNE-BIDS (should be recording-)
+    f = eeg_dir / "sub-01_task-rest_rec-mag_eeg.set"
+    f.touch()
+
+    ds = EEGBIDSDataset(data_dir=str(d), dataset="ds_warn")
+
+    # Should not raise, just warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        bp = ds._get_bids_path_from_file(str(f))
+
+    assert bp.subject == "01"
+    assert bp.task == "rest"

--- a/tests/unit_tests/test_digest_parsers.py
+++ b/tests/unit_tests/test_digest_parsers.py
@@ -1,0 +1,87 @@
+"""Tests for format-specific fallback parsers in the digestion script."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The digestion script uses relative imports (from _constants import ...)
+# that only work when run from scripts/ingestions/. Add that dir to sys.path.
+_INGESTIONS_DIR = str(Path(__file__).resolve().parents[2] / "scripts" / "ingestions")
+
+
+@pytest.fixture()
+def fif_parser():
+    """Import _parse_fif_with_mne from the digestion script."""
+    import importlib.util
+
+    old_path = sys.path.copy()
+    sys.path.insert(0, _INGESTIONS_DIR)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_digest_mod",
+            Path(_INGESTIONS_DIR) / "3_digest.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._parse_fif_with_mne
+    finally:
+        sys.path = old_path
+
+
+def test_parse_fif_nonexistent_file(fif_parser, tmp_path):
+    """Returns None for a file that does not exist."""
+    assert fif_parser(tmp_path / "nonexistent.fif") is None
+
+
+def test_parse_fif_broken_symlink(fif_parser, tmp_path):
+    """Returns None for a broken symlink (git-annex stub)."""
+    link = tmp_path / "broken.fif"
+    link.symlink_to(tmp_path / "target_does_not_exist.fif")
+    assert fif_parser(link) is None
+
+
+def test_parse_fif_extracts_metadata(fif_parser, tmp_path):
+    """Extracts sfreq and channel info from a real FIF file via MNE."""
+    import mne
+
+    info = mne.create_info(
+        ch_names=["EEG1", "EEG2", "EEG3"], sfreq=256.0, ch_types="eeg"
+    )
+    raw = mne.io.RawArray([[0] * 100, [0] * 100, [0] * 100], info)
+
+    fif_path = tmp_path / "test_raw.fif"
+    raw.save(str(fif_path), overwrite=True, verbose=False)
+
+    result = fif_parser(fif_path)
+    assert result is not None
+    assert result["sampling_frequency"] == 256.0
+    assert result["nchans"] == 3
+    assert result["ch_names"] == ["EEG1", "EEG2", "EEG3"]
+
+
+def test_parse_fif_passes_on_split_missing_warn(fif_parser, tmp_path):
+    """Calls read_raw_fif with on_split_missing='warn'."""
+    fif_path = tmp_path / "test.fif"
+    fif_path.touch()
+
+    mock_raw = MagicMock()
+    mock_raw.info = {"sfreq": 1000.0, "ch_names": ["MEG1"]}
+
+    with patch("mne.io.read_raw_fif", return_value=mock_raw) as mock_read:
+        result = fif_parser(fif_path)
+
+    mock_read.assert_called_once_with(
+        str(fif_path), preload=False, on_split_missing="warn", verbose=False
+    )
+    assert result["sampling_frequency"] == 1000.0
+    assert result["nchans"] == 1
+
+
+def test_parse_fif_returns_none_on_read_error(fif_parser, tmp_path):
+    """Returns None when MNE cannot read the file."""
+    fif_path = tmp_path / "bad.fif"
+    fif_path.write_bytes(b"not a fif file")
+
+    assert fif_parser(fif_path) is None


### PR DESCRIPTION
## Summary

- **FIF fallback parser for digestion**: Add `_parse_fif_with_mne()` to `3_digest.py` that reads FIF headers with `on_split_missing="warn"`, allowing metadata extraction from git-annex datasets (ds003483, ds004837, ds006334, ds003694) where content-hash filenames break MNE's split-file linkage.
- **Full BIDS entity extraction**: Refactor `_get_bids_path_from_file` to use `mne_bids.get_entities_from_fname` instead of 4 manual regex patterns, now correctly extracting all standard entities (acquisition, processing, recording, space, split, description) in addition to subject, session, task, and run.
- **Fix ambiguous BIDSPath errors**: Files with entities like `acq-crosstalk` (e.g., ds000248) no longer cause `RuntimeError` due to incomplete BIDSPath matching.

## Test plan

- [x] 42 tests pass (`test_bids_dataset.py`) — 98% coverage on `bids_dataset.py`
- [x] 5 tests for FIF fallback parser (`test_digest_parsers.py`)
- [x] Verified acquisition entity extraction resolves ds000248 ambiguity
- [x] Verified all 9 standard BIDS entities are parsed correctly
- [x] Verified modality detection from directory path (including fnirs → nirs normalization)
- [x] Verified non-standard entities warn instead of raising