### PR TITLE
fix(loader): handle CTF "Illegal date" for numeric dash dates

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -10,6 +10,7 @@ braindecode for machine learning workflows and handles data loading from both lo
 """
 
 import re
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,7 @@ from ..logging import logger
 from ..schemas import validate_record
 from .exceptions import DataIntegrityError
 from .io import (
+    _convert_time_with_numeric_dash,
     _ensure_coordsystem_symlink,
     _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
@@ -313,12 +315,16 @@ class EEGDashRaw(RawDataset):
           the scans.tsv and retries.
         - **Invalid BIDS entity characters** (hyphens in task, etc.):
           falls back to direct MNE reader.
+        - **CTF "Illegal date"** (numeric dash dates like 14-10-1925): patches
+          MNE's CTF date parser to try %d-%m-%Y and retries.
         """
         try:
             return self._read_raw_bids()
         except RuntimeError as first_error:
             if "coordsystem.json is REQUIRED" in str(first_error):
                 return self._retry_with_generated_coordsystem(first_error)
+            if "Illegal date" in str(first_error):
+                return self._retry_with_ctf_date_patch(first_error)
             raise
         except (ValueError, OSError) as first_error:
             msg = str(first_error)
@@ -410,6 +416,17 @@ class EEGDashRaw(RawDataset):
                 )
                 raise retry_error from first_error
         raise first_error
+
+    def _retry_with_ctf_date_patch(self, first_error: Exception) -> BaseRaw:
+        """Retry CTF read after patching MNE to accept numeric dash dates (e.g. 14-10-1925)."""
+        import mne.io.ctf.info as ctf_info
+
+        orig = ctf_info._convert_time
+        try:
+            ctf_info._convert_time = partial(_convert_time_with_numeric_dash, orig=orig)
+            return self._read_raw_bids()
+        finally:
+            ctf_info._convert_time = orig
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -10,9 +10,22 @@ import os
 import re
 from difflib import SequenceMatcher
 from pathlib import Path
+from time import strptime
 from typing import Any
 
 from ..logging import logger
+
+
+def _convert_time_with_numeric_dash(date_str: str, time_str: str, *, orig):
+    """Try numeric dash date formats and delegate to orig (MNE's _convert_time)."""
+    for fmt in ("%d-%m-%Y", "%m-%d-%Y", "%Y-%m-%d"):
+        try:
+            date = strptime(date_str.strip(), fmt)
+            normalized = f"{date.tm_mday:02d}/{date.tm_mon:02d}/{date.tm_year}"
+            return orig(normalized, time_str)
+        except ValueError:
+            continue
+    return orig(date_str, time_str)
 
 
 def _find_best_matching_file(

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -105,6 +105,41 @@ def test_base_ensure_raw_failure(tmp_path):
                 assert len(ds) == 0
 
 
+def test_load_raw_retries_on_ctf_illegal_date(tmp_path):
+    """When _read_raw_bids raises 'Illegal date', _load_raw patches CTF parser and retries."""
+    from unittest.mock import MagicMock, patch
+
+    from eegdash.dataset.base import EEGDashRaw
+
+    (tmp_path / "sub-01" / "sub-01_meg.ds").mkdir(
+        parents=True
+    )  # CTF .ds is a directory
+    record = {
+        "dataset": "ds",
+        "bids_relpath": "sub-01/sub-01_meg.ds",
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path),
+            "raw_key": "sub-01/sub-01_meg.ds",
+        },
+    }
+    mock_raw = MagicMock()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=[]):
+        ds = EEGDashRaw(record, str(tmp_path))
+        with patch.object(ds, "_download_required_files"):
+            with patch(
+                "eegdash.dataset.base.mne_bids.read_raw_bids",
+                side_effect=[
+                    RuntimeError("Illegal date: 14-10-1925."),
+                    mock_raw,
+                ],
+            ):
+                result = ds._load_raw()
+
+    assert result is mock_raw
+
+
 def test_base_len_from_metadata(tmp_path):
     from unittest.mock import patch
 

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -1,9 +1,10 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from eegdash.dataset.io import (
+    _convert_time_with_numeric_dash,
     _ensure_coordsystem_symlink,
     _find_best_matching_file,
     _generate_coordsystem_json,
@@ -13,6 +14,43 @@ from eegdash.dataset.io import (
     _repair_tsv_encoding,
     _repair_vhdr_pointers,
 )
+
+
+def test_convert_time_with_numeric_dash_dd_mm_yyyy():
+    """Numeric dash date 14-10-1925 (DD-MM-YYYY) is normalized to 14/10/1925 and delegated."""
+    orig = MagicMock(return_value=12345.0)
+    out = _convert_time_with_numeric_dash("14-10-1925", "12:00:00", orig=orig)
+    assert out == 12345.0
+    orig.assert_called_once_with("14/10/1925", "12:00:00")
+
+
+def test_convert_time_with_numeric_dash_mm_dd_yyyy():
+    """Numeric dash date 10-14-1925 (MM-DD-YYYY) is normalized and delegated."""
+    orig = MagicMock(return_value=0.0)
+    _convert_time_with_numeric_dash("10-14-1925", "00:00:00", orig=orig)
+    orig.assert_called_once_with("14/10/1925", "00:00:00")
+
+
+def test_convert_time_with_numeric_dash_iso():
+    """ISO-style YYYY-MM-DD is normalized to dd/mm/yyyy and delegated."""
+    orig = MagicMock(return_value=1.0)
+    _convert_time_with_numeric_dash("1925-10-14", "01:00:00", orig=orig)
+    orig.assert_called_once_with("14/10/1925", "01:00:00")
+
+
+def test_convert_time_with_numeric_dash_fallback():
+    """Unsupported date format is passed through to orig unchanged."""
+    orig = MagicMock(return_value=999.0)
+    out = _convert_time_with_numeric_dash("14/Oct/1925", "12:00:00", orig=orig)
+    assert out == 999.0
+    orig.assert_called_once_with("14/Oct/1925", "12:00:00")
+
+
+def test_convert_time_with_numeric_dash_strips_whitespace():
+    """Date string is stripped before parsing."""
+    orig = MagicMock(return_value=0.0)
+    _convert_time_with_numeric_dash("  14-10-1925  ", "00:00:00", orig=orig)
+    orig.assert_called_once_with("14/10/1925", "00:00:00")
 
 
 def test_repair_vhdr_pointers(tmp_path):


### PR DESCRIPTION
## Summary

Fixes loading of BIDS/CTF MEG data when the CTF file stores the acquisition date in a **numeric dash format** (e.g. `14-10-1925`) instead of a format MNE supports (e.g. `14/10/1925` or `14-Oct-1925`). Previously this raised:

```
RuntimeError: Illegal date: 14-10-1925.
```

## Cause

MNE's `mne.io.ctf.info._convert_time` only tries these date formats:

- `%d/%m/%Y`, `%d-%b-%Y`, `%a, %b %d, %Y`, `%Y/%m/%d`

It does **not** try `%d-%m-%Y` (numeric month with dashes), so dates like `14-10-1925` always fail. Changing the process locale does not help because the format list is fixed.

## Approach

- On `RuntimeError` with message containing `"Illegal date"`, call `_retry_with_ctf_date_patch` in `base.py`.
- The helper in `eegdash.dataset.io`, `_convert_time_with_numeric_dash(date_str, time_str, *, orig)`, tries `%d-%m-%Y`, `%m-%d-%Y`, and `%Y-%m-%d`; when one matches, it normalizes to `dd/mm/yyyy` and calls `orig`, otherwise delegates to `orig`. It is applied via `functools.partial(..., orig=orig)` so there is no nested function (pre-commit `no-nested-functions` compliant).
- `_retry_with_ctf_date_patch` temporarily assigns `mne.io.ctf.info._convert_time` to this partial, retries `_read_raw_bids()`, then restores the original in a `finally` block.

## Testing

- **Manual:** Verified with dataset **ds000247** (OpenNeuro), which has an emptyroom CTF file with date `14-10-1925`; loading now succeeds.
- **Unit tests:**
  - `tests/unit_tests/dataset/test_io.py`: `_convert_time_with_numeric_dash` for DD-MM-YYYY, MM-DD-YYYY, YYYY-MM-DD, fallback for unsupported format, and whitespace stripping.
  - `tests/unit_tests/dataset/test_base.py`: `test_load_raw_retries_on_ctf_illegal_date` — when `read_raw_bids` first raises `RuntimeError("Illegal date: 14-10-1925.")`, `_load_raw` retries and returns the raw on the second call.

## Backward compatibility

- No change when CTF dates are already in a supported format.
- Patch is applied only for the duration of the retry and then restored.
