### PR TITLE
fix(io): force-rewrite git-annex key pointers in VHDR files

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -197,17 +197,17 @@ class EEGDashRaw(RawDataset):
 
         # Helper: Handle VHDR files - generate if missing, repair if broken
         if self.filecache and self.filecache.suffix == ".vhdr":
+            # Generate VMRK stub first so pointer repair can find the target
+            vmrk_path = self.filecache.with_suffix(".vmrk")
+            if not vmrk_path.exists():
+                _generate_vmrk_stub(vmrk_path, self.filecache.name)
+
             if not self.filecache.exists():
                 # Generate VHDR from database metadata if file is missing
                 _generate_vhdr_from_metadata(self.filecache, self.record)
             else:
                 # Auto-Repair broken VHDR pointers (common in OpenNeuro exports)
                 _repair_vhdr_pointers(self.filecache)
-
-            # Also generate VMRK stub if missing (common issue with some datasets)
-            vmrk_path = self.filecache.with_suffix(".vmrk")
-            if not vmrk_path.exists():
-                _generate_vmrk_stub(vmrk_path, self.filecache.name)
 
         if self._raw is None:
             try:

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -60,6 +60,9 @@ def _find_best_matching_file(
     return best_match
 
 
+_ANNEX_KEY_RE = re.compile(r"^(SHA256E|MD5E)-s\d+--[0-9a-f]+\.", flags=re.IGNORECASE)
+
+
 class _VHDRPointerFixer:
     """Helper class to fix VHDR pointers with state tracking."""
 
@@ -73,23 +76,24 @@ class _VHDRPointerFixer:
         key = match.group(1)  # DataFile or MarkerFile
         old_val = match.group(2).strip()
 
-        annex_key_pattern = re.compile(
-            r"^(SHA256E|MD5E)-[^.]*\.(vmrk|eeg)$", flags=re.IGNORECASE
-        )
+        is_annex_key = bool(_ANNEX_KEY_RE.match(old_val))
 
-        # If the pointed file exists, do nothing
-        if (self.data_dir / old_val).exists():
+        # If the pointed file exists AND it's not an annex key, keep it.
+        # Annex keys are always rewritten: the key-based filename only
+        # resolves inside a git-annex repo, so outside that context
+        # (e.g. S3 download cache) it will always fail.
+        if not is_annex_key and (self.data_dir / old_val).exists():
             return match.group(0)
 
         # Determine expected extension
         ext = ".vmrk" if key == "MarkerFile" else ".eeg"
 
-        # Strategy 1: Check if BIDS filename exists (same stem as .vhdr)
+        # Strategy 1: Use BIDS filename (same stem as .vhdr).
+        # For annex keys we always rewrite — the target file need not
+        # exist yet (a VMRK stub may be generated right after repair).
         bids_name = self.vhdr_path.with_suffix(ext).name
-        # Do not \"repair\" to an annex-style filename
-        if (
-            not annex_key_pattern.match(bids_name)
-            and (self.data_dir / bids_name).exists()
+        if not _ANNEX_KEY_RE.match(bids_name) and (
+            is_annex_key or (self.data_dir / bids_name).exists()
         ):
             self.changes = True
             logger.info(
@@ -104,7 +108,7 @@ class _VHDRPointerFixer:
         if (
             fuzzy_match
             and (self.data_dir / fuzzy_match).exists()
-            and not annex_key_pattern.match(fuzzy_match)
+            and not _ANNEX_KEY_RE.match(fuzzy_match)
         ):
             self.changes = True
             logger.info(

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -88,6 +88,55 @@ MarkerFile=MD5E-s11657--7a519e74754041a678931b7b7d72f0ab.vmrk
     assert "MD5E-s11657--" not in text
 
 
+def test_repair_vhdr_annex_key_no_bids_file(tmp_path):
+    """Annex-key pointers rewritten to BIDS names even when target doesn't exist.
+
+    Covers ds002158, ds003688, ds003848, ds005953 where the .vmrk was not
+    downloaded and is only created as a stub *after* repair.
+    """
+    eeg_dir = tmp_path
+
+    # No BIDS-named companion files exist yet
+    vhdr_path = eeg_dir / "sub-01_ses-01_task-visual_run-01_ieeg.vhdr"
+    vhdr_content = """Brain Vision Data Exchange Header File Version 1.0
+[Common Infos]
+DataFile=SHA256E-s9999--abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.eeg
+MarkerFile=SHA256E-s1808--43036bd24716b3b8a7b2c56f44360206d2872b30480859311989e9e10466598a.vmrk
+"""
+    vhdr_path.write_text(vhdr_content)
+
+    repaired = _repair_vhdr_pointers(vhdr_path)
+    assert repaired is True
+    text = vhdr_path.read_text()
+    assert "DataFile=sub-01_ses-01_task-visual_run-01_ieeg.eeg" in text
+    assert "MarkerFile=sub-01_ses-01_task-visual_run-01_ieeg.vmrk" in text
+    assert "SHA256E-" not in text
+
+
+def test_repair_vhdr_annex_key_resolved_symlink(tmp_path):
+    """Annex keys are rewritten even when the annex symlink resolves."""
+    eeg_dir = tmp_path
+
+    # Simulate a resolved annex symlink — file exists with the annex key name
+    annex_eeg = "SHA256E-s5000--aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344.eeg"
+    (eeg_dir / annex_eeg).touch()
+
+    vhdr_path = eeg_dir / "sub-02_task-rest_eeg.vhdr"
+    vhdr_content = f"""Brain Vision Data Exchange Header File Version 1.0
+[Common Infos]
+DataFile={annex_eeg}
+MarkerFile=sub-02_task-rest_eeg.vmrk
+"""
+    vhdr_path.write_text(vhdr_content)
+    (eeg_dir / "sub-02_task-rest_eeg.vmrk").touch()
+
+    repaired = _repair_vhdr_pointers(vhdr_path)
+    assert repaired is True
+    text = vhdr_path.read_text()
+    assert "DataFile=sub-02_task-rest_eeg.eeg" in text
+    assert "SHA256E-" not in text
+
+
 def test_repair_vhdr_no_change_needed(tmp_path):
     """Test that VHDR is untouched if pointers are valid."""
     eeg_dir = tmp_path


### PR DESCRIPTION
## Summary

- BrainVision `.vhdr` files in **ds002158, ds003688, ds003848, ds005953** can reference git-annex keys (`SHA256E-s...--hash.vmrk`) as `MarkerFile`/`DataFile` instead of BIDS filenames (happens in datalad-cloned datasets). ds002158 also has internal name mismatches (`s2_run1_08062017.eeg` instead of BIDS name). MNE cannot resolve either of these outside their original context, causing `FileNotFoundError`.
- `_VHDRPointerFixer` now detects annex keys in pointer values and force-rewrites them to BIDS names **without requiring the target file to exist**. Previously the repair only worked when the BIDS-named companion was already on disk.
- `_ensure_raw` now generates the VMRK stub **before** running pointer repair (instead of after), so the repair has a valid target when the `.vmrk` was not downloaded.

## Test plan

- [x] New unit test: annex key pointers rewritten when no BIDS companion files exist on disk
- [x] New unit test: annex key rewritten even when the annex-named file (resolved symlink) exists on disk
- [x] Existing pointer repair tests still pass (non-annex internal names, fuzzy match, typos)
- [x] Integration test: downloaded real `.vhdr`/`.vmrk` from ds002158 S3, verified internal name repair works
- [x] Integration test: injected annex key pointers into real ds002158 data, verified force-rewrite works (with and without companion files on disk)
- [x] Ruff lint + format clean