### PR TITLE
Add acq- BIDS entity to record pipeline

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -124,9 +124,7 @@ class EEGDashRaw(RawDataset):
         # that predate the acquisition field in entities_mne
         acq_val = entities_mne.get("acquisition")
         if acq_val is None:
-            _acq_match = re.search(
-                r"acq-([^_/]+)", self.record.get("bids_relpath", "")
-            )
+            _acq_match = re.search(r"acq-([^_/]+)", self.record.get("bids_relpath", ""))
             if _acq_match:
                 acq_val = _acq_match.group(1)
 

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -9,6 +9,7 @@ including classes for individual recordings and collections of datasets. It inte
 braindecode for machine learning workflows and handles data loading from both local and remote sources.
 """
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -119,6 +120,16 @@ class EEGDashRaw(RawDataset):
 
         entities_mne = self.record.get("entities_mne") or {}
 
+        # Fallback: parse acquisition from bids_relpath for records
+        # that predate the acquisition field in entities_mne
+        acq_val = entities_mne.get("acquisition")
+        if acq_val is None:
+            _acq_match = re.search(
+                r"acq-([^_/]+)", self.record.get("bids_relpath", "")
+            )
+            if _acq_match:
+                acq_val = _acq_match.group(1)
+
         self.bidspath = BIDSPath(
             root=self.bids_root,
             datatype=MODALITY_ALIASES.get(
@@ -132,6 +143,7 @@ class EEGDashRaw(RawDataset):
             session=entities_mne.get("session"),
             task=entities_mne.get("task"),
             run=entities_mne.get("run"),
+            acquisition=acq_val,
             check=False,
         )
 

--- a/eegdash/dataset/bids_dataset.py
+++ b/eegdash/dataset/bids_dataset.py
@@ -490,6 +490,7 @@ class EEGBIDSDataset:
             "session": entities.get("session", bids_path.session),
             "task": entities.get("task", bids_path.task),
             "run": entities.get("run", bids_path.run),
+            "acquisition": entities.get("acquisition", bids_path.acquisition),
             "modality": entities.get("modality", bids_path.datatype),
         }
 

--- a/eegdash/local_bids.py
+++ b/eegdash/local_bids.py
@@ -136,6 +136,7 @@ def discover_local_bids_records(
             session=bids_path.session or None,
             task=bids_path.task or None,
             run=bids_path.run or None,
+            acquisition=bids_path.acquisition or None,
             dep_keys=[],
             datatype=datatype,
             suffix=suffix,

--- a/eegdash/schemas.py
+++ b/eegdash/schemas.py
@@ -124,6 +124,7 @@ class EntitiesModel(BaseModel):
     session: str | None = None
     task: str | None = None
     run: str | None = None
+    acquisition: str | None = None
 
 
 class RecordModel(BaseModel):
@@ -758,6 +759,8 @@ class Entities(TypedDict, total=False):
         Task label (e.g., "rest").
     run : str | None
         Run label (e.g., "1" or "01").
+    acquisition : str | None
+        Acquisition label (e.g., "bipolar", "PSG").
 
     """
 
@@ -765,6 +768,7 @@ class Entities(TypedDict, total=False):
     session: str | None
     task: str | None
     run: str | None
+    acquisition: str | None
 
 
 class Record(TypedDict, total=False):
@@ -851,6 +855,7 @@ def create_record(
     session: str | None = None,
     task: str | None = None,
     run: str | None = None,
+    acquisition: str | None = None,
     dep_keys: list[str] | None = None,
     datatype: str = "eeg",
     suffix: str = "eeg",
@@ -874,7 +879,7 @@ def create_record(
         Remote storage base URI (e.g., "s3://openneuro.org/ds000001").
     bids_relpath : str
         BIDS-relative path to the raw file (e.g., "sub-01/eeg/sub-01_task-rest_eeg.vhdr").
-    subject, session, task, run : str, optional
+    subject, session, task, run, acquisition : str, optional
         BIDS entities.
     dep_keys : list[str], optional
         Dependency paths relative to storage_base.
@@ -924,6 +929,7 @@ def create_record(
         "session": session,
         "task": task,
         "run": run,
+        "acquisition": acquisition,
     }
 
     entities_mne: Entities = dict(entities)  # type: ignore[assignment]

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -813,6 +813,7 @@ def extract_record(
     session = bids_dataset.get_bids_file_attribute("session", bids_file)
     task = bids_dataset.get_bids_file_attribute("task", bids_file)
     run = bids_dataset.get_bids_file_attribute("run", bids_file)
+    acquisition = bids_dataset.get_bids_file_attribute("acquisition", bids_file)
     modality = bids_dataset.get_bids_file_attribute("modality", bids_file) or "eeg"
     mod_canon = normalize_modality(modality) or "eeg"
 
@@ -1209,6 +1210,7 @@ def extract_record(
         session=session,
         task=task,
         run=str(run) if run is not None else None,
+        acquisition=acquisition,
         dep_keys=dep_keys,
         datatype=datatype,
         suffix=suffix,
@@ -1898,6 +1900,7 @@ def digest_from_manifest(
                 session=entities.get("session"),
                 task=entities.get("task"),
                 run=entities.get("run"),
+                acquisition=entities.get("acquisition"),
                 dep_keys=[],
                 datatype=entities.get("datatype", detected_modality),
                 suffix=entities.get("suffix", detected_modality),
@@ -1949,6 +1952,7 @@ def digest_from_manifest(
                         session=entities.get("session"),
                         task=entities.get("task"),
                         run=entities.get("run"),
+                        acquisition=entities.get("acquisition"),
                         dep_keys=[],
                         datatype=entities.get("datatype", detected_modality),
                         suffix=entities.get("suffix", detected_modality),
@@ -2130,7 +2134,8 @@ def digest_from_manifest(
                 session=entities.get("session"),
                 task=entities.get("task"),
                 run=entities.get("run"),
-                dep_keys=[],  # Can't determine dependencies without actual files
+                acquisition=entities.get("acquisition"),
+                dep_keys=[],
                 datatype=entities.get("datatype", detected_modality),
                 suffix=entities.get("suffix", detected_modality),
                 storage_backend=get_storage_backend(source),
@@ -2172,6 +2177,7 @@ def digest_from_manifest(
                 session=entities.get("session"),
                 task=entities.get("task"),
                 run=entities.get("run"),
+                acquisition=entities.get("acquisition"),
                 dep_keys=[],
                 datatype=entities.get("datatype", detected_modality),
                 suffix=entities.get("suffix", detected_modality),


### PR DESCRIPTION
# Add `acq-` BIDS entity to record pipeline

## Summary

Propagate the `acquisition` BIDS entity through the EEGDash record pipeline so that `BIDSPath` is built with `acq-` when present. This fixes verification/loading for 26 datasets whose data files use an acquisition label (e.g. `acq-bipolar`, `acq-PSG`, `acq-ecog`). Previously, `acquisition` was parsed by `mne_bids.find_matching_paths()` but dropped before `create_record()` and `BIDSPath()`, so `read_raw_bids()` looked for the wrong filename and failed.

## Root cause

- `find_matching_paths()` (and BIDS layout) expose `acquisition`, but it was never stored in records or passed into `BIDSPath()`.
- Both code paths (local: `local_bids.py` → `create_record()`; DB: `3_digest.py` → `create_record()` → MongoDB → `EEGDashRaw`) dropped `acquisition` before `base.py` built `BIDSPath()`, so the path used for reading was missing `acq-` and file lookup failed.

## Changes (5 files)

| File | Change |
|------|--------|
| **eegdash/schemas.py** | Add `acquisition: str \| None` to `Entities` TypedDict, `EntitiesModel`, and `create_record()` (param + entities dict). |
| **eegdash/local_bids.py** | Pass `bids_path.acquisition or None` into `create_record()`. |
| **eegdash/dataset/base.py** | Build `BIDSPath(acquisition=...)` from `entities_mne["acquisition"]`, with fallback: parse `acq-` from `bids_relpath` for existing DB records that don’t have the field yet. |
| **eegdash/dataset/bids_dataset.py** | Add `acquisition` to `get_bids_file_attribute()` `direct_attrs` so the digest script can read it. |
| **scripts/ingestions/3_digest.py** | Read `acquisition` via `get_bids_file_attribute()` and pass it into all `create_record()` call sites (main digest + API-only and parsed-entity call sites). |

## Backward compatibility

- `acquisition` is optional and defaults to `None` everywhere; `BIDSPath(acquisition=None)` is unchanged.
- `Entities` is `total=False`; `EntitiesModel` has `extra="allow"`. Existing MongoDB records without `acquisition` in `entities_mne` still work via the `bids_relpath` fallback in `base.py` (no re-digestion required).

## Testing / verification

- Verification run on the 26 previously failing (acq-related) datasets: **acq- issue is resolved**; paths now include `acq-` and failures observed are due to other causes (git-annex content not retrieved, no common channels, etc.), not missing acquisition in the path.
- One of the 26 (e.g. ds001849) completes successfully; others fail on unrelated errors (annex, channel config, etc.).

## Affected datasets (26)

ds001849, ds003029, ds003688, ds004100, ds004738, ds004789, ds004809, ds004865, ds004993, ds004998, ds005059, ds005178, ds005185, ds005207, ds005411, ds005489, ds005491, ds005494, ds005522, ds005523, ds005555, ds005557, ds005558, ds005620, ds006840, ds006923.
