### PR TITLE
fix(io): handle empty or malformed channels.tsv for BIDS compliance

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -337,9 +337,8 @@ class EEGDashRaw(RawDataset):
           falls back to direct MNE reader.
         - **CTF "Illegal date"** (numeric dash dates like 14-10-1925): patches
           MNE's CTF date parser to try %d-%m-%Y and retries.
-        - **Empty/malformed channels.tsv** (KeyError: 'name'): repairs the
-          channels.tsv in-place (adds missing header or renames first column)
-          and retries.
+        - **Empty/malformed channels.tsv** (KeyError: 'name'): removes empty
+          files or renames the first column to 'name' and retries.
         """
         try:
             return self._read_raw_bids()

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -32,6 +32,7 @@ from .io import (
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
     _load_raw_direct,
+    _repair_channels_tsv,
     _repair_events_tsv_nan_samples,
     _repair_participants_tsv_ids,
     _repair_scans_tsv_timestamps,
@@ -281,6 +282,7 @@ class EEGDashRaw(RawDataset):
             _repair_tsv_decimal_separators(self.filecache.parent)
             _repair_scans_tsv_timestamps(self.filecache.parent)
             _repair_events_tsv_nan_samples(self.filecache.parent)
+            _repair_channels_tsv(self.filecache.parent)
 
         # Helper: Handle VHDR files - generate if missing, repair if broken
         if self.filecache and self.filecache.suffix == ".vhdr":
@@ -335,6 +337,9 @@ class EEGDashRaw(RawDataset):
           falls back to direct MNE reader.
         - **CTF "Illegal date"** (numeric dash dates like 14-10-1925): patches
           MNE's CTF date parser to try %d-%m-%Y and retries.
+        - **Empty/malformed channels.tsv** (KeyError: 'name'): repairs the
+          channels.tsv in-place (adds missing header or renames first column)
+          and retries.
         """
         try:
             return self._read_raw_bids()
@@ -344,7 +349,7 @@ class EEGDashRaw(RawDataset):
             if "Illegal date" in str(first_error):
                 return self._retry_with_ctf_date_patch(first_error)
             raise
-        except (TypeError, ValueError, OSError) as first_error:
+        except (TypeError, ValueError, KeyError, OSError) as first_error:
             msg = str(first_error)
 
             # Unrecoverable data corruption (bad EDF, empty MEG, corrupt MAT,
@@ -357,6 +362,15 @@ class EEGDashRaw(RawDataset):
                     record=self.record,
                     issues=[msg],
                 ) from first_error
+
+            # Malformed channels.tsv (empty or missing 'name' column)
+            if isinstance(first_error, KeyError) and "name" in str(first_error):
+                if self.filecache and _repair_channels_tsv(self.filecache.parent):
+                    logger.info("Repaired malformed channels.tsv, retrying load...")
+                    try:
+                        return self._read_raw_bids()
+                    except Exception as retry_error:
+                        raise retry_error from first_error
 
             # Invalid timestamp in scans.tsv (seconds >= 60, NaN, etc.)
             if "second must be" in msg or "does not match format" in msg:

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -363,7 +363,7 @@ class EEGDashRaw(RawDataset):
                 ) from first_error
 
             # Malformed channels.tsv (empty or missing 'name' column)
-            if isinstance(first_error, KeyError) and "name" in str(first_error):
+            if isinstance(first_error, KeyError) and first_error.args == ("name",):
                 if self.filecache and _repair_channels_tsv(self.filecache.parent):
                     logger.info("Repaired malformed channels.tsv, retrying load...")
                     try:

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -797,8 +797,8 @@ def _repair_channels_tsv(data_dir: Path) -> bool:
 
     for tsv_path in tsv_files:
         try:
-            raw = tsv_path.read_text(encoding="utf-8-sig")
-            stripped = raw.strip()
+            content = tsv_path.read_text(encoding="utf-8-sig")
+            stripped = content.strip()
 
             if not stripped:
                 # Empty or whitespace-only — remove so MNE-BIDS skips
@@ -808,16 +808,15 @@ def _repair_channels_tsv(data_dir: Path) -> bool:
                 repaired_any = True
                 continue
 
-            header_line = stripped.split("\n", 1)[0]
-            columns = header_line.split("\t")
+            parts = stripped.split("\n", 1)
+            columns = parts[0].split("\t")
 
-            if "name" not in [c.strip().lower() for c in columns]:
+            if "name" not in [c.strip() for c in columns]:
                 # First column must be 'name' per BIDS spec — rename it
                 columns[0] = "name"
                 new_header = "\t".join(columns)
-                rest = stripped.split("\n", 1)
-                if len(rest) > 1:
-                    new_content = new_header + "\n" + rest[1] + "\n"
+                if len(parts) > 1:
+                    new_content = new_header + "\n" + parts[1] + "\n"
                 else:
                     new_content = new_header + "\n"
                 tsv_path.write_text(new_content, encoding="utf-8")

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -771,6 +771,66 @@ def _repair_events_tsv_nan_samples(data_dir: Path) -> bool:
     return repaired_any
 
 
+def _repair_channels_tsv(data_dir: Path) -> bool:
+    r"""Repair empty or malformed ``*_channels.tsv`` files in *data_dir*.
+
+    MNE-BIDS skips channel metadata when ``channels.tsv`` is absent but
+    raises ``KeyError: 'name'`` when the file exists and is empty or lacks
+    the required ``name`` column.  This function fixes such files in-place:
+
+    * **Empty / whitespace-only** → overwritten with a minimal ``name\n``
+      header so MNE-BIDS treats the channel list as empty.
+    * **Has content but no ``name`` column** → the first column header is
+      renamed to ``name`` (per BIDS spec the first column must be ``name``).
+
+    Returns ``True`` if any file was repaired.
+    """
+    if not data_dir.is_dir():
+        return False
+
+    repaired_any = False
+
+    try:
+        tsv_files = list(data_dir.glob("*_channels.tsv"))
+    except Exception:
+        return False
+
+    for tsv_path in tsv_files:
+        try:
+            raw = tsv_path.read_text(encoding="utf-8-sig")
+            stripped = raw.strip()
+
+            if not stripped:
+                # Empty or whitespace-only file
+                tsv_path.write_text("name\n", encoding="utf-8")
+                logger.info("Repaired empty channels.tsv: %s", tsv_path.name)
+                repaired_any = True
+                continue
+
+            header_line = stripped.split("\n", 1)[0]
+            columns = header_line.split("\t")
+
+            if "name" not in [c.strip().lower() for c in columns]:
+                # First column must be 'name' per BIDS spec — rename it
+                columns[0] = "name"
+                new_header = "\t".join(columns)
+                rest = stripped.split("\n", 1)
+                if len(rest) > 1:
+                    new_content = new_header + "\n" + rest[1] + "\n"
+                else:
+                    new_content = new_header + "\n"
+                tsv_path.write_text(new_content, encoding="utf-8")
+                logger.info(
+                    "Repaired channels.tsv (renamed first column to 'name'): %s",
+                    tsv_path.name,
+                )
+                repaired_any = True
+        except Exception as exc:
+            logger.warning("Failed to repair %s: %s", tsv_path.name, exc)
+
+    return repaired_any
+
+
 def _repair_participants_tsv_ids(bids_root: Path) -> bool:
     """Align ``participant_id`` values in ``participants.tsv`` with ``sub-*`` folders.
 

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -776,10 +776,10 @@ def _repair_channels_tsv(data_dir: Path) -> bool:
 
     MNE-BIDS skips channel metadata when ``channels.tsv`` is absent but
     raises ``KeyError: 'name'`` when the file exists and is empty or lacks
-    the required ``name`` column.  This function fixes such files in-place:
+    the required ``name`` column.  This function fixes such files:
 
-    * **Empty / whitespace-only** → overwritten with a minimal ``name\n``
-      header so MNE-BIDS treats the channel list as empty.
+    * **Empty / whitespace-only** → removed so MNE-BIDS skips channel
+      metadata gracefully (an empty file has no data to preserve).
     * **Has content but no ``name`` column** → the first column header is
       renamed to ``name`` (per BIDS spec the first column must be ``name``).
 
@@ -801,9 +801,10 @@ def _repair_channels_tsv(data_dir: Path) -> bool:
             stripped = raw.strip()
 
             if not stripped:
-                # Empty or whitespace-only file
-                tsv_path.write_text("name\n", encoding="utf-8")
-                logger.info("Repaired empty channels.tsv: %s", tsv_path.name)
+                # Empty or whitespace-only — remove so MNE-BIDS skips
+                # channel metadata gracefully (no data to preserve).
+                tsv_path.unlink()
+                logger.info("Removed empty channels.tsv: %s", tsv_path.name)
                 repaired_any = True
                 continue
 

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -10,6 +10,7 @@ from eegdash.dataset.io import (
     _generate_coordsystem_json,
     _generate_vhdr_from_metadata,
     _generate_vmrk_stub,
+    _repair_channels_tsv,
     _repair_events_tsv_nan_samples,
     _repair_tsv_decimal_separators,
     _repair_tsv_encoding,
@@ -618,3 +619,81 @@ def test_repair_events_tsv_no_nan(tmp_path):
 def test_repair_events_tsv_nonexistent_dir(tmp_path):
     """Returns False for nonexistent directory."""
     assert _repair_events_tsv_nan_samples(tmp_path / "missing") is False
+
+
+# ---------- _repair_channels_tsv ----------
+
+
+def test_repair_channels_tsv_empty_file(tmp_path):
+    """Empty channels.tsv is overwritten with 'name' header."""
+    (tmp_path / "sub-01_channels.tsv").write_text("")
+    assert _repair_channels_tsv(tmp_path) is True
+    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+
+
+def test_repair_channels_tsv_whitespace_only(tmp_path):
+    """Whitespace-only channels.tsv is overwritten with 'name' header."""
+    (tmp_path / "sub-01_channels.tsv").write_text("   \n\n  \t  \n")
+    assert _repair_channels_tsv(tmp_path) is True
+    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+
+
+def test_repair_channels_tsv_missing_name_column(tmp_path):
+    """First column is renamed to 'name' when header lacks it."""
+    content = "foo\ttype\tunits\nEEG1\teeg\tuV\nEEG2\teeg\tuV\n"
+    (tmp_path / "sub-01_channels.tsv").write_text(content)
+    assert _repair_channels_tsv(tmp_path) is True
+    lines = (tmp_path / "sub-01_channels.tsv").read_text().splitlines()
+    assert lines[0] == "name\ttype\tunits"
+    assert lines[1] == "EEG1\teeg\tuV"
+    assert lines[2] == "EEG2\teeg\tuV"
+
+
+def test_repair_channels_tsv_valid_file(tmp_path):
+    """Valid channels.tsv with 'name' column is left unchanged."""
+    content = "name\ttype\tunits\nEEG1\teeg\tuV\n"
+    (tmp_path / "sub-01_channels.tsv").write_text(content)
+    assert _repair_channels_tsv(tmp_path) is False
+    assert (tmp_path / "sub-01_channels.tsv").read_text() == content
+
+
+def test_repair_channels_tsv_header_only(tmp_path):
+    """Header-only channels.tsv with 'name' is left unchanged."""
+    content = "name\ttype\tunits\n"
+    (tmp_path / "sub-01_channels.tsv").write_text(content)
+    assert _repair_channels_tsv(tmp_path) is False
+
+
+def test_repair_channels_tsv_nonexistent_dir(tmp_path):
+    """Returns False for nonexistent directory."""
+    assert _repair_channels_tsv(tmp_path / "missing") is False
+
+
+def test_repair_channels_tsv_no_channels_files(tmp_path):
+    """Returns False when no *_channels.tsv files exist."""
+    (tmp_path / "sub-01_events.tsv").write_text("onset\tduration\n")
+    assert _repair_channels_tsv(tmp_path) is False
+
+
+def test_repair_channels_tsv_bom_valid(tmp_path):
+    """BOM + valid header is left unchanged."""
+    content = "name\ttype\tunits\nEEG1\teeg\tuV\n"
+    (tmp_path / "sub-01_channels.tsv").write_text(content, encoding="utf-8-sig")
+    assert _repair_channels_tsv(tmp_path) is False
+
+
+def test_repair_channels_tsv_bom_empty(tmp_path):
+    """BOM-only file (no real content) is overwritten with 'name' header."""
+    (tmp_path / "sub-01_channels.tsv").write_bytes(b"\xef\xbb\xbf")
+    assert _repair_channels_tsv(tmp_path) is True
+    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+
+
+def test_repair_channels_tsv_multiple_files(tmp_path):
+    """Only bad files are repaired; good files are unchanged."""
+    good = "name\ttype\tunits\nEEG1\teeg\tuV\n"
+    (tmp_path / "sub-01_channels.tsv").write_text(good)
+    (tmp_path / "sub-02_channels.tsv").write_text("")
+    assert _repair_channels_tsv(tmp_path) is True
+    assert (tmp_path / "sub-01_channels.tsv").read_text() == good
+    assert (tmp_path / "sub-02_channels.tsv").read_text() == "name\n"

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -625,17 +625,17 @@ def test_repair_events_tsv_nonexistent_dir(tmp_path):
 
 
 def test_repair_channels_tsv_empty_file(tmp_path):
-    """Empty channels.tsv is overwritten with 'name' header."""
+    """Empty channels.tsv is removed so MNE-BIDS skips gracefully."""
     (tmp_path / "sub-01_channels.tsv").write_text("")
     assert _repair_channels_tsv(tmp_path) is True
-    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+    assert not (tmp_path / "sub-01_channels.tsv").exists()
 
 
 def test_repair_channels_tsv_whitespace_only(tmp_path):
-    """Whitespace-only channels.tsv is overwritten with 'name' header."""
+    """Whitespace-only channels.tsv is removed."""
     (tmp_path / "sub-01_channels.tsv").write_text("   \n\n  \t  \n")
     assert _repair_channels_tsv(tmp_path) is True
-    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+    assert not (tmp_path / "sub-01_channels.tsv").exists()
 
 
 def test_repair_channels_tsv_missing_name_column(tmp_path):
@@ -683,10 +683,10 @@ def test_repair_channels_tsv_bom_valid(tmp_path):
 
 
 def test_repair_channels_tsv_bom_empty(tmp_path):
-    """BOM-only file (no real content) is overwritten with 'name' header."""
+    """BOM-only file (no real content) is removed."""
     (tmp_path / "sub-01_channels.tsv").write_bytes(b"\xef\xbb\xbf")
     assert _repair_channels_tsv(tmp_path) is True
-    assert (tmp_path / "sub-01_channels.tsv").read_text() == "name\n"
+    assert not (tmp_path / "sub-01_channels.tsv").exists()
 
 
 def test_repair_channels_tsv_multiple_files(tmp_path):
@@ -696,4 +696,4 @@ def test_repair_channels_tsv_multiple_files(tmp_path):
     (tmp_path / "sub-02_channels.tsv").write_text("")
     assert _repair_channels_tsv(tmp_path) is True
     assert (tmp_path / "sub-01_channels.tsv").read_text() == good
-    assert (tmp_path / "sub-02_channels.tsv").read_text() == "name\n"
+    assert not (tmp_path / "sub-02_channels.tsv").exists()


### PR DESCRIPTION
## Summary

- Adds `_repair_channels_tsv()` to handle datasets where `channels.tsv` exists but is empty or missing the required `name` column — MNE-BIDS raises `KeyError: 'name'` in these cases
- **Empty/whitespace-only files** are removed so MNE-BIDS skips channel metadata gracefully (same as absent file)
- **Files missing the `name` column** get their first column renamed to `name` per BIDS spec
- Wired both proactively in `_ensure_raw()` and reactively in `_load_raw()` with exact `KeyError("name")` matching
- 10 unit tests covering empty, whitespace, BOM, missing column, valid files, and multi-file scenarios

## Test plan

- [x] `pytest tests/unit_tests/dataset/test_io.py -x -q` — 58 passed
- [x] `pytest tests/ -x -q` — 637 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `pre-commit run` — all hooks pass
- [x] End-to-end validation with real ds004752 data from OpenNeuro S3