### PR TITLE
fix(loader): handle corrupt data, bad timestamps, and invalid BIDS entities

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -29,12 +29,22 @@ from .io import (
     _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
-    _load_raw_brainvision_direct,
+    _load_raw_direct,
+    _repair_scans_tsv_timestamps,
     _repair_snirf_bids_metadata,
     _repair_tsv_decimal_separators,
     _repair_tsv_encoding,
     _repair_vhdr_pointers,
 )
+
+# Error messages indicating unrecoverable data corruption — the source
+# file itself is broken and no amount of BIDS-metadata repair will help.
+_UNRECOVERABLE_PATTERNS = [
+    "Bad EDF",
+    "invalid literal for int",
+    "Could not find any data",
+    "no valid samples",
+]
 
 
 class EEGDashRaw(RawDataset):
@@ -175,8 +185,69 @@ class EEGDashRaw(RawDataset):
                 self._raw_uri, self.filecache, filesystem=filesystem
             )
 
+        # CTF MEG .ds directories require internal files (.meg4, .res4, etc.)
+        if self.filecache and self.filecache.suffix == ".ds":
+            self._ensure_ctf_directory_complete()
+
         # Always set filenames (important for local datasets)
         self.filenames = [self.filecache]
+
+    def _ensure_ctf_directory_complete(self) -> None:
+        """Verify a CTF ``.ds`` directory has the required internal files.
+
+        CTF MEG datasets are stored as directories containing ``.meg4``
+        (data), ``.res4`` (header), and other supporting files.  When
+        downloading from S3 the individual dependency keys may not
+        include all internal files.  This method checks for the minimum
+        required files and, if missing, attempts a recursive download of
+        the entire ``.ds`` S3 prefix.
+        """
+        ds_dir = self.filecache
+        if not ds_dir.exists():
+            ds_dir.mkdir(parents=True, exist_ok=True)
+
+        required_exts = (".meg4", ".res4")
+        missing = [ext for ext in required_exts if not list(ds_dir.glob(f"*{ext}"))]
+
+        if not missing:
+            return
+
+        # Attempt recursive S3 download of the full .ds prefix
+        if self._raw_uri is not None:
+            logger.info(
+                "CTF .ds directory missing %s — attempting recursive S3 download.",
+                ", ".join(missing),
+            )
+            try:
+                filesystem = downloader.get_s3_filesystem()
+                # Strip protocol prefix for s3fs operations
+                s3_prefix = re.sub(r"^s3://", "", self._raw_uri)
+                remote_files = filesystem.ls(s3_prefix, detail=False)
+                pairs = []
+                for remote in remote_files:
+                    fname = Path(remote).name
+                    local = ds_dir / fname
+                    pairs.append((f"s3://{remote}", local))
+                if pairs:
+                    downloader.download_files(
+                        pairs, filesystem=filesystem, skip_existing=True
+                    )
+            except Exception as e:
+                logger.warning("Recursive CTF download failed: %s", e)
+
+        # Re-check after download attempt
+        still_missing = [
+            ext for ext in required_exts if not list(ds_dir.glob(f"*{ext}"))
+        ]
+        if still_missing:
+            raise DataIntegrityError(
+                message=(
+                    f"CTF .ds directory incomplete — missing {', '.join(still_missing)} "
+                    f"in {ds_dir}"
+                ),
+                record=self.record,
+                issues=[f"Missing required CTF file(s): {', '.join(still_missing)}"],
+            )
 
     def _ensure_raw(self) -> None:
         """Ensure the raw data file and its dependencies are cached locally.
@@ -194,6 +265,7 @@ class EEGDashRaw(RawDataset):
             _ensure_coordsystem_symlink(self.filecache.parent)
             _repair_tsv_encoding(self.filecache.parent)
             _repair_tsv_decimal_separators(self.filecache.parent)
+            _repair_scans_tsv_timestamps(self.filecache.parent)
 
         # Helper: Handle VHDR files - generate if missing, repair if broken
         if self.filecache and self.filecache.suffix == ".vhdr":
@@ -235,15 +307,63 @@ class EEGDashRaw(RawDataset):
           ``iEEGCoordinateSystem`` keys and retry.
         - **SNIRF** metadata issues: regenerates ``channels.tsv`` /
           ``scans.tsv`` and retries.
+        - **Unrecoverable corruption** (Bad EDF, empty MEG data, etc.):
+          raises ``DataIntegrityError`` for clean error reporting.
+        - **Invalid scans.tsv timestamps** (seconds >= 60, NaN): repairs
+          the scans.tsv and retries.
+        - **Invalid BIDS entity characters** (hyphens in task, etc.):
+          falls back to direct MNE reader.
         """
         try:
             return self._read_raw_bids()
         except RuntimeError as first_error:
-            # mne-bids raises RuntimeError with this message when
-            # electrodes.tsv exists but coordsystem.json is missing.
-            # Fragile string match — tied to mne-bids wording (PR #1523).
             if "coordsystem.json is REQUIRED" in str(first_error):
                 return self._retry_with_generated_coordsystem(first_error)
+            raise
+        except (ValueError, OSError) as first_error:
+            msg = str(first_error)
+
+            # Unrecoverable data corruption (bad EDF, empty MEG, etc.)
+            if any(p in msg for p in _UNRECOVERABLE_PATTERNS):
+                raise DataIntegrityError(
+                    message=f"Cannot read data file: {msg}",
+                    record=self.record,
+                    issues=[msg],
+                ) from first_error
+
+            # Invalid timestamp in scans.tsv (seconds >= 60, NaN, etc.)
+            if "second must be" in msg or "does not match format" in msg:
+                if self.filecache and _repair_scans_tsv_timestamps(
+                    self.filecache.parent
+                ):
+                    logger.info("Repaired scans.tsv timestamps, retrying load...")
+                    try:
+                        return self._read_raw_bids()
+                    except Exception as retry_error:
+                        raise retry_error from first_error
+
+            # Invalid BIDS entity characters (hyphens/underscores in task, etc.)
+            if "Unallowed" in msg and self.filecache:
+                try:
+                    return _load_raw_direct(self.filecache)
+                except Exception as fallback_error:
+                    raise fallback_error from first_error
+
+            # VHDR with non-numeric run (ValueError from MNE-BIDS entity validation)
+            if (
+                self.filecache
+                and self.filecache.suffix.lower() == ".vhdr"
+                and self._has_non_numeric_run()
+            ):
+                logger.warning(
+                    "MNE-BIDS failed for VHDR with non-numeric run, "
+                    "falling back to direct MNE reader."
+                )
+                try:
+                    return _load_raw_direct(self.filecache)
+                except Exception as fallback_error:
+                    raise fallback_error from first_error
+
             raise
         except Exception as first_error:
             # For SNIRF files, try to fix and retry
@@ -257,21 +377,6 @@ class EEGDashRaw(RawDataset):
                     except Exception as retry_error:
                         logger.error(f"Retry also failed: {retry_error}")
                         raise retry_error from first_error
-            # For VHDR files with non-numeric run values (e.g. run-5H),
-            # fall back to direct mne.io.read_raw_brainvision()
-            if (
-                self.filecache
-                and self.filecache.suffix.lower() == ".vhdr"
-                and self._has_non_numeric_run()
-            ):
-                logger.warning(
-                    "MNE-BIDS failed for VHDR with non-numeric run, "
-                    "falling back to direct mne.io.read_raw_brainvision()."
-                )
-                try:
-                    return _load_raw_brainvision_direct(self.filecache)
-                except Exception as fallback_error:
-                    raise fallback_error from first_error
 
             # Not a fixable case - re-raise original error
             raise

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -599,65 +599,135 @@ def _repair_snirf_bids_metadata(snirf_path: Path, record: dict[str, Any]) -> boo
         logger.warning(f"Error reading SNIRF for channel repair: {e}")
 
     # ==== Fix 2: Remove malformed scans.tsv entries ====
-    try:
-        scans_files = list(data_dir.parent.glob("*_scans.tsv"))
-        if not scans_files:
-            scans_files = list(data_dir.parent.glob("scans.tsv"))
-
-        for scans_tsv in scans_files:
-            try:
-                import pandas as pd
-
-                df = pd.read_csv(scans_tsv, sep="\t")
-
-                if "acq_time" in df.columns:
-                    # Check for malformed timestamps: NaN, empty, or very short strings
-                    malformed = df["acq_time"].apply(
-                        lambda x: (
-                            pd.isna(x)
-                            or (isinstance(x, str) and (len(x) < 10 or x.strip() == ""))
-                        )
-                    )
-
-                    if malformed.any():
-                        repairs_made = True
-
-                        # Convert column to string type, then replace malformed values
-                        df["acq_time"] = df["acq_time"].astype(str)
-                        df.loc[malformed, "acq_time"] = "n/a"
-                        df.to_csv(scans_tsv, sep="\t", index=False)
-                        logger.info(
-                            f"Fixed {malformed.sum()} malformed timestamps in {scans_tsv.name}"
-                        )
-
-            except Exception as e:
-                logger.warning(f"Could not repair scans.tsv: {e}")
-
-    except Exception as e:
-        logger.warning(f"Error fixing scans.tsv: {e}")
+    if _repair_scans_tsv_timestamps(data_dir):
+        repairs_made = True
 
     return repairs_made
 
 
-def _load_raw_brainvision_direct(vhdr_path: Path):
-    """Load a BrainVision file directly, bypassing MNE-BIDS.
+def _repair_scans_tsv_timestamps(data_dir: Path) -> bool:
+    """Fix invalid timestamps in ``*_scans.tsv`` files.
 
-    Used as a fallback when MNE-BIDS cannot handle non-numeric BIDS run
-    values (e.g. ``run-5H``).  The signal data, channel names, and sampling
-    frequency from the VHDR header are preserved; BIDS sidecar integration
-    (channels.tsv, eeg.json) is skipped.
+    ``mne_bids.read_raw_bids()`` parses ``acq_time`` values via
+    ``datetime.fromisoformat()``.  Some datasets contain malformed
+    timestamps (seconds >= 60, NaN values, truncated strings) that crash
+    the parser.  This function replaces any unparsable ``acq_time``
+    entries with ``"n/a"`` so that loading can proceed.
 
     Parameters
     ----------
-    vhdr_path : Path
-        Path to the ``.vhdr`` file.
+    data_dir : Path
+        The directory containing the data file (e.g. ``sub-01/eeg/``).
+        Scans files are searched in both ``data_dir`` *and* its parent
+        (session-level ``scans.tsv``).
+
+    Returns
+    -------
+    bool
+        True if any timestamps were repaired, False otherwise.
+
+    """
+    from datetime import datetime
+
+    search_dirs = [data_dir]
+    if data_dir.parent.exists():
+        search_dirs.append(data_dir.parent)
+
+    repaired_any = False
+    seen: set[Path] = set()
+
+    for d in search_dirs:
+        for scans_tsv in list(d.glob("*_scans.tsv")) + list(d.glob("scans.tsv")):
+            if scans_tsv in seen:
+                continue
+            seen.add(scans_tsv)
+
+            try:
+                lines = scans_tsv.read_text(encoding="utf-8").splitlines()
+            except Exception:
+                continue
+
+            if not lines:
+                continue
+
+            header = lines[0].split("\t")
+            try:
+                acq_idx = header.index("acq_time")
+            except ValueError:
+                continue
+
+            new_lines = [lines[0]]
+            changed = False
+            for line in lines[1:]:
+                cols = line.split("\t")
+                if acq_idx < len(cols):
+                    ts = cols[acq_idx].strip()
+                    if ts and ts.lower() != "n/a":
+                        try:
+                            datetime.fromisoformat(ts)
+                        except (ValueError, TypeError):
+                            cols[acq_idx] = "n/a"
+                            changed = True
+                new_lines.append("\t".join(cols))
+
+            if changed:
+                try:
+                    scans_tsv.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+                    logger.info(f"Repaired invalid timestamps in {scans_tsv.name}")
+                    repaired_any = True
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to write repaired scans.tsv {scans_tsv.name}: {e}"
+                    )
+
+    return repaired_any
+
+
+def _load_raw_direct(filepath: Path):  # -> mne.io.BaseRaw
+    """Load a data file directly via MNE readers, bypassing MNE-BIDS.
+
+    Used as a fallback when MNE-BIDS entity validation rejects the
+    filename (e.g. hyphens in ``task-`` entities) but the underlying
+    data file is perfectly readable.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to the data file.
 
     Returns
     -------
     mne.io.BaseRaw
         The loaded Raw object.
 
+    Raises
+    ------
+    ValueError
+        If the file extension is not supported.
+
     """
     import mne
 
-    return mne.io.read_raw_brainvision(str(vhdr_path), preload=False, verbose="ERROR")
+    _EXT_TO_READER = {
+        ".vhdr": mne.io.read_raw_brainvision,
+        ".edf": mne.io.read_raw_edf,
+        ".bdf": mne.io.read_raw_bdf,
+        ".set": mne.io.read_raw_eeglab,
+        ".fif": mne.io.read_raw_fif,
+        ".cnt": mne.io.read_raw_cnt,
+    }
+
+    ext = filepath.suffix.lower()
+    reader = _EXT_TO_READER.get(ext)
+    if reader is None:
+        raise ValueError(
+            f"No direct reader for extension {ext!r}. "
+            f"Supported: {sorted(_EXT_TO_READER)}"
+        )
+
+    logger.warning(
+        "Falling back to direct %s reader for %s (bypassing MNE-BIDS).",
+        ext,
+        filepath.name,
+    )
+    return reader(str(filepath), preload=False, verbose="ERROR")

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -557,7 +557,7 @@ def test_load_raw_falls_back_for_non_numeric_run_vhdr(mock_validate, tmp_path):
 
     with patch("mne_bids.read_raw_bids", side_effect=ValueError("run is not an index")):
         with patch(
-            "eegdash.dataset.base._load_raw_brainvision_direct", return_value=mock_raw
+            "eegdash.dataset.base._load_raw_direct", return_value=mock_raw
         ) as mock_direct:
             result = ds._load_raw()
 
@@ -591,7 +591,7 @@ def test_load_raw_numeric_run_vhdr_does_not_fallback(mock_validate, tmp_path):
     ds = EEGDashRaw(record, cache_dir=str(tmp_path))
 
     with patch("mne_bids.read_raw_bids", side_effect=ValueError("Some other error")):
-        with patch("eegdash.dataset.base._load_raw_brainvision_direct") as mock_direct:
+        with patch("eegdash.dataset.base._load_raw_direct") as mock_direct:
             with pytest.raises(ValueError, match="Some other error"):
                 ds._load_raw()
 
@@ -633,7 +633,7 @@ def test_load_raw_vhdr_fallback_failure_chains_exceptions(mock_validate, tmp_pat
 
     with patch("mne_bids.read_raw_bids", side_effect=original_error):
         with patch(
-            "eegdash.dataset.base._load_raw_brainvision_direct",
+            "eegdash.dataset.base._load_raw_direct",
             side_effect=fallback_error,
         ):
             with pytest.raises(IOError, match="Corrupted VHDR file") as exc_info:
@@ -641,3 +641,260 @@ def test_load_raw_vhdr_fallback_failure_chains_exceptions(mock_validate, tmp_pat
 
     # Verify exception chaining preserves the original MNE-BIDS error
     assert exc_info.value.__cause__ is original_error
+
+
+# ─── Tests for new error handlers ───────────────────────────────────────
+
+
+def _make_local_eegdashraw(tmp_path, dataset_id, bids_relpath, ext=".edf", **extra):
+    """Helper: create an EEGDashRaw with a local backend and minimal record."""
+    from eegdash.dataset.base import EEGDashRaw
+
+    parts = bids_relpath.split("/")
+    data_dir = tmp_path / dataset_id / "/".join(parts[:-1])
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_path / dataset_id / bids_relpath).touch()
+
+    record = {
+        "dataset": dataset_id,
+        "bids_relpath": bids_relpath,
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / dataset_id),
+            "raw_key": bids_relpath,
+        },
+        "entities": extra.get("entities", {"subject": "01", "task": "rest"}),
+        "entities_mne": extra.get("entities_mne", {"subject": "01", "task": "rest"}),
+    }
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        return EEGDashRaw(record, cache_dir=str(tmp_path))
+
+
+# ── Error 2 / 3: Unrecoverable data corruption → DataIntegrityError ──
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        "Bad EDF+ header: invalid data record count",
+        "invalid literal for int() with base 10: 'abc'",
+        "Could not find any data in the raw file",
+        "no valid samples found in data",
+    ],
+    ids=["bad_edf", "invalid_int", "no_data", "no_samples"],
+)
+def test_load_raw_unrecoverable_raises_data_integrity_error(tmp_path, error_msg):
+    """Unrecoverable ValueError/OSError must become DataIntegrityError."""
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds_corrupt", "sub-01/eeg/sub-01_task-rest_eeg.edf"
+    )
+
+    exc_cls = OSError if "Could not find" in error_msg else ValueError
+    with patch("mne_bids.read_raw_bids", side_effect=exc_cls(error_msg)):
+        with pytest.raises(DataIntegrityError, match="Cannot read data file"):
+            ds._load_raw()
+
+
+# ── Error 1: Invalid scans.tsv timestamp → repair + retry ──
+
+
+def test_load_raw_repairs_bad_scans_timestamp_and_retries(tmp_path):
+    """'second must be' error should trigger timestamp repair then retry."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds003775", "sub-01/ses-t1/eeg/sub-01_ses-t1_task-rest_eeg.edf"
+    )
+
+    mock_raw = MagicMock()
+    call_count = 0
+
+    def side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ValueError("second must be in 0..59")
+        return mock_raw
+
+    with patch("mne_bids.read_raw_bids", side_effect=side_effect):
+        with patch(
+            "eegdash.dataset.base._repair_scans_tsv_timestamps", return_value=True
+        ) as mock_repair:
+            result = ds._load_raw()
+
+    mock_repair.assert_called_once()
+    assert result is mock_raw
+    assert call_count == 2
+
+
+def test_load_raw_timestamp_repair_fails_still_raises(tmp_path):
+    """If timestamp repair returns False, original ValueError re-raises."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds003775", "sub-01/ses-t1/eeg/sub-01_ses-t1_task-rest_eeg.edf"
+    )
+
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=ValueError("second must be in 0..59"),
+    ):
+        with patch(
+            "eegdash.dataset.base._repair_scans_tsv_timestamps",
+            return_value=False,
+        ):
+            with pytest.raises(ValueError, match="second must be"):
+                ds._load_raw()
+
+
+# ── Error 5: Unallowed BIDS entity → direct reader fallback ──
+
+
+def test_load_raw_unallowed_entity_falls_back_to_direct(tmp_path):
+    """'Unallowed' ValueError should fall back to _load_raw_direct."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds005752", "sub-01/eeg/sub-01_task-my-task_eeg.edf"
+    )
+
+    mock_raw = MagicMock()
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=ValueError("Unallowed -, _, or / in task"),
+    ):
+        with patch(
+            "eegdash.dataset.base._load_raw_direct", return_value=mock_raw
+        ) as mock_direct:
+            result = ds._load_raw()
+
+    mock_direct.assert_called_once_with(ds.filecache)
+    assert result is mock_raw
+
+
+# ── Error 4: CTF .ds directory completeness ──
+
+
+@patch("eegdash.dataset.base.validate_record", return_value=None)
+def test_ensure_ctf_directory_complete_passes_when_files_exist(mock_validate, tmp_path):
+    """CTF check should pass when .meg4 and .res4 exist."""
+    from eegdash.dataset.base import EEGDashRaw
+
+    dataset_id = "ds005279"
+    bids_relpath = "sub-01/meg/sub-01_task-rest_meg.ds"
+    ds_dir = tmp_path / dataset_id / "sub-01" / "meg" / "sub-01_task-rest_meg.ds"
+    ds_dir.mkdir(parents=True)
+    (ds_dir / "sub-01_task-rest_meg.meg4").touch()
+    (ds_dir / "sub-01_task-rest_meg.res4").touch()
+
+    record = {
+        "dataset": dataset_id,
+        "bids_relpath": bids_relpath,
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / dataset_id),
+            "raw_key": bids_relpath,
+        },
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+
+    ds = EEGDashRaw(record, cache_dir=str(tmp_path))
+    # Should not raise — files exist
+    ds._ensure_ctf_directory_complete()
+
+
+@patch("eegdash.dataset.base.validate_record", return_value=None)
+def test_ensure_ctf_directory_incomplete_raises(mock_validate, tmp_path):
+    """CTF check should raise DataIntegrityError when files are missing."""
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    dataset_id = "ds005279"
+    bids_relpath = "sub-01/meg/sub-01_task-rest_meg.ds"
+    ds_dir = tmp_path / dataset_id / "sub-01" / "meg" / "sub-01_task-rest_meg.ds"
+    ds_dir.mkdir(parents=True)
+    # Only create .res4, missing .meg4
+    (ds_dir / "sub-01_task-rest_meg.res4").touch()
+
+    record = {
+        "dataset": dataset_id,
+        "bids_relpath": bids_relpath,
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / dataset_id),
+            "raw_key": bids_relpath,
+        },
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+
+    ds = EEGDashRaw(record, cache_dir=str(tmp_path))
+
+    with pytest.raises(DataIntegrityError, match="CTF .ds directory incomplete"):
+        ds._ensure_ctf_directory_complete()
+
+
+# ── _repair_scans_tsv_timestamps standalone tests ──
+
+
+def test_repair_scans_tsv_timestamps_fixes_bad_seconds(tmp_path):
+    """Timestamps with seconds >= 60 should be replaced with n/a."""
+    from eegdash.dataset.io import _repair_scans_tsv_timestamps
+
+    scans = tmp_path / "sub-01_scans.tsv"
+    scans.write_text(
+        "filename\tacq_time\n"
+        "eeg/file1.edf\t2020-01-01T12:30:60\n"
+        "eeg/file2.edf\t2020-01-01T12:30:45\n"
+    )
+
+    assert _repair_scans_tsv_timestamps(tmp_path) is True
+
+    lines = scans.read_text().strip().split("\n")
+    assert lines[1].split("\t")[1] == "n/a"
+    assert lines[2].split("\t")[1] == "2020-01-01T12:30:45"
+
+
+def test_repair_scans_tsv_timestamps_noop_when_valid(tmp_path):
+    """No changes when all timestamps are valid."""
+    from eegdash.dataset.io import _repair_scans_tsv_timestamps
+
+    scans = tmp_path / "sub-01_scans.tsv"
+    scans.write_text("filename\tacq_time\neeg/file1.edf\t2020-01-01T12:30:45\n")
+
+    assert _repair_scans_tsv_timestamps(tmp_path) is False
+
+
+def test_repair_scans_tsv_timestamps_handles_na(tmp_path):
+    """Existing n/a values should not be modified."""
+    from eegdash.dataset.io import _repair_scans_tsv_timestamps
+
+    scans = tmp_path / "sub-01_scans.tsv"
+    scans.write_text("filename\tacq_time\neeg/file1.edf\tn/a\n")
+
+    assert _repair_scans_tsv_timestamps(tmp_path) is False
+
+
+# ── _load_raw_direct standalone tests ──
+
+
+def test_load_raw_direct_unsupported_extension():
+    """Unsupported extension should raise ValueError."""
+    from pathlib import Path
+
+    from eegdash.dataset.io import _load_raw_direct
+
+    with pytest.raises(ValueError, match="No direct reader"):
+        _load_raw_direct(Path("/tmp/test.xyz"))
+
+
+def test_load_raw_direct_calls_correct_reader(tmp_path):
+    """_load_raw_direct should map extensions to correct MNE readers."""
+    from eegdash.dataset.io import _load_raw_direct
+
+    edf_path = tmp_path / "test.edf"
+    edf_path.touch()
+
+    mock_raw = MagicMock()
+    with patch("mne.io.read_raw_edf", return_value=mock_raw) as mock_reader:
+        result = _load_raw_direct(edf_path)
+
+    mock_reader.assert_called_once_with(str(edf_path), preload=False, verbose="ERROR")
+    assert result is mock_raw

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -9,7 +9,6 @@ from eegdash.dataset.io import (
     _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
-    _load_raw_brainvision_direct,
     _repair_tsv_decimal_separators,
     _repair_tsv_encoding,
     _repair_vhdr_pointers,
@@ -498,18 +497,3 @@ def test_repair_tsv_decimal_separators_preserves_tab_commas(tmp_path):
     tsv_path.write_text("name\ttype\tunits\nFp1\tEEG\tµV\n")
 
     assert _repair_tsv_decimal_separators(tmp_path) is False
-
-
-# Tests for direct BrainVision loader
-
-
-def test_load_raw_brainvision_direct_calls_mne(tmp_path):
-    """Test _load_raw_brainvision_direct calls mne.io.read_raw_brainvision."""
-    vhdr_path = tmp_path / "sub-01_task-rest_run-5H_eeg.vhdr"
-
-    mock_raw = MagicMock()
-    with patch("mne.io.read_raw_brainvision", return_value=mock_raw) as mock_read:
-        result = _load_raw_brainvision_direct(vhdr_path)
-
-    mock_read.assert_called_once_with(str(vhdr_path), preload=False, verbose="ERROR")
-    assert result is mock_raw


### PR DESCRIPTION
## Summary

- Add error handlers in `_load_raw()` for five categories of dataset loading failures:
  - **Unrecoverable data corruption** (Bad EDF, empty MEG) → raises `DataIntegrityError` instead of raw tracebacks
  - **Invalid scans.tsv timestamps** (seconds >= 60, NaN) → proactive repair via `_repair_scans_tsv_timestamps()` + reactive catch-and-retry
  - **Invalid BIDS entity characters** (hyphens in task names) → falls back to `_load_raw_direct()` generic MNE reader
  - **Incomplete CTF .ds directories** (missing .meg4/.res4) → `_ensure_ctf_directory_complete()` with recursive S3 download
- Consolidate `_load_raw_brainvision_direct` into the new generic `_load_raw_direct`
- Replace duplicate pandas-based scans.tsv repair in SNIRF handler with shared `_repair_scans_tsv_timestamps()`

## Affected datasets

| Dataset | Error | Handler |
|---------|-------|---------|
| ds003775 | `ValueError: second must be in 0..59` | Timestamp repair + retry |
| ds004395 | `ValueError: Bad EDF` | `DataIntegrityError` |
| ds004011 | `OSError: no valid samples` | `DataIntegrityError` |
| ds004624 / ds005279 | `FileNotFoundError: missing .ds` | CTF directory completeness check |
| ds005752 | `ValueError: Unallowed - in task` | Direct MNE reader fallback |

## Test plan

- [x] 43 unit tests for `test_base.py` (29 existing + 14 new), all passing
- [x] 38 unit tests for `test_io.py` (39 existing - 1 removed for consolidated function), all passing
- [x] Real-data verification with ds003775 (timestamps) and ds004395 (EDF loading)
- [x] Ruff lint + format clean
- [x] All pre-commit hooks pass (codespell, nested-functions check, etc.)