### PR TITLE
BrainVision .vhdr annex-key fix and local BIDS discovery tweaks

### DIFF
--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -73,6 +73,10 @@ class _VHDRPointerFixer:
         key = match.group(1)  # DataFile or MarkerFile
         old_val = match.group(2).strip()
 
+        annex_key_pattern = re.compile(
+            r"^(SHA256E|MD5E)-[^.]*\.(vmrk|eeg)$", flags=re.IGNORECASE
+        )
+
         # If the pointed file exists, do nothing
         if (self.data_dir / old_val).exists():
             return match.group(0)
@@ -82,7 +86,11 @@ class _VHDRPointerFixer:
 
         # Strategy 1: Check if BIDS filename exists (same stem as .vhdr)
         bids_name = self.vhdr_path.with_suffix(ext).name
-        if (self.data_dir / bids_name).exists():
+        # Do not \"repair\" to an annex-style filename
+        if (
+            not annex_key_pattern.match(bids_name)
+            and (self.data_dir / bids_name).exists()
+        ):
             self.changes = True
             logger.info(
                 f"Auto-repairing {self.vhdr_path.name}: {key}={old_val} -> {bids_name}"
@@ -93,7 +101,11 @@ class _VHDRPointerFixer:
         # This handles typos (rsub- vs sub-, sternbeg vs sternberg) and
         # BIDS renames where original filename was completely different
         fuzzy_match = _find_best_matching_file(self.data_dir, old_val, ext)
-        if fuzzy_match and (self.data_dir / fuzzy_match).exists():
+        if (
+            fuzzy_match
+            and (self.data_dir / fuzzy_match).exists()
+            and not annex_key_pattern.match(fuzzy_match)
+        ):
             self.changes = True
             logger.info(
                 f"Auto-repairing {self.vhdr_path.name}: {key}={old_val} -> {fuzzy_match} (fuzzy match)"
@@ -521,8 +533,10 @@ def _repair_snirf_bids_metadata(snirf_path: Path, record: dict[str, Any]) -> boo
                 if "acq_time" in df.columns:
                     # Check for malformed timestamps: NaN, empty, or very short strings
                     malformed = df["acq_time"].apply(
-                        lambda x: pd.isna(x)
-                        or (isinstance(x, str) and (len(x) < 10 or x.strip() == ""))
+                        lambda x: (
+                            pd.isna(x)
+                            or (isinstance(x, str) and (len(x) < 10 or x.strip() == ""))
+                        )
                     )
 
                     if malformed.any():

--- a/eegdash/local_bids.py
+++ b/eegdash/local_bids.py
@@ -15,6 +15,29 @@ from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS
 from .const import MODALITY_ALIASES
 from .schemas import create_record
 
+# Keys added to each record when EEGBIDSDataset is available
+_FILE_METADATA_KEYS = ("sampling_frequency", "nchans", "ntimes", "ch_names")
+
+
+def _get_file_metadata(ds_helper: Any, file_path: str) -> dict[str, Any]:
+    """Get BIDS file metadata (sfreq, nchans, ntimes, ch_names) when possible."""
+    empty = {k: None for k in _FILE_METADATA_KEYS}
+    if ds_helper is None:
+        return empty
+    try:
+        result = {
+            "sampling_frequency": ds_helper.get_bids_file_attribute("sfreq", file_path),
+            "nchans": ds_helper.get_bids_file_attribute("nchans", file_path),
+            "ntimes": ds_helper.get_bids_file_attribute("ntimes", file_path),
+        }
+        try:
+            result["ch_names"] = ds_helper.channel_labels(file_path)
+        except Exception:
+            result["ch_names"] = None
+        return result
+    except Exception:
+        return empty
+
 
 def _normalize_modalities(modality_filter: Any) -> list[str]:
     """Normalize modality filter to a list of strings.
@@ -99,6 +122,17 @@ def discover_local_bids_records(
         for ext in ALLOWED_DATATYPE_EXTENSIONS.get(MODALITY_ALIASES.get(m, m), [])
     }
 
+    # create a dataset object to extract more metadata if possible
+    try:
+        # local import to avoid circular dependency
+        from .dataset.bids_dataset import EEGBIDSDataset
+
+        ds_helper = EEGBIDSDataset(
+            data_dir=dataset_root, dataset=dataset_id, allow_symlinks=True
+        )
+    except Exception:
+        ds_helper = None
+
     for bids_path in matched_paths:
         file_path = Path(bids_path.fpath)
 
@@ -121,7 +155,13 @@ def discover_local_bids_records(
             continue
 
         try:
-            bids_relpath = file_path.resolve().relative_to(dataset_root_path.resolve())
+            # IMPORTANT: keep the BIDS symlink path, do NOT resolve to annex
+            # objects. Resolving would turn a BIDS path like:
+            #   sub-02/ses-001/eeg/sub-02_ses-001_task-main_run-001_eeg.vhdr
+            # into:
+            #   .git/annex/objects/.../MD5E-s...vhdr/MD5E-s...vhdr
+            # which breaks downstream helpers that expect BIDS-relative paths.
+            bids_relpath = file_path.relative_to(dataset_root_path.resolve())
         except ValueError:
             bids_relpath = Path(file_path.name)
 
@@ -143,36 +183,8 @@ def discover_local_bids_records(
             storage_backend="local",
         )
 
-        # Try to extract more metadata if possible
-        # (This is a simplified version for local discovery)
-        current_rec = bids_path.fpath
-        try:
-            # local import to avoid circular dependency
-            from .dataset.bids_dataset import EEGBIDSDataset
-
-            # Note: creating a dataset object per file is expensive, but this is local discovery
-            # In a real scenario we'd reuse it.
-            ds_helper = EEGBIDSDataset(
-                data_dir=dataset_root, dataset=dataset_id, allow_symlinks=True
-            )
-            rec["sampling_frequency"] = ds_helper.get_bids_file_attribute(
-                "sfreq", str(current_rec)
-            )
-            rec["nchans"] = ds_helper.get_bids_file_attribute(
-                "nchans", str(current_rec)
-            )
-            rec["ntimes"] = ds_helper.get_bids_file_attribute(
-                "ntimes", str(current_rec)
-            )
-            try:
-                rec["ch_names"] = ds_helper.channel_labels(str(current_rec))
-            except Exception:
-                rec["ch_names"] = None
-        except Exception:
-            rec["sampling_frequency"] = None
-            rec["nchans"] = None
-            rec["ntimes"] = None
-            rec["ch_names"] = None
+        # Enrich with file metadata when available (sfreq, nchans, ntimes, ch_names)
+        rec.update(_get_file_metadata(ds_helper, str(bids_path.fpath)))
 
         records_out.append(rec)
 

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -34,6 +34,56 @@ MarkerFile=INTERNAL_NAME.vmrk
     assert repaired is True
 
 
+def test_repair_vhdr_pointers_annex_marker(tmp_path):
+    """VHDR with annex-key MarkerFile should point to BIDS .vmrk."""
+    eeg_dir = tmp_path
+
+    # BIDS-named companion files
+    (eeg_dir / "sub-01_task-rest_eeg.eeg").touch()
+    (eeg_dir / "sub-01_task-rest_eeg.vmrk").touch()
+
+    vhdr_path = eeg_dir / "sub-01_task-rest_eeg.vhdr"
+    vhdr_content = """Brain Vision Data Exchange Header File Version 1.0
+[Common Infos]
+DataFile=sub-01_task-rest_eeg.eeg
+MarkerFile=SHA256E-s3719--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.vmrk
+"""
+    vhdr_path.write_text(vhdr_content)
+
+    repaired = _repair_vhdr_pointers(vhdr_path)
+    assert repaired is True
+    text = vhdr_path.read_text()
+    # MarkerFile should now reference the BIDS-named file, not the annex key
+    assert "MarkerFile=sub-01_task-rest_eeg.vmrk" in text
+    assert "SHA256E-s3719--" not in text
+
+
+def test_repair_vhdr_pointers_annex_and_internal(tmp_path):
+    """VHDR with internal DataFile and annex-key MarkerFile maps both to BIDS."""
+    eeg_dir = tmp_path
+
+    # BIDS-named companion files
+    (eeg_dir / "sub-01_task-main_run-001_eeg.eeg").touch()
+    (eeg_dir / "sub-01_task-main_run-001_eeg.vmrk").touch()
+
+    vhdr_path = eeg_dir / "sub-01_task-main_run-001_eeg.vhdr"
+    vhdr_content = """Brain Vision Data Exchange Header File Version 1.0
+[Common Infos]
+DataFile=s2_run1_08062017.eeg
+MarkerFile=MD5E-s11657--7a519e74754041a678931b7b7d72f0ab.vmrk
+"""
+    vhdr_path.write_text(vhdr_content)
+
+    repaired = _repair_vhdr_pointers(vhdr_path)
+    assert repaired is True
+    text = vhdr_path.read_text()
+    # Both pointers should now use the BIDS-named companions
+    assert "DataFile=sub-01_task-main_run-001_eeg.eeg" in text
+    assert "MarkerFile=sub-01_task-main_run-001_eeg.vmrk" in text
+    assert "s2_run1_08062017.eeg" not in text
+    assert "MD5E-s11657--" not in text
+
+
 def test_repair_vhdr_no_change_needed(tmp_path):
     """Test that VHDR is untouched if pointers are valid."""
     eeg_dir = tmp_path


### PR DESCRIPTION
# BrainVision .vhdr annex-key fix and local BIDS discovery tweaks

## Summary

- Fix loading for datasets where the .vhdr header points at git-annex keys instead of BIDS filenames (DataFile/MarkerFile).
- Keep BIDS-relative paths in local discovery when files are symlinks to annex objects.
- Speed up local BIDS discovery by reusing a single `EEGBIDSDataset` for metadata instead of creating one per file.

## Changes

### `eegdash/dataset/io.py`

- **VHDR repair:** Detect annex-style filenames (`SHA256E-...` / `MD5E-...` with `.vmrk` or `.eeg`). Do not replace a `DataFile`/`MarkerFile` line with such a name. Strategy 1 (BIDS-name) and Strategy 2 (fuzzy match) only apply when the replacement value is not annex-style, so we never “repair” to a non-existent annex key.
- Minor: SNIRF scans.tsv repair lambda formatting (style only).

### `eegdash/local_bids.py`

- **BIDS path for symlinks:** When building `bids_relpath`, use `file_path.relative_to(dataset_root_path.resolve())` instead of `file_path.resolve().relative_to(...)`. So when the raw file is a symlink into `.git/annex/objects/...`, the record keeps the BIDS path (e.g. `sub-02/ses-001/eeg/sub-02_..._eeg.vhdr`) instead of the resolved annex path. Downstream VHDR repair then runs in the correct directory and finds the BIDS-named .vmrk/.eeg.
- **Local discovery performance:** Create one `EEGBIDSDataset` per `discover_local_bids_records` call and reuse it for all files; extract metadata via a small `_get_file_metadata(ds_helper, file_path)` helper instead of instantiating `EEGBIDSDataset` per file. Reduces work when many recordings are discovered in one dataset.

### `tests/unit_tests/dataset/test_io.py`

- Add tests for VHDR repair when the header contains annex-key MarkerFile (and optionally internal DataFile); assert repair replaces with BIDS-named files and never with annex-style names.

## Affected datasets (46)

Identified in verification as having .vhdr files referencing git-annex keys (DataFile/MarkerFile) instead of BIDS filenames:

`ds002158`, `ds002833`, `ds003421`, `ds003702`, `ds003768`, `ds003844`, `ds003848`, `ds004000`, `ds004024`, `ds004067`, `ds004075`, `ds004080`, `ds004127`, `ds004148`, `ds004256`, `ds004356`, `ds004370`, `ds004502`, `ds004582`, `ds004587`, `ds004621`, `ds004774`, `ds004796`, `ds004816`, `ds004952`, `ds005131`, `ds005169`, `ds005280`, `ds005286`, `ds005289`, `ds005291`, `ds005448`, `ds005473`, `ds005486`, `ds005520`, `ds005624`, `ds005691`, `ds005692`, `ds005795`, `ds005863`, `ds006033`, `ds006065`, `ds006269`, `ds006434`, `ds006519`, `ds006735`

## Verification status (post-fix)

Re-verification on the cluster (pre-downloaded, read-only annex storage) for all 46 affected datasets:

- **Passed: 24** — Complete without the previous `.vhdr` / annex-key `FileNotFoundError`; repair logic and BIDS path fix behave as intended.
- **Permission denied: 2** — `ds002158`, `ds003848`. The code correctly identifies and repairs the pointers, but writing the repaired .vhdr fails with `[Errno 13]` because the target is read-only. Using `download=True` into a writable cache avoids this.
- **Other failures: 20** — Unrelated reasons (e.g. no common channels, missing .fdt, or other dataset-specific issues). Not caused by the .vhdr/annex fix.

## Backward compatibility

- Existing datasets with correct .vhdr or non-annex paths are unchanged.
- Local discovery still returns the same record shape; only the path stored and the metadata lookup are adjusted.
