### PR TITLE
fix(loader): retry EEGLAB .set files with latin-1 codec on char-encoding errors

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -305,10 +305,13 @@ class EEGDashRaw(RawDataset):
                 )
                 raise
 
-    def _read_raw_bids(self) -> BaseRaw:
+    def _read_raw_bids(self, extra_params: dict | None = None) -> BaseRaw:
         """Call ``mne_bids.read_raw_bids`` with the standard arguments."""
         return mne_bids.read_raw_bids(
-            bids_path=self.bidspath, verbose="ERROR", on_ch_mismatch="rename"
+            bids_path=self.bidspath,
+            extra_params=extra_params,
+            verbose="ERROR",
+            on_ch_mismatch="rename",
         )
 
     def _load_raw(self) -> BaseRaw:
@@ -322,6 +325,9 @@ class EEGDashRaw(RawDataset):
           ``iEEGCoordinateSystem`` keys and retry.
         - **SNIRF** metadata issues: regenerates ``channels.tsv`` /
           ``scans.tsv`` and retries.
+        - **EEGLAB char-encoding** (``.set`` files with non-UTF char fields):
+          ``scipy.io.loadmat`` raises ``TypeError: buffer is too small``.
+          Retries with ``uint16_codec='latin-1'`` via ``extra_params``.
         - **Unrecoverable corruption** (Bad EDF, empty MEG data, corrupt
           MAT/EEGLAB files with array errors, etc.): raises
           ``DataIntegrityError`` for clean error reporting.
@@ -346,6 +352,24 @@ class EEGDashRaw(RawDataset):
             raise
         except (TypeError, ValueError, OSError) as first_error:
             msg = str(first_error)
+
+            # EEGLAB .set files with non-UTF char fields: scipy.io.loadmat
+            # crashes with "buffer is too small" in read_char.  Retry with
+            # uint16_codec='latin-1' before giving up.
+            if (
+                isinstance(first_error, TypeError)
+                and "buffer is too small" in msg
+                and self.filecache
+                and self.filecache.suffix.lower() == ".set"
+            ):
+                logger.info(
+                    "EEGLAB char-encoding error, retrying with "
+                    "uint16_codec='latin-1'..."
+                )
+                try:
+                    return self._read_raw_bids(extra_params={"uint16_codec": "latin-1"})
+                except Exception as retry_error:
+                    raise retry_error from first_error
 
             # Unrecoverable data corruption (bad EDF, empty MEG, corrupt MAT,
             # or any TypeError from array/parsing failures in scipy/numpy)

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -1004,3 +1004,25 @@ def test_load_raw_direct_calls_correct_reader(tmp_path):
 
     mock_reader.assert_called_once_with(str(edf_path), preload=False, verbose="ERROR")
     assert result is mock_raw
+
+
+def test_load_raw_snirf_array_error_raises_data_integrity_error(tmp_path):
+    """ds005929: ValueError('setting an array element with a sequence') from SNIRF
+    must be caught by _UNRECOVERABLE_PATTERNS as DataIntegrityError, NOT fall
+    through to the generic SNIRF `except Exception` handler.
+    """
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    ds = _make_local_eegdashraw(
+        tmp_path,
+        "ds005929",
+        "sub-01/nirs/sub-01_task-rest_nirs.snirf",
+        ext=".snirf",
+    )
+
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=ValueError("setting an array element with a sequence"),
+    ):
+        with pytest.raises(DataIntegrityError, match="Cannot read data file"):
+            ds._load_raw()

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -746,12 +746,53 @@ def test_load_raw_type_error_raises_data_integrity_error(tmp_path, error_msg):
     """TypeError from corrupt MAT/EEGLAB files must become DataIntegrityError."""
     from eegdash.dataset.exceptions import DataIntegrityError
 
+    # Use .edf (not .set) so buffer_small doesn't trigger the latin-1 retry
     ds = _make_local_eegdashraw(
-        tmp_path, "ds_corrupt", "sub-01/eeg/sub-01_task-rest_eeg.set"
+        tmp_path, "ds_corrupt", "sub-01/eeg/sub-01_task-rest_eeg.edf"
     )
 
     with patch("mne_bids.read_raw_bids", side_effect=TypeError(error_msg)):
         with pytest.raises(DataIntegrityError, match="Cannot read data file"):
+            ds._load_raw()
+
+
+# ── EEGLAB .set char-encoding retry with uint16_codec='latin-1' ──
+
+
+def test_load_raw_set_buffer_error_retries_with_latin1(tmp_path):
+    """EEGLAB .set 'buffer is too small' retries with uint16_codec='latin-1'."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds004166", "sub-01/eeg/sub-01_ses-01_task-WM_run-1_eeg.set"
+    )
+
+    mock_raw = MagicMock()
+    call_count = 0
+
+    def side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise TypeError("buffer is too small for requested array")
+        return mock_raw
+
+    with patch("mne_bids.read_raw_bids", side_effect=side_effect):
+        result = ds._load_raw()
+
+    assert result is mock_raw
+    assert call_count == 2
+
+
+def test_load_raw_set_buffer_error_retry_fails_propagates(tmp_path):
+    """EEGLAB .set latin-1 retry also fails -> error propagates."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds004166", "sub-01/eeg/sub-01_ses-01_task-WM_run-1_eeg.set"
+    )
+
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=TypeError("buffer is too small for requested array"),
+    ):
+        with pytest.raises(TypeError, match="buffer is too small"):
             ds._load_raw()
 
 

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -618,3 +618,69 @@ def test_repair_events_tsv_no_nan(tmp_path):
 def test_repair_events_tsv_nonexistent_dir(tmp_path):
     """Returns False for nonexistent directory."""
     assert _repair_events_tsv_nan_samples(tmp_path / "missing") is False
+
+
+def test_repair_events_tsv_all_nan_rows(tmp_path):
+    """Events.tsv where ALL data rows are NaN -> only header remains."""
+    events = "onset\tduration\tsample\tvalue\nnan\tnan\tnan\t1\nnan\tnan\tnan\t2\n"
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(events)
+
+    assert _repair_events_tsv_nan_samples(tmp_path) is True
+
+    content = (tmp_path / "sub-01_task-x_events.tsv").read_text()
+    lines = content.splitlines()
+    assert len(lines) == 1  # only header
+    assert lines[0].startswith("onset")
+
+
+def test_repair_events_tsv_na_strings(tmp_path):
+    """Rows with 'n/a' in onset column should be dropped."""
+    events = (
+        "onset\tduration\tsample\tvalue\n"
+        "1.0\t0.0\t256\t1\n"
+        "n/a\t0.0\t512\t2\n"
+        "3.0\t0.0\t768\t3\n"
+    )
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(events)
+
+    assert _repair_events_tsv_nan_samples(tmp_path) is True
+
+    lines = (tmp_path / "sub-01_task-x_events.tsv").read_text().splitlines()
+    assert len(lines) == 3  # header + 2 valid rows
+    assert all("n/a" not in line for line in lines)
+
+
+def test_repair_events_tsv_empty_onset(tmp_path):
+    """Rows with empty onset field should be dropped."""
+    events = (
+        "onset\tduration\tsample\tvalue\n"
+        "1.0\t0.0\t256\t1\n"
+        "\t0.0\t512\t2\n"
+        "3.0\t0.0\t768\t3\n"
+    )
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(events)
+
+    assert _repair_events_tsv_nan_samples(tmp_path) is True
+
+    lines = (tmp_path / "sub-01_task-x_events.tsv").read_text().splitlines()
+    assert len(lines) == 3  # header + 2 valid rows
+
+
+def test_repair_events_tsv_mixed_nan_types(tmp_path):
+    """Mix of nan, n/a, and empty values all get dropped."""
+    events = (
+        "onset\tduration\tsample\tvalue\n"
+        "1.0\t0.0\t256\t1\n"
+        "nan\tnan\tnan\t2\n"
+        "n/a\t0.0\t512\t3\n"
+        "\t0.0\t768\t4\n"
+        "5.0\t0.0\t1280\t5\n"
+    )
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(events)
+
+    assert _repair_events_tsv_nan_samples(tmp_path) is True
+
+    lines = (tmp_path / "sub-01_task-x_events.tsv").read_text().splitlines()
+    assert len(lines) == 3  # header + 2 valid rows (1.0 and 5.0)
+    assert "1.0" in lines[1]
+    assert "5.0" in lines[2]


### PR DESCRIPTION
## Summary

- **ds004166** `.set` files contain non-UTF-8 characters in MATLAB struct char fields, causing `scipy.io.loadmat` to raise `TypeError: buffer is too small for requested array` in `read_char`. The data itself is intact — this is a character encoding issue, not corruption.
- Adds a retry with `extra_params={'uint16_codec': 'latin-1'}` for `.set` files before the unrecoverable-error handler, recovering all recordings in ds004166 (66ch, 500–1000 Hz).
- Also includes edge-case tests for NaN events repair (`_repair_events_tsv_nan_samples`) and SNIRF array error pattern matching.

## Changes

| File | Change |
|------|--------|
| `eegdash/dataset/base.py` | `_read_raw_bids()` accepts `extra_params`; new retry handler for `"buffer is too small"` TypeError on `.set` files |
| `tests/unit_tests/dataset/test_base.py` | 3 new tests (latin-1 retry success, retry failure propagation, SNIRF pattern match); existing `buffer_small` test updated to use `.edf` |
| `tests/unit_tests/dataset/test_io.py` | 4 new edge-case tests for `_repair_events_tsv_nan_samples` (all-NaN, n/a strings, empty onset, mixed types) |

## Verification

Tested end-to-end with real data downloaded via `s5cmd`:

| Dataset | Before | After |
|---------|--------|-------|
| **ds004166** (sub-01 × 3 sessions + sub-02) | 0/4 `DataIntegrityError` | **4/4 loaded** (66ch, 500–1000 Hz) |
| **ds004841** (sub-001, NaN events) | Already fixed | 1/1 loaded after NaN repair |
| **ds005929** (7 SNIRF subjects) | Already fixed | 7/7 loaded |

All loaded via `EEGDashDataset(cache_dir='/tmp', dataset='ds004166', download=False)`.

## Test plan

- [x] `pytest tests/ -x -q` — 634 passed
- [x] `ruff check . && ruff format .` — all clean
- [x] `pre-commit run --all-files` — all passed
- [x] End-to-end loading of ds004166 via `EEGDashDataset`