### PR TITLE
feat(downloader): expose max_concurrency for faster S3 downloads

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -265,6 +265,7 @@ class EEGDashRaw(RawDataset):
         **kwargs,
     ):
         self._on_error = kwargs.pop("on_error", "raise")
+        self._max_concurrency = kwargs.pop("max_concurrency", 20)
         self._skipped = False
         self._integrity_error = None
         super().__init__(None, **kwargs)
@@ -378,7 +379,7 @@ class EEGDashRaw(RawDataset):
 
     def _download_required_files(self) -> None:
         if self._raw_uri is not None:
-            filesystem = downloader.get_s3_filesystem()
+            filesystem = downloader.get_s3_filesystem(max_concurrency=self._max_concurrency)
 
             # Download deps first (sidecars, companions), then raw.
             # skip_missing=True because dep_keys may include companion files
@@ -555,7 +556,7 @@ class EEGDashRaw(RawDataset):
                 ", ".join(missing),
             )
             try:
-                filesystem = downloader.get_s3_filesystem()
+                filesystem = downloader.get_s3_filesystem(max_concurrency=self._max_concurrency)
                 # Strip protocol prefix for s3fs operations
                 s3_prefix = re.sub(r"^s3://", "", self._raw_uri)
                 remote_files = filesystem.ls(s3_prefix, detail=False)
@@ -760,7 +761,7 @@ class EEGDashRaw(RawDataset):
         if not candidates:
             return None
 
-        filesystem = downloader.get_s3_filesystem()
+        filesystem = downloader.get_s3_filesystem(max_concurrency=self._max_concurrency)
         failures: list[str] = []
         for next_key, next_path in candidates:
             if next_key in attempted_keys:

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -135,6 +135,10 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
     auth_token : str | None
         Authentication token for accessing protected databases. Required for
         staging or admin operations.
+    max_concurrency : int, default 20
+        Maximum number of parallel S3 transfer connections used when
+        downloading data.  Higher values speed up large/multi-file
+        downloads but consume more bandwidth.
     on_error : str, default "raise"
         How to handle :class:`DataIntegrityError` when accessing ``.raw``
         on individual recordings:
@@ -167,6 +171,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         database: str | None = None,
         auth_token: str | None = None,
         on_error: str = "raise",
+        max_concurrency: int = 20,
         **kwargs,
     ):
         # Parameters that don't need validation
@@ -179,6 +184,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         self.records = records
         self.download = download
         self.n_jobs = n_jobs
+        self.max_concurrency = max_concurrency
         self.eeg_dash_instance = eeg_dash_instance
 
         if description_fields is None:
@@ -220,6 +226,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             k: v for k, v in kwargs.items() if k not in ALLOWED_QUERY_FIELDS
         }
         base_dataset_kwargs["on_error"] = self._on_error
+        base_dataset_kwargs["max_concurrency"] = self.max_concurrency
 
         if "dataset" not in self.query:
             # If explicit records are provided, infer dataset from records
@@ -341,7 +348,9 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 base_dataset_kwargs=base_dataset_kwargs,
             )
             # We only need filesystem if we need to access S3
-            self.filesystem = downloader.get_s3_filesystem()
+            self.filesystem = downloader.get_s3_filesystem(
+                max_concurrency=self.max_concurrency,
+            )
 
             # Provide helpful error message when no datasets are found
             if len(datasets) == 0:
@@ -575,7 +584,9 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         if not keys_to_download:
             return
 
-        filesystem = downloader.get_s3_filesystem()
+        filesystem = downloader.get_s3_filesystem(
+            max_concurrency=self.max_concurrency,
+        )
 
         # Download files that don't exist locally
         files_to_download = []

--- a/eegdash/downloader.py
+++ b/eegdash/downloader.py
@@ -20,11 +20,22 @@ from rich.console import Console
 from .logging import logger
 
 
-def get_s3_filesystem() -> s3fs.S3FileSystem:
+def get_s3_filesystem(
+    *,
+    max_concurrency: int = 20,
+    region: str = "us-east-2",
+) -> s3fs.S3FileSystem:
     """Get an anonymous S3 filesystem object.
 
     Initializes and returns an ``s3fs.S3FileSystem`` for anonymous access
-    to public S3 buckets, configured for the 'us-east-2' region.
+    to public S3 buckets.
+
+    Parameters
+    ----------
+    max_concurrency : int
+        Maximum number of parallel transfer connections (default 20).
+    region : str
+        AWS region for the S3 endpoint (default ``"us-east-2"``).
 
     Returns
     -------
@@ -32,7 +43,13 @@ def get_s3_filesystem() -> s3fs.S3FileSystem:
         An S3 filesystem object.
 
     """
-    return s3fs.S3FileSystem(anon=True, client_kwargs={"region_name": "us-east-2"})
+    if max_concurrency < 1:
+        raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
+    return s3fs.S3FileSystem(
+        anon=True,
+        max_concurrency=max_concurrency,
+        client_kwargs={"region_name": region},
+    )
 
 
 def get_s3path(s3_bucket: str, filepath: str) -> str:


### PR DESCRIPTION
## Summary

- Bump default `s3fs` parallel transfer connections from 10 to 20 for ~2x faster downloads out of the box
- Expose `max_concurrency` as a user-facing parameter on `EEGDashDataset` and `EEGChallengeDataset`
- Also expose `region` on `get_s3_filesystem()` (keyword-only, defaults unchanged)
- Add input validation (`max_concurrency >= 1`)

## Usage

```python
# Default — already faster (20 connections vs previous 10)
dataset = EEGDashDataset(cache_dir="./data", dataset="ds002718")

# Tune for faster downloads on a good connection
dataset = EEGDashDataset(cache_dir="./data", dataset="ds002718", max_concurrency=50)

# Works with EEGChallengeDataset too (flows through **kwargs)
dataset = EEGChallengeDataset(release="R5", cache_dir="./data", max_concurrency=40)
```

## Test plan

- [x] All 29 existing downloader tests pass
- [x] Lint clean (`ruff check`)
- [ ] Manual smoke test: download a dataset with default and custom `max_concurrency`