### PR TITLE
feat(loader): add on_error parameter to skip bad records and improve fallbacks

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -149,6 +149,12 @@ class EEGDashRaw(RawDataset):
         Must have schema_version=2 and include storage.base (no default bucket).
     cache_dir : str
         The local directory where the data will be cached.
+    on_error : str, default "raise"
+        How to handle :class:`DataIntegrityError` when accessing ``.raw``:
+
+        - ``"raise"`` (default): propagate the exception.
+        - ``"warn"``: log the error as a warning and set ``.raw`` to ``None``.
+        - ``"skip"``: silently set ``.raw`` to ``None``.
     **kwargs
         Additional keyword arguments passed to the
         :class:`braindecode.datasets.BaseDataset` constructor.
@@ -166,6 +172,9 @@ class EEGDashRaw(RawDataset):
         cache_dir: str,
         **kwargs,
     ):
+        self._on_error = kwargs.pop("on_error", "raise")
+        self._skipped = False
+        self._integrity_error = None
         super().__init__(None, **kwargs)
         self.cache_dir = Path(cache_dir)
 
@@ -561,8 +570,9 @@ class EEGDashRaw(RawDataset):
           ``scipy.io.loadmat`` raises ``TypeError: buffer is too small``.
           Retries with ``uint16_codec='latin-1'`` via ``extra_params``.
         - **Unrecoverable corruption** (Bad EDF, empty MEG data, corrupt
-          MAT/EEGLAB files with array errors, etc.): raises
-          ``DataIntegrityError`` for clean error reporting.
+          MAT/EEGLAB files with array errors, etc.): attempts EEGLAB fallback
+          for ``.set`` files and direct MNE reader before raising
+          ``DataIntegrityError``.
         - **Invalid scans.tsv timestamps** (seconds >= 60, NaN): repairs
           the scans.tsv and retries.
         - **participants.tsv subject mismatches**: repairs ``participant_id``
@@ -582,7 +592,8 @@ class EEGDashRaw(RawDataset):
         - **Split FIF** (record points to split-02+ file): direct MNE reader
           loads with ``on_split_missing="warn"`` so partial data is returned.
         - **Bad record metadata** (e.g. ``.json`` extension, missing ``task``
-          entity): raises ``DataIntegrityError`` for clean error reporting.
+          entity): attempts direct MNE reader before raising
+          ``DataIntegrityError``.
         """
         current_split_key = self.record.get("storage", {}).get("raw_key")
         current_split_path = self.filecache
@@ -639,6 +650,22 @@ class EEGDashRaw(RawDataset):
 
                 # Unrecoverable patterns in RuntimeError
                 if any(p in msg for p in _UNRECOVERABLE_PATTERNS):
+                    # For .set files, try manual EEGLAB parser before giving up
+                    if self.filecache and self.filecache.suffix.lower() == ".set":
+                        try:
+                            return _load_raw_eeglab_fallback(
+                                self.filecache, bids_root=self.bids_root
+                            )
+                        except Exception:
+                            pass
+
+                    # For supported formats, try direct MNE reader (bypasses BIDS)
+                    if self.filecache:
+                        try:
+                            return _load_raw_direct(self.filecache)
+                        except Exception:
+                            pass
+
                     raise DataIntegrityError(
                         message=f"Cannot read data file: {msg}",
                         record=self.record,
@@ -647,6 +674,19 @@ class EEGDashRaw(RawDataset):
 
                 # Bad record metadata (e.g. .json extension, missing task entity)
                 if "must contain" in msg and "task" in msg:
+                    if self.filecache:
+                        logger.warning(
+                            "Missing 'task' entity in BIDSPath — "
+                            "falling back to direct reader."
+                        )
+                        try:
+                            return _load_raw_direct(self.filecache)
+                        except Exception as fallback_error:
+                            raise DataIntegrityError(
+                                message=f"Bad record metadata and direct reader failed: {msg}",
+                                record=self.record,
+                                issues=[msg, str(fallback_error)],
+                            ) from first_error
                     raise DataIntegrityError(
                         message=f"Bad record metadata: {msg}",
                         record=self.record,
@@ -1019,6 +1059,8 @@ class EEGDashRaw(RawDataset):
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""
+        if self._skipped:
+            return 0
         if self._raw is None:
             ntimes = self.record.get("ntimes")
             if ntimes is not None:
@@ -1036,20 +1078,32 @@ class EEGDashRaw(RawDataset):
         return len(self._raw)
 
     @property
-    def raw(self) -> BaseRaw:
+    def raw(self) -> BaseRaw | None:
         """The MNE Raw object for this recording.
 
         Accessing this property triggers the download and caching of the data
         if it has not been accessed before.
 
+        Returns ``None`` when ``on_error`` is ``"warn"`` or ``"skip"`` and
+        the record could not be loaded due to a
+        :class:`~eegdash.dataset.exceptions.DataIntegrityError`.
+
         Returns
         -------
-        mne.io.BaseRaw
-            The loaded MNE Raw object.
+        mne.io.BaseRaw | None
+            The loaded MNE Raw object, or ``None`` for skipped records.
 
         """
-        if self._raw is None:
-            self._ensure_raw()
+        if self._raw is None and not self._skipped:
+            try:
+                self._ensure_raw()
+            except DataIntegrityError as e:
+                if self._on_error == "raise":
+                    raise
+                self._skipped = True
+                self._integrity_error = e
+                if self._on_error == "warn":
+                    e.log_warning()
         return self._raw
 
     @raw.setter

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -135,6 +135,15 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
     auth_token : str | None
         Authentication token for accessing protected databases. Required for
         staging or admin operations.
+    on_error : str, default "raise"
+        How to handle :class:`DataIntegrityError` when accessing ``.raw``
+        on individual recordings:
+
+        - ``"raise"`` (default): propagate the exception.
+        - ``"warn"``: log the error as a warning and set ``.raw`` to ``None``.
+        - ``"skip"``: silently set ``.raw`` to ``None``.
+
+        Use :meth:`drop_bad` after iteration to remove skipped recordings.
     **kwargs : dict
         Additional keyword arguments serving two purposes:
 
@@ -157,11 +166,13 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         eeg_dash_instance: Any = None,
         database: str | None = None,
         auth_token: str | None = None,
+        on_error: str = "raise",
         **kwargs,
     ):
         # Parameters that don't need validation
         _suppress_comp_warning: bool = kwargs.pop("_suppress_comp_warning", False)
         self._dedupe_records: bool = kwargs.pop("_dedupe_records", False)
+        self._on_error = on_error
         self.s3_bucket = s3_bucket
         self.database = database
         self.auth_token = auth_token
@@ -208,6 +219,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         base_dataset_kwargs = {
             k: v for k, v in kwargs.items() if k not in ALLOWED_QUERY_FIELDS
         }
+        base_dataset_kwargs["on_error"] = self._on_error
 
         if "dataset" not in self.query:
             # If explicit records are provided, infer dataset from records
@@ -354,6 +366,31 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 pass
 
         super().__init__(datasets, lazy=True)
+
+    def drop_bad(self) -> list[dict]:
+        """Remove skipped datasets and return their records.
+
+        Call after accessing ``.raw`` on all datasets (e.g. after iteration
+        or preprocessing) to clean up the dataset list.
+
+        Returns
+        -------
+        list of dict
+            Records that were removed because loading failed.
+
+        """
+        bad = []
+        valid_datasets = []
+        valid_records = []
+        for ds, record in zip(self.datasets, self.records):
+            if getattr(ds, "_skipped", False):
+                bad.append(record)
+            else:
+                valid_datasets.append(ds)
+                valid_records.append(record)
+        self.datasets = valid_datasets
+        self.records = valid_records
+        return bad
 
     @property
     def cumulative_sizes(self) -> list[int]:

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -1961,7 +1961,11 @@ def test_raw_property_on_error_warn_skips_integrity_error(tmp_path):
     record = {
         "dataset": "ds",
         "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
-        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / "ds"),
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        },
         "entities": {"subject": "01", "task": "rest"},
         "entities_mne": {"subject": "01", "task": "rest"},
     }
@@ -1988,7 +1992,11 @@ def test_raw_property_on_error_raise_still_raises(tmp_path):
     record = {
         "dataset": "ds",
         "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
-        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / "ds"),
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        },
         "entities": {"subject": "01", "task": "rest"},
         "entities_mne": {"subject": "01", "task": "rest"},
     }
@@ -2012,7 +2020,11 @@ def test_raw_property_on_error_skip_silent(tmp_path):
     record = {
         "dataset": "ds",
         "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
-        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / "ds"),
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        },
         "entities": {"subject": "01", "task": "rest"},
         "entities_mne": {"subject": "01", "task": "rest"},
     }
@@ -2052,7 +2064,11 @@ def test_raw_property_skipped_does_not_retry(tmp_path):
     record = {
         "dataset": "ds",
         "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
-        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / "ds"),
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        },
         "entities": {"subject": "01", "task": "rest"},
         "entities_mne": {"subject": "01", "task": "rest"},
     }
@@ -2075,9 +2091,7 @@ def test_raw_property_skipped_does_not_retry(tmp_path):
 
 def test_load_raw_missing_task_falls_back_to_direct_reader(tmp_path):
     """RuntimeError about missing 'task' entity falls back to direct reader."""
-    ds = _make_local_eegdashraw(
-        tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf"
-    )
+    ds = _make_local_eegdashraw(tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf")
 
     mock_raw = MagicMock()
     with patch(
@@ -2097,9 +2111,7 @@ def test_load_raw_missing_task_direct_reader_also_fails(tmp_path):
     """RuntimeError about missing 'task' + direct reader failure → DataIntegrityError."""
     from eegdash.dataset.exceptions import DataIntegrityError
 
-    ds = _make_local_eegdashraw(
-        tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf"
-    )
+    ds = _make_local_eegdashraw(tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf")
 
     with patch(
         "mne_bids.read_raw_bids",
@@ -2109,7 +2121,9 @@ def test_load_raw_missing_task_direct_reader_also_fails(tmp_path):
             "eegdash.dataset.base._load_raw_direct",
             side_effect=Exception("reader failed"),
         ):
-            with pytest.raises(DataIntegrityError, match="Bad record metadata and direct reader failed"):
+            with pytest.raises(
+                DataIntegrityError, match="Bad record metadata and direct reader failed"
+            ):
                 ds._load_raw()
 
 

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -13,6 +13,7 @@ def test_len_with_ntimes_and_sfreq():
 
     recording = EEGDashRaw.__new__(EEGDashRaw)
     recording._raw = mock_raw
+    recording._skipped = False
     recording.record = {"ntimes": 10.5, "sampling_frequency": 500}
 
     # Access length - should use len(self._raw) since _raw exists
@@ -26,6 +27,7 @@ def test_len_without_raw_with_ntimes_sfreq():
 
     recording = EEGDashRaw.__new__(EEGDashRaw)
     recording._raw = None
+    recording._skipped = False
     recording.record = {"ntimes": 10, "sampling_frequency": 100}
 
     # Should return int(ntimes) = 10
@@ -1412,8 +1414,12 @@ def test_load_raw_runtime_error_unrecoverable_raises_data_integrity(
         "mne_bids.read_raw_bids",
         side_effect=RuntimeError(error_msg),
     ):
-        with pytest.raises(DataIntegrityError, match="Cannot read data file"):
-            ds._load_raw()
+        with patch(
+            "eegdash.dataset.base._load_raw_direct",
+            side_effect=Exception("direct reader failed too"),
+        ):
+            with pytest.raises(DataIntegrityError, match="Cannot read data file"):
+                ds._load_raw()
 
 
 # ── CTF mandatory HPI fix → retry with patched kind dict ──
@@ -1941,4 +1947,207 @@ def test_load_raw_is_not_in_list_without_did_you_mean_tries_participants(tmp_pat
             result = ds._load_raw()
 
     mock_repair.assert_called_once()
+    assert result is mock_raw
+
+
+# ── on_error parameter tests ──
+
+
+def test_raw_property_on_error_warn_skips_integrity_error(tmp_path):
+    """on_error='warn' catches DataIntegrityError, sets .raw to None."""
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    record = {
+        "dataset": "ds",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+    (tmp_path / "ds" / "sub-01" / "eeg").mkdir(parents=True)
+    (tmp_path / "ds" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashRaw(record, cache_dir=str(tmp_path), on_error="warn")
+
+    err = DataIntegrityError(message="corrupt", record=record, issues=["bad"])
+    with patch.object(ds, "_ensure_raw", side_effect=err):
+        result = ds.raw
+
+    assert result is None
+    assert ds._skipped is True
+    assert ds._integrity_error is err
+
+
+def test_raw_property_on_error_raise_still_raises(tmp_path):
+    """on_error='raise' (default) propagates DataIntegrityError."""
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    record = {
+        "dataset": "ds",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+    (tmp_path / "ds" / "sub-01" / "eeg").mkdir(parents=True)
+    (tmp_path / "ds" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashRaw(record, cache_dir=str(tmp_path))
+
+    err = DataIntegrityError(message="corrupt", record=record, issues=["bad"])
+    with patch.object(ds, "_ensure_raw", side_effect=err):
+        with pytest.raises(DataIntegrityError):
+            _ = ds.raw
+
+
+def test_raw_property_on_error_skip_silent(tmp_path):
+    """on_error='skip' silently sets .raw to None, no warning logged."""
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    record = {
+        "dataset": "ds",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+    (tmp_path / "ds" / "sub-01" / "eeg").mkdir(parents=True)
+    (tmp_path / "ds" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashRaw(record, cache_dir=str(tmp_path), on_error="skip")
+
+    err = DataIntegrityError(message="corrupt", record=record, issues=["bad"])
+    with patch.object(ds, "_ensure_raw", side_effect=err):
+        with patch.object(err, "log_warning") as mock_warn:
+            result = ds.raw
+
+    assert result is None
+    assert ds._skipped is True
+    mock_warn.assert_not_called()
+
+
+def test_len_returns_zero_when_skipped():
+    """Skipped record returns 0 from __len__."""
+    from eegdash.dataset.base import EEGDashRaw
+
+    ds = EEGDashRaw.__new__(EEGDashRaw)
+    ds._raw = None
+    ds._skipped = True
+    ds.record = {"ntimes": 1000}
+
+    assert len(ds) == 0
+
+
+def test_raw_property_skipped_does_not_retry(tmp_path):
+    """Accessing .raw twice on a skipped record doesn't re-attempt loading."""
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    record = {
+        "dataset": "ds",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "storage": {"backend": "local", "base": str(tmp_path / "ds"), "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf"},
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+    (tmp_path / "ds" / "sub-01" / "eeg").mkdir(parents=True)
+    (tmp_path / "ds" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashRaw(record, cache_dir=str(tmp_path), on_error="warn")
+
+    err = DataIntegrityError(message="corrupt", record=record, issues=["bad"])
+    with patch.object(ds, "_ensure_raw", side_effect=err) as mock_ensure:
+        ds.raw  # first access — triggers _ensure_raw
+        ds.raw  # second access — should NOT trigger _ensure_raw again
+
+    mock_ensure.assert_called_once()
+
+
+# ── Fallback tests ──
+
+
+def test_load_raw_missing_task_falls_back_to_direct_reader(tmp_path):
+    """RuntimeError about missing 'task' entity falls back to direct reader."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf"
+    )
+
+    mock_raw = MagicMock()
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=RuntimeError("BIDSPath must contain 'task' entity"),
+    ):
+        with patch(
+            "eegdash.dataset.base._load_raw_direct",
+            return_value=mock_raw,
+        ):
+            result = ds._load_raw()
+
+    assert result is mock_raw
+
+
+def test_load_raw_missing_task_direct_reader_also_fails(tmp_path):
+    """RuntimeError about missing 'task' + direct reader failure → DataIntegrityError."""
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds_task", "sub-01/eeg/sub-01_eeg.edf"
+    )
+
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=RuntimeError("BIDSPath must contain 'task' entity"),
+    ):
+        with patch(
+            "eegdash.dataset.base._load_raw_direct",
+            side_effect=Exception("reader failed"),
+        ):
+            with pytest.raises(DataIntegrityError, match="Bad record metadata and direct reader failed"):
+                ds._load_raw()
+
+
+def test_load_raw_runtime_unrecoverable_set_tries_eeglab_fallback(tmp_path):
+    """Unrecoverable RuntimeError on .set file tries EEGLAB fallback first."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds_set", "sub-01/eeg/sub-01_task-rest_eeg.set", ext=".set"
+    )
+
+    mock_raw = MagicMock()
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=RuntimeError("Allowed values for the Extension"),
+    ):
+        with patch(
+            "eegdash.dataset.base._load_raw_eeglab_fallback",
+            return_value=mock_raw,
+        ):
+            result = ds._load_raw()
+
+    assert result is mock_raw
+
+
+def test_load_raw_runtime_unrecoverable_tries_direct_reader(tmp_path):
+    """Unrecoverable RuntimeError on .edf tries direct reader before raising."""
+    ds = _make_local_eegdashraw(
+        tmp_path, "ds_edf", "sub-01/eeg/sub-01_task-rest_eeg.edf"
+    )
+
+    mock_raw = MagicMock()
+    with patch(
+        "mne_bids.read_raw_bids",
+        side_effect=RuntimeError("incorrect number of samples in the data"),
+    ):
+        with patch(
+            "eegdash.dataset.base._load_raw_direct",
+            return_value=mock_raw,
+        ):
+            result = ds._load_raw()
+
     assert result is mock_raw

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -1577,8 +1577,16 @@ def test_dataset_drop_bad_removes_skipped(tmp_path):
             "entities_mne": {"subject": f"{i:02d}", "task": "rest"},
         }
         records.append(r)
-        (tmp_path / "ds_test" / f"sub-{i:02d}" / "eeg").mkdir(parents=True, exist_ok=True)
-        (tmp_path / "ds_test" / f"sub-{i:02d}" / "eeg" / f"sub-{i:02d}_task-rest_eeg.edf").touch()
+        (tmp_path / "ds_test" / f"sub-{i:02d}" / "eeg").mkdir(
+            parents=True, exist_ok=True
+        )
+        (
+            tmp_path
+            / "ds_test"
+            / f"sub-{i:02d}"
+            / "eeg"
+            / f"sub-{i:02d}_task-rest_eeg.edf"
+        ).touch()
 
     with patch("eegdash.dataset.base.validate_record", return_value=None):
         ds = EEGDashDataset(

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -1524,3 +1524,77 @@ def test_cumulative_sizes_recomputes_after_length_change(tmp_path):
     # cumulative_sizes must reflect the NEW lengths without any manual refresh
     assert ds.cumulative_sizes == [99_500, 182_817, 852_417]
     assert len(ds) == 852_417
+
+
+# ── on_error and drop_bad tests ──
+
+
+def test_dataset_on_error_passed_to_raw(tmp_path):
+    """on_error parameter flows from EEGDashDataset to each EEGDashRaw."""
+    record = {
+        "dataset": "ds_test",
+        "data_name": "sub-01_task-rest_eeg.edf",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "storage": {
+            "backend": "local",
+            "base": str(tmp_path / "ds_test"),
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        },
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+    }
+
+    (tmp_path / "ds_test" / "sub-01" / "eeg").mkdir(parents=True)
+    (tmp_path / "ds_test" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashDataset(
+            cache_dir=tmp_path,
+            records=[record],
+            dataset="ds_test",
+            on_error="warn",
+            _suppress_comp_warning=True,
+        )
+
+    assert ds._on_error == "warn"
+    assert ds.datasets[0]._on_error == "warn"
+
+
+def test_dataset_drop_bad_removes_skipped(tmp_path):
+    """drop_bad() removes skipped datasets and returns their records."""
+    records = []
+    for i in range(3):
+        r = {
+            "dataset": "ds_test",
+            "data_name": f"sub-{i:02d}_task-rest_eeg.edf",
+            "bids_relpath": f"sub-{i:02d}/eeg/sub-{i:02d}_task-rest_eeg.edf",
+            "storage": {
+                "backend": "local",
+                "base": str(tmp_path / "ds_test"),
+                "raw_key": f"sub-{i:02d}/eeg/sub-{i:02d}_task-rest_eeg.edf",
+            },
+            "entities": {"subject": f"{i:02d}", "task": "rest"},
+            "entities_mne": {"subject": f"{i:02d}", "task": "rest"},
+        }
+        records.append(r)
+        (tmp_path / "ds_test" / f"sub-{i:02d}" / "eeg").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "ds_test" / f"sub-{i:02d}" / "eeg" / f"sub-{i:02d}_task-rest_eeg.edf").touch()
+
+    with patch("eegdash.dataset.base.validate_record", return_value=None):
+        ds = EEGDashDataset(
+            cache_dir=tmp_path,
+            records=records,
+            dataset="ds_test",
+            on_error="warn",
+            _suppress_comp_warning=True,
+        )
+
+    # Mark the second dataset as skipped
+    ds.datasets[1]._skipped = True
+
+    bad = ds.drop_bad()
+
+    assert len(bad) == 1
+    assert bad[0] is records[1]
+    assert len(ds.datasets) == 2
+    assert len(ds.records) == 2


### PR DESCRIPTION
## Summary

- Add `on_error` parameter (`"raise"`/`"warn"`/`"skip"`) to `EEGDashRaw` and `EEGDashDataset` so that `DataIntegrityError` on individual records can be caught instead of crashing the entire pipeline
- Add `drop_bad()` method to `EEGDashDataset` for removing skipped records after iteration
- Improve two `_load_raw()` error paths that gave up too early:
  - **Unrecoverable RuntimeError patterns**: now tries EEGLAB fallback for `.set` files and direct MNE reader before raising `DataIntegrityError`
  - **Missing `task` BIDS entity**: now falls back to direct reader before raising `DataIntegrityError`

## Usage

```python
dataset = EEGDashDataset(
    cache_dir="./data",
    dataset="ds002718",
    on_error="warn",  # log warnings instead of crashing
)
for ds in dataset.datasets:
    if ds.raw is not None:
        process(ds.raw)

# Optionally clean up skipped records
bad_records = dataset.drop_bad()
```

## Test plan

- [x] Updated 1 existing test to mock `_load_raw_direct` (now attempted before raising)
- [x] Fixed 2 existing `__new__`-based tests to set `_skipped` attribute
- [x] Added 9 new tests for `on_error` behavior in `EEGDashRaw` (warn/raise/skip, `__len__`, no-retry, fallbacks)
- [x] Added 2 new tests for `EEGDashDataset` (`on_error` propagation, `drop_bad()`)
- [x] Full unit test suite passes (725 passed)
- [x] Ruff lint passes