### PR TITLE
fix(loader): resolve split FIF annex paths and add CTF direct reader

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -11,6 +11,7 @@ braindecode for machine learning workflows and handles data loading from both lo
 
 import configparser
 import re
+import shutil
 from functools import partial
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -543,6 +544,26 @@ class EEGDashRaw(RawDataset):
                     next_path,
                     filesystem=filesystem,
                 )
+                # When the primary file is resolved through git-annex, MNE
+                # expects the continuation at the annex path, not the BIDS
+                # path.  Place a copy there so MNE can find it on retry.
+                if (
+                    expected_path is not None
+                    and expected_path.resolve() != next_path.resolve()
+                ):
+                    try:
+                        expected_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(next_path, expected_path)
+                        logger.info(
+                            "Copied continuation to expected path %s",
+                            expected_path,
+                        )
+                    except Exception as copy_err:
+                        logger.warning(
+                            "Failed to copy continuation to expected path %s: %s",
+                            expected_path,
+                            copy_err,
+                        )
                 return next_key, next_path
             except Exception as error:
                 failures.append(f"{next_uri}: {error}")
@@ -720,6 +741,26 @@ class EEGDashRaw(RawDataset):
                     if split_download is not None:
                         current_split_key, current_split_path = split_download
                         continue
+
+                    # All download attempts failed — fall back to direct
+                    # reader which uses on_split_missing="warn" for .fif
+                    # files, loading only the available splits.
+                    if self.filecache:
+                        logger.warning(
+                            "Split FIF continuation download failed — "
+                            "falling back to direct reader."
+                        )
+                        try:
+                            return _load_raw_direct(self.filecache)
+                        except Exception as fallback_error:
+                            raise DataIntegrityError(
+                                message=(
+                                    f"Split FIF continuation missing and "
+                                    f"direct reader failed: {fallback_error}"
+                                ),
+                                record=self.record,
+                                issues=[msg, str(fallback_error)],
+                            ) from first_error
 
                 # Non-UTF-8 encoding in TSV sidecar files (e.g. µ in Latin-1)
                 if isinstance(first_error, UnicodeDecodeError) and self.filecache:

--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -1122,6 +1122,7 @@ def _load_raw_direct(filepath: Path):  # -> mne.io.BaseRaw
         ".set": mne.io.read_raw_eeglab,
         ".fif": mne.io.read_raw_fif,
         ".cnt": mne.io.read_raw_cnt,
+        ".ds": mne.io.read_raw_ctf,
     }
 
     ext = filepath.suffix.lower()

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -1759,7 +1759,7 @@ def test_load_raw_falls_back_for_non_numeric_run_edf(mock_validate, tmp_path):
         with patch(
             "eegdash.dataset.base._load_raw_direct", return_value=mock_raw
         ) as mock_direct:
-            result = ds._load_raw()
+            ds._load_raw()
 
     mock_direct.assert_called_once_with(edf_path)
 

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -1762,6 +1762,8 @@ def test_load_raw_falls_back_for_non_numeric_run_edf(mock_validate, tmp_path):
             result = ds._load_raw()
 
     mock_direct.assert_called_once_with(edf_path)
+
+
 # ── EEGLAB epoch files (trials > 1) → read_epochs_eeglab handler ──
 
 
@@ -2244,4 +2246,132 @@ def test_load_raw_runtime_unrecoverable_tries_direct_reader(tmp_path):
         ):
             result = ds._load_raw()
 
+    assert result is mock_raw
+
+
+# ── Split FIF annex path resolution ──
+
+
+def test_split_fif_continuation_copies_to_expected_annex_path(tmp_path):
+    """Downloaded continuation should also be placed at the expected (annex) path."""
+    ds = _make_remote_eegdashraw(
+        tmp_path, "ds_annex", "sub-01/meg/sub-01_task-rest_meg.fif"
+    )
+    annex_dir = tmp_path / "annex_objects" / "ab" / "cd"
+    annex_next = annex_dir / "MD5E-s123--abc-1.fif"
+    mock_raw = MagicMock()
+    mock_fs = object()
+
+    def download_side_effect(s3_path, local_path, filesystem=None):
+        # Simulate successful download by creating the file
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(b"fake fif data")
+        return local_path
+
+    with patch.object(
+        ds,
+        "_read_raw_bids",
+        side_effect=[
+            ValueError(
+                f"Split raw file detected but next file {annex_next} does not exist"
+            ),
+            mock_raw,
+        ],
+    ):
+        with patch(
+            "eegdash.dataset.base.downloader.get_s3_filesystem", return_value=mock_fs
+        ):
+            with patch(
+                "eegdash.dataset.base.downloader.download_s3_file",
+                side_effect=download_side_effect,
+            ):
+                result = ds._load_raw()
+
+    assert result is mock_raw
+    # The file should also exist at the annex path
+    assert annex_next.exists()
+    assert annex_next.read_bytes() == b"fake fif data"
+
+
+def test_split_fif_download_fails_falls_back_to_direct_reader(tmp_path):
+    """When split FIF download fails, should fall back to _load_raw_direct."""
+    ds = _make_remote_eegdashraw(
+        tmp_path, "ds_split_fail", "sub-01/meg/sub-01_task-rest_meg.fif"
+    )
+    mock_raw = MagicMock()
+    mock_fs = object()
+
+    with patch.object(
+        ds,
+        "_read_raw_bids",
+        side_effect=ValueError(
+            "Split raw file detected but next file /tmp/missing-1.fif does not exist"
+        ),
+    ):
+        with patch(
+            "eegdash.dataset.base.downloader.get_s3_filesystem", return_value=mock_fs
+        ):
+            with patch(
+                "eegdash.dataset.base.downloader.download_s3_file",
+                side_effect=FileNotFoundError("not on S3"),
+            ):
+                with patch(
+                    "eegdash.dataset.base._load_raw_direct",
+                    return_value=mock_raw,
+                ) as mock_direct:
+                    result = ds._load_raw()
+
+    mock_direct.assert_called_once_with(ds.filecache)
+    assert result is mock_raw
+
+
+def test_split_fif_download_and_direct_both_fail_raises(tmp_path):
+    """When both split download and direct reader fail → DataIntegrityError."""
+    from eegdash.dataset.exceptions import DataIntegrityError
+
+    ds = _make_remote_eegdashraw(
+        tmp_path, "ds_split_bad", "sub-01/meg/sub-01_task-rest_meg.fif"
+    )
+    mock_fs = object()
+
+    with patch.object(
+        ds,
+        "_read_raw_bids",
+        side_effect=ValueError(
+            "Split raw file detected but next file /tmp/missing-1.fif does not exist"
+        ),
+    ):
+        with patch(
+            "eegdash.dataset.base.downloader.get_s3_filesystem", return_value=mock_fs
+        ):
+            with patch(
+                "eegdash.dataset.base.downloader.download_s3_file",
+                side_effect=FileNotFoundError("not on S3"),
+            ):
+                with patch(
+                    "eegdash.dataset.base._load_raw_direct",
+                    side_effect=ValueError("cannot read"),
+                ):
+                    with pytest.raises(
+                        DataIntegrityError,
+                        match="Split FIF continuation missing",
+                    ):
+                        ds._load_raw()
+
+
+# ── CTF .ds direct reader support ──
+
+
+def test_load_raw_direct_ctf_calls_read_raw_ctf(tmp_path):
+    """_load_raw_direct should support .ds extension via read_raw_ctf."""
+    from eegdash.dataset.io import _load_raw_direct
+
+    ds_path = tmp_path / "sub-01_task-rest_meg.ds"
+    ds_path.mkdir()
+
+    mock_raw = MagicMock()
+    with patch("mne.io.read_raw_ctf", return_value=mock_raw) as mock_reader:
+        result = _load_raw_direct(ds_path)
+
+    mock_reader.assert_called_once_with(str(ds_path), preload=False, verbose="ERROR")
     assert result is mock_raw


### PR DESCRIPTION
## Summary

- **Split FIF annex path fix**: When split FIF primary files are resolved through git-annex, MNE expects continuations in the annex directory. The download helper now copies the continuation to the expected path (parsed from MNE's error message) so MNE can find it on retry.
- **Split FIF fallback**: When all continuation download attempts fail (e.g. no continuation files on S3), falls back to `_load_raw_direct()` which loads partial splits via `on_split_missing="warn"`.
- **CTF `.ds` direct reader**: Adds `read_raw_ctf` to `_load_raw_direct()` so CTF files can be read directly when MNE-BIDS fails for non-trial-size reasons.

Affected datasets:
| Issue | Datasets | Outcome |
|-------|----------|---------|
| Split FIF missing continuation | ds002712, ds003483, ds003694, ds004837, ds006334 | Annex path copy + partial-load fallback |
| MEG trial size mismatch | ds002001, ds002550, ds002908, ds004398, ds005065 | DataIntegrityError (data genuinely truncated at source) |
| Incorrect samples (ds004166) | ds004166 | Already solved — DataIntegrityError |

## Verification

- **Split FIF**: Created real split FIF files with MNE, verified annex path copy enables MNE to find continuations, and verified `on_split_missing="warn"` loads partial data when continuations are absent.
- **CTF trial size**: Downloaded `.res4` header from ds002001 and computed trial math — `.meg4` has 6 complete trials + 99.97% of a 7th. Data is genuinely truncated at source; `DataIntegrityError` is correct.
- **S3 check**: Confirmed no continuation files exist on S3 for split FIF datasets, validating the direct reader fallback path.

## Test plan

- [x] Unit tests: 4 new tests (annex copy, download-fail fallback, both-fail raises, CTF direct reader)
- [x] All 109 existing tests pass
- [x] Integration tests with real MNE split FIF data
- [x] Real `.res4` analysis for CTF trial size verification
- [x] `ruff check` and `ruff format` clean