### PR TITLE
fix(downloader): safely support directory-based formats with recursive download

### DIFF
--- a/eegdash/downloader.py
+++ b/eegdash/downloader.py
@@ -248,7 +248,7 @@ def _filesystem_get(
         )
 
     try:
-        filesystem.get(s3path, str(filepath), callback=callback)
+        filesystem.get(s3path, str(filepath), callback=callback, recursive=True)
     finally:
         # Ensure callback is closed properly (important for Rich to clean up display)
         if hasattr(callback, "close"):


### PR DESCRIPTION
This PR adds `recursive=True` to the `fsspec` downloader call in `eegdash/downloader.py`. This enables EEGDash to properly download directory-based dataset formats (such as MEF3 / `.mefd` used in `ds003708`) without affecting standard file downloads.