### PR TITLE
fix(io): handle iEEG coordsystem.json with correct BIDS keys

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -26,6 +26,7 @@ from ..schemas import validate_record
 from .exceptions import DataIntegrityError
 from .io import (
     _ensure_coordsystem_symlink,
+    _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
     _repair_snirf_bids_metadata,
@@ -203,17 +204,33 @@ class EEGDashRaw(RawDataset):
                 )
                 raise
 
+    def _read_raw_bids(self) -> BaseRaw:
+        """Call ``mne_bids.read_raw_bids`` with the standard arguments."""
+        return mne_bids.read_raw_bids(
+            bids_path=self.bidspath, verbose="ERROR", on_ch_mismatch="rename"
+        )
+
     def _load_raw(self) -> BaseRaw:
         """Load raw data, preferring MNE-BIDS if BIDSPath resolves.
 
-        For SNIRF (fNIRS) files, if initial loading fails, applies on-the-fly
-        fixes to BIDS metadata (channels.tsv, scans.tsv) and retries.
+        Applies on-the-fly fixes and retries for known failure modes:
+
+        - **iEEG** missing ``coordsystem.json``: mne-bids raises
+          ``RuntimeError`` because coordinates are mandatory for intracranial
+          data. We generate a minimal ``coordsystem.json`` with the correct
+          ``iEEGCoordinateSystem`` keys and retry.
+        - **SNIRF** metadata issues: regenerates ``channels.tsv`` /
+          ``scans.tsv`` and retries.
         """
         try:
-            # First attempt: standard MNE-BIDS loading
-            return mne_bids.read_raw_bids(
-                bids_path=self.bidspath, verbose="ERROR", on_ch_mismatch="rename"
-            )
+            return self._read_raw_bids()
+        except RuntimeError as first_error:
+            # mne-bids raises RuntimeError with this message when
+            # electrodes.tsv exists but coordsystem.json is missing.
+            # Fragile string match — tied to mne-bids wording (PR #1523).
+            if "coordsystem.json is REQUIRED" in str(first_error):
+                return self._retry_with_generated_coordsystem(first_error)
+            raise
         except Exception as first_error:
             # For SNIRF files, try to fix and retry
             if self.filecache and self.filecache.suffix.lower() == ".snirf":
@@ -221,18 +238,43 @@ class EEGDashRaw(RawDataset):
                     "Initial load failed for SNIRF file, attempting to fix BIDS metadata..."
                 )
                 if _repair_snirf_bids_metadata(self.filecache, self.record):
-                    # Retry after fix
                     try:
-                        return mne_bids.read_raw_bids(
-                            bids_path=self.bidspath,
-                            verbose="ERROR",
-                            on_ch_mismatch="rename",
-                        )
+                        return self._read_raw_bids()
                     except Exception as retry_error:
                         logger.error(f"Retry also failed: {retry_error}")
                         raise retry_error from first_error
             # Not a SNIRF or fix didn't help - re-raise original error
             raise
+
+    def _retry_with_generated_coordsystem(self, first_error: Exception) -> BaseRaw:
+        """Generate a minimal coordsystem.json on-the-fly and retry loading.
+
+        This handles the case where mne-bids raises ``RuntimeError`` for
+        missing ``coordsystem.json`` — particularly strict for iEEG where
+        coordinates are always required.
+        """
+        data_dir = self.filecache.parent if self.filecache else None
+        if data_dir is None or not data_dir.exists():
+            raise first_error
+
+        datatype = data_dir.name  # eeg, ieeg, meg
+        electrodes_files = list(data_dir.glob("*_electrodes.tsv"))
+        if not electrodes_files:
+            raise first_error
+
+        logger.warning(
+            f"Missing coordsystem.json for {datatype} data, "
+            "generating minimal one and retrying..."
+        )
+        if _generate_coordsystem_json(electrodes_files[0], datatype=datatype):
+            try:
+                return self._read_raw_bids()
+            except Exception as retry_error:
+                logger.error(
+                    f"Retry after coordsystem generation also failed: {retry_error}"
+                )
+                raise retry_error from first_error
+        raise first_error
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -164,22 +164,25 @@ def _repair_vhdr_pointers(vhdr_path: Path) -> bool:
     return False
 
 
-# TO-DO: fix this when mne-bids is fixed
 def _ensure_coordsystem_symlink(data_dir: Path) -> None:
     """Ensure coordsystem.json exists in the data directory using symlinks if needed.
 
     MNE-BIDS can be strict about coordsystem.json location. If it's missing
-    in the EEG directory but present in the subject root, this function
-    creates a symlink.
+    in the data directory but present in the subject root, this function
+    creates a symlink. Otherwise it generates a minimal one with the correct
+    datatype-specific keys (EEG vs iEEG vs MEG).
 
     Parameters
     ----------
     data_dir : Path
-        The directory containing the EEG data files (e.g. sub-01/eeg/).
+        The directory containing the data files (e.g. sub-01/eeg/, sub-01/ieeg/).
 
     """
     if not data_dir.exists():
         return
+
+    # Infer BIDS datatype from directory name (eeg, ieeg, meg, …)
+    datatype = data_dir.name
 
     try:
         # Check if we have electrodes.tsv here (implies need for coordsystem)
@@ -216,13 +219,15 @@ def _ensure_coordsystem_symlink(data_dir: Path) -> None:
             # No coordsystem.json found anywhere — generate a minimal one
             # Infer the coordinate system from the electrodes filename
             # (e.g. "sub-01_ses-01_space-CapTrak_electrodes.tsv")
-            _generate_coordsystem_json(electrodes_files[0])
+            _generate_coordsystem_json(electrodes_files[0], datatype=datatype)
 
     except Exception as e:
         logger.warning(f"Error checking coordsystem symlinks: {e}")
 
 
-def _generate_coordsystem_json(electrodes_tsv: Path) -> bool:
+def _generate_coordsystem_json(
+    electrodes_tsv: Path, datatype: str = "eeg"
+) -> bool:
     """Generate a minimal coordsystem.json from the electrodes.tsv filename.
 
     BIDS requires coordsystem.json whenever electrodes.tsv exists. Some
@@ -230,10 +235,18 @@ def _generate_coordsystem_json(electrodes_tsv: Path) -> bool:
     extracting the coordinate system from the ``space-<label>`` entity
     in the electrodes filename.
 
+    The JSON keys are datatype-specific per BIDS:
+
+    - iEEG: ``iEEGCoordinateSystem`` / ``iEEGCoordinateUnits``
+    - MEG:  ``MEGCoordinateSystem``  / ``MEGCoordinateUnits``
+    - EEG (default): ``EEGCoordinateSystem`` / ``EEGCoordinateUnits``
+
     Parameters
     ----------
     electrodes_tsv : Path
         Path to the electrodes.tsv file.
+    datatype : str
+        BIDS datatype (``"eeg"``, ``"ieeg"``, or ``"meg"``).
 
     Returns
     -------
@@ -252,15 +265,25 @@ def _generate_coordsystem_json(electrodes_tsv: Path) -> bool:
         coordsystem_name = name.replace("_electrodes", "_coordsystem") + ".json"
         coordsystem_path = electrodes_tsv.parent / coordsystem_name
 
+        # BIDS uses datatype-specific keys for coordinate system metadata
+        _COORD_PREFIX = {"eeg": "EEG", "ieeg": "iEEG", "meg": "MEG"}
+        prefix = _COORD_PREFIX.get(datatype)
+        if prefix is None:
+            logger.warning(
+                f"Unexpected datatype {datatype!r} for coordsystem generation, "
+                f"expected one of {set(_COORD_PREFIX)}. Defaulting to EEG keys."
+            )
+            prefix = "EEG"
+
         coordsystem_data = {
-            "EEGCoordinateSystem": coord_system,
-            "EEGCoordinateUnits": "m",
+            f"{prefix}CoordinateSystem": coord_system,
+            f"{prefix}CoordinateUnits": "m",
         }
 
         coordsystem_path.write_text(json.dumps(coordsystem_data, indent=2))
         logger.info(
             f"Generated minimal coordsystem.json: {coordsystem_path.name} "
-            f"(system={coord_system})"
+            f"(datatype={datatype}, system={coord_system})"
         )
         return True
     except Exception as e:

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from eegdash.dataset.io import (
     _ensure_coordsystem_symlink,
     _find_best_matching_file,
+    _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
     _repair_tsv_encoding,
@@ -364,3 +366,67 @@ def test_repair_tsv_encoding_edge_cases(tmp_path):
     (tmp_path / "participants.tsv").write_text("id\nsub-01\n", encoding="utf-8")
     (tmp_path / "channels.tsv").write_bytes("name\tunits\nFp1\tµV\n".encode("latin-1"))
     assert _repair_tsv_encoding(tmp_path) is True
+
+
+# Tests for coordsystem.json generation with datatype-specific keys
+
+
+@pytest.mark.parametrize(
+    "datatype,expected_prefix",
+    [("eeg", "EEG"), ("ieeg", "iEEG"), ("meg", "MEG")],
+    ids=["eeg", "ieeg", "meg"],
+)
+def test_generate_coordsystem_json_datatype_keys(tmp_path, datatype, expected_prefix):
+    """Generated coordsystem.json uses correct keys per BIDS datatype."""
+    electrodes = tmp_path / "sub-01_space-MNI_electrodes.tsv"
+    electrodes.write_text("name\tx\ty\tz\nCh1\t0\t0\t0\n")
+
+    assert _generate_coordsystem_json(electrodes, datatype=datatype) is True
+
+    coordsystem = tmp_path / "sub-01_space-MNI_coordsystem.json"
+    assert coordsystem.exists()
+    data = json.loads(coordsystem.read_text())
+    assert f"{expected_prefix}CoordinateSystem" in data
+    assert data[f"{expected_prefix}CoordinateSystem"] == "MNI"
+    assert f"{expected_prefix}CoordinateUnits" in data
+    assert data[f"{expected_prefix}CoordinateUnits"] == "m"
+
+
+def test_generate_coordsystem_json_no_space_entity(tmp_path):
+    """Coordsystem defaults to 'Other' when electrodes filename has no space entity."""
+    electrodes = tmp_path / "sub-01_electrodes.tsv"
+    electrodes.write_text("name\tx\ty\tz\nCh1\t0\t0\t0\n")
+
+    assert _generate_coordsystem_json(electrodes, datatype="ieeg") is True
+
+    coordsystem = tmp_path / "sub-01_coordsystem.json"
+    data = json.loads(coordsystem.read_text())
+    assert data["iEEGCoordinateSystem"] == "Other"
+
+
+def test_generate_coordsystem_json_default_datatype(tmp_path):
+    """Default datatype is 'eeg' when not specified."""
+    electrodes = tmp_path / "sub-01_electrodes.tsv"
+    electrodes.write_text("name\tx\ty\tz\nCh1\t0\t0\t0\n")
+
+    assert _generate_coordsystem_json(electrodes) is True
+
+    coordsystem = tmp_path / "sub-01_coordsystem.json"
+    data = json.loads(coordsystem.read_text())
+    assert "EEGCoordinateSystem" in data
+
+
+def test_ensure_coordsystem_symlink_generates_ieeg_keys(tmp_path):
+    """_ensure_coordsystem_symlink infers ieeg datatype from directory name."""
+    ieeg_dir = tmp_path / "sub-01" / "ieeg"
+    ieeg_dir.mkdir(parents=True)
+
+    (ieeg_dir / "sub-01_electrodes.tsv").write_text("name\tx\ty\tz\nCh1\t0\t0\t0\n")
+
+    _ensure_coordsystem_symlink(ieeg_dir)
+
+    coordsystem = ieeg_dir / "sub-01_coordsystem.json"
+    assert coordsystem.exists()
+    data = json.loads(coordsystem.read_text())
+    assert "iEEGCoordinateSystem" in data
+    assert "iEEGCoordinateUnits" in data


### PR DESCRIPTION
## Summary

- Generate datatype-specific coordinate system keys (`iEEGCoordinateSystem`/`iEEGCoordinateUnits` for iEEG, `MEGCoordinateSystem`/`MEGCoordinateUnits` for MEG) instead of always using EEG keys — aligns with [mne-bids PR #1523](https://github.com/mne-tools/mne-bids/pull/1523) which keeps strict `RuntimeError` for iEEG when `coordsystem.json` is missing
- Add on-the-fly retry in `_load_raw` that catches the iEEG `RuntimeError`, generates a minimal `coordsystem.json` with the correct keys, and retries — following the existing SNIRF retry pattern
- Extract `_read_raw_bids()` to deduplicate three identical `mne_bids.read_raw_bids(...)` call sites
- Validate the `datatype` parameter in `_generate_coordsystem_json` with a warning on unexpected values instead of silent fallthrough

## Test plan

- [x] Parametrized test for all three datatypes (eeg, ieeg, meg) verifying correct JSON keys
- [x] Test for missing `space-` entity defaulting to `"Other"`
- [x] Test for backward-compatible default (`datatype="eeg"`)
- [x] End-to-end test that `_ensure_coordsystem_symlink` infers `ieeg` from directory name
- [ ] Manual test with an iEEG dataset missing `coordsystem.json`