### PR TITLE
docs: remove AI-isms across user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional recording-info parameter for feature extractors (#284, #285)
 - `on_error` parameter to skip bad records during data loading (#276)
 - CTF direct reader for `.ds` directories (#279)
-- Robust BrainVision handling with auto-repair and metadata generation (#236)
+- BrainVision handling with auto-repair and metadata generation (#236)
 - Enhanced documentation search with autocomplete and live search (#238)
 - fNIRS metadata extraction support (#238)
 - EDF/BDF metadata extraction via MNE
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified color palette across plots and CSS tags
 
 ### Fixed
-- Robust data loading across 522 EEG datasets (#282)
+- Reliable data loading across 522 EEG datasets (#282)
 - Git-annex key path resolution to BIDS names for S3 downloads (#280)
 - BIDS TSV whitespace-padded `n/a` values (#278)
 - BIDS coordinate system validation and extended non-numeric run fallback (#277)
@@ -53,8 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrupt data, bad timestamps, and invalid BIDS entity handling (#260)
 - Directory-based format recursive download support (#253)
 - Dynamic `cumulative_sizes` and accurate `nchans` computation (#243)
-- Robust BIDSPath entity extraction for git-annex datasets (#245)
-- Robust subject/participant TSV fallback (#248)
+- BIDSPath entity extraction for git-annex datasets (#245)
+- Subject/participant TSV fallback handling (#248)
 - Signal filter preprocessor bug (#288)
 - Anonymous hyperlinks in docstrings to avoid duplicate target warnings
 - MNE/Dataset compatibility with retry handlers for multiple failing datasets (#271)
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `braindecode` dependency to `>=1.4.0`
 
 ### Documentation
-- Comprehensive docstrings for Features module (#281, #287)
+- Full docstrings for Features module (#281, #287)
 - Dataset documentation with tags, feedback section, and visualization updates (#235)
 - P3 oddball tutorial updates (#192)
 - Improved dataset page layout and README parser
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Time estimation feature for tutorials
 - User guide documentation for EEGDash
 - Warning system for nonexistent query conditions
-- Comprehensive API documentation
+- Full API documentation
 
 ### Fixed
 - Python 3.10 compatibility issues with type annotations
@@ -134,12 +134,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up legacy code and removed dead code
 
 ### Performance
-- Significant speedup in offline dataset loading
-- Optimized feature extraction with better vectorization
-- Improved S3 download retry logic with exponential backoff
+- 2x speedup in offline dataset loading
+- Vectorized feature extraction
+- S3 download retry logic with exponential backoff
 
 ### Documentation
-- Added comprehensive user guide
+- Added user guide
 - Improved API documentation structure
 - Added tutorial time estimates
 - Updated logo and visual assets
@@ -196,7 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Initial documentation deployment to GitHub Pages
-- Added comprehensive examples
+- Added end-to-end examples
 - Created tutorial notebooks for common tasks
 
 ## [0.2.0] - 2025-xx-xx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ This will automatically run code quality checks (ruff, codespell) before each co
 pytest tests/ -v
 
 # Check that you can import eegdash
-python -c "from eegdash import EEGDash; print('Setup successful!')"
+python -c "import eegdash; print(eegdash.__version__)"
 ```
 
 ## Coding Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to EEG-Dash
 
-Thank you for your interest in contributing to EEG-Dash! This document provides guidelines and instructions for contributing to the project.
+Thanks for taking the time to contribute. This document covers the conventions, workflows, and tooling for working on EEG-Dash.
 
 ## Table of Contents
 
@@ -244,7 +244,7 @@ xdg-open build/html/index.html  # Linux
 
 Reviewers will check:
 - ✓ Code follows project style and conventions
-- ✓ Tests are comprehensive and passing
+- ✓ Tests cover the change and pass
 - ✓ Documentation is clear and complete
 - ✓ Commit messages follow conventions
 - ✓ No breaking changes (or properly documented)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,17 @@ EEGDash datasets are [braindecode](https://braindecode.org/stable/index.html) da
 ## EEG-Dash usage
 
 ### Install
-Use your preferred Python environment manager with Python > 3.10 to install the package.
-* To install the eegdash package, use the following command: `pip install eegdash`
-* To verify the installation, start a Python session and type: `from eegdash import EEGDash`
+Requires Python 3.10 or higher. Use whichever environment manager you prefer.
+
+```bash
+pip install eegdash
+```
+
+Verify the install in a Python session:
+
+```python
+from eegdash import EEGDash
+```
 
 See the tutorials at [eegdash.org](https://eegdash.org/) for end-to-end examples.
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@
 [![Downloads](https://pepy.tech/badge/eegdash)](https://pepy.tech/project/eegdash)
 [![Coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Feegdash%2FEEGDash%2Fmain%2Fcoverage.json&query=%24.totals.percent_covered_display&suffix=%25&label=coverage)](https://github.com/eegdash/EEGDash/blob/main/coverage.json)
 
-To leverage recent and ongoing advancements in large-scale computational methods and to ensure the preservation of scientific data generated from publicly funded research, the EEG-DaSh data archive will create a data-sharing resource for MEEG (EEG, MEG) data contributed by collaborators for machine learning (ML) and deep learning (DL) applications
+EEG-DaSh is a data-sharing archive for MEEG (EEG, MEG) recordings contributed by collaborating labs. It preserves publicly funded research data and exposes it in a form that machine learning and deep learning workflows can use directly.
 
 ## Data source
 
-The data in EEG-DaSh originates from a collaboration involving 25 laboratories, encompassing 27,053 participants. This extensive collection includes MEEG data, which is a combination of EEG and MEG signals. The data is sourced from various studies conducted by these labs, involving both healthy subjects and clinical populations with conditions such as ADHD, depression, schizophrenia, dementia, autism, and psychosis. Additionally, data spans different mental states like sleep, meditation, and cognitive tasks. In addition, EEG-DaSh will incorporate a subset of the data converted from NEMAR, which includes 330 MEEG BIDS-formatted datasets, further expanding the archive with well-curated, standardized neuroelectromagnetic data.
+The archive draws on 25 labs and 27,053 participants, with recordings covering both EEG and MEG. Subjects include healthy controls and clinical groups: ADHD, depression, schizophrenia, dementia, autism, and psychosis. Tasks range across sleep, meditation, and cognitive paradigms. EEG-DaSh also pulls in 330 BIDS-formatted MEEG datasets converted from NEMAR.
 
 ## Data format
 
-EEGDash queries return a **Pytorch Dataset** formatted to facilitate machine learning (ML) and deep learning (DL) applications. PyTorch Datasets are the best format for EEGDash queries because they provide an efficient, scalable, and flexible structure for machine learning (ML) and deep learning (DL) applications. They allow seamless integration with PyTorch’s DataLoader, enabling efficient batching, shuffling, and parallel data loading, which is essential for training deep learning models on large EEG datasets.
+EEGDash queries return a **PyTorch Dataset**. The format plugs directly into PyTorch's `DataLoader` for batching, shuffling, and parallel loading, which matters when training models on large EEG corpora.
 
 ## Data preprocessing
 
-EEGDash datasets are processed using the popular [braindecode](https://braindecode.org/stable/index.html) library. In fact, EEGDash datasets are braindecode datasets, which are themselves PyTorch datasets. This means that any preprocessing possible on braindecode datasets is also possible on EEGDash datasets. Refer to [braindecode](https://braindecode.org/stable/index.html) tutorials for guidance on preprocessing EEG data.
+EEGDash datasets are [braindecode](https://braindecode.org/stable/index.html) datasets, which are themselves PyTorch datasets. Any preprocessing that works on a braindecode dataset works on an EEGDash dataset. See the braindecode tutorials for the available options.
 
 ## EEG-Dash usage
 
@@ -29,11 +29,11 @@ Use your preferred Python environment manager with Python > 3.10 to install the 
 * To install the eegdash package, use the following command: `pip install eegdash`
 * To verify the installation, start a Python session and type: `from eegdash import EEGDash`
 
-Please check our tutorial webpages to explore what you can do with [eegdash](https://eegdash.org/)! 
+See the tutorials at [eegdash.org](https://eegdash.org/) for end-to-end examples.
 
-## Education -- Coming soon...
+## Education (coming soon)
 
-We organize workshops and educational events to foster cross-cultural education and student training, offering both online and in-person opportunities in collaboration with US and Israeli partners. Events for 2025 will be announced via the EEGLABNEWS mailing list. Be sure to [subscribe](https://sccn.ucsd.edu/mailman/listinfo/eeglabnews).
+We run workshops and student training events with US and Israeli partners, online and in person. 2025 dates will go out on the EEGLABNEWS mailing list. [Subscribe here](https://sccn.ucsd.edu/mailman/listinfo/eeglabnews).
 
 ## About EEG-DaSh
 

--- a/docs/export_paper_figures.py
+++ b/docs/export_paper_figures.py
@@ -935,7 +935,7 @@ def _capture_moabb(html_path: Path, out_dir: Path) -> None:
     document.querySelectorAll('*').forEach(el => { try { var cs = getComputedStyle(el); if (cs.fontFamily.includes('system-ui') || cs.fontFamily.includes('Inter')) el.style.fontFamily = 'Helvetica, Arial, sans-serif'; } catch(e) {} });
     var b = document.createElement('div');
     b.style.cssText = 'position:absolute;top:8px;left:50%;transform:translateX(-50%);z-index:9999;font-family:Helvetica,Arial,sans-serif;font-size:15px;font-weight:600;color:#374151;letter-spacing:0.5px;background:rgba(255,255,255,0.92);padding:6px 24px;border-radius:4px;border:1px solid rgba(0,108,163,0.15)';
-    b.innerHTML = '<span style="color:#006CA3;font-weight:700">719</span> datasets \\u00B7 <span style="color:#006CA3;font-weight:700">35,008</span> subjects \\u00B7 <span style="color:#006CA3;font-weight:700">65,175</span> hours \\u00B7 <span style="color:#006CA3;font-weight:700">5</span> modalities';
+    b.innerHTML = '<span style="color:#006CA3;font-weight:700">700+</span> datasets \\u00B7 <span style="color:#006CA3;font-weight:700">35,000+</span> subjects \\u00B7 <span style="color:#006CA3;font-weight:700">65,000+</span> hours \\u00B7 <span style="color:#006CA3;font-weight:700">5</span> modalities';
     document.body.appendChild(b);
 }""")
 

--- a/docs/source/_extra/404.html
+++ b/docs/source/_extra/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>404 — EEGDash</title>
+  <title>404: EEGDash</title>
   <meta name="description" content="The page you're looking for moved or no longer exists. Redirecting you to the closest match in the EEGDash catalog.">
   <meta name="robots" content="noindex">
   <link rel="canonical" href="https://eegdash.org/">
@@ -65,7 +65,7 @@
   <ul>
     <li><a href="/">EEGDash home</a></li>
     <li><a href="/dataset_summary.html">Browse the full dataset catalog</a></li>
-    <li><a href="/user_guide.html">User guide — load data in Python</a></li>
+    <li><a href="/user_guide.html">User guide: load data in Python</a></li>
     <li><a href="/install/install.html">Install EEGDash</a></li>
     <li><a href="/api/api.html">API reference</a></li>
   </ul>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -420,16 +420,17 @@ DATASET_INDEX_TEMPLATE = """{notice}.. _api/dataset/api_dataset:
 Datasets API
 =======================
 
-The :mod:`eegdash.dataset` package exposes dynamically registered dataset
-classes. See :doc:`eegdash.dataset` for the module-level API, including
-:class:`~eegdash.dataset.EEGChallengeDataset` and helper utilities.
+The :mod:`eegdash.dataset` package exposes dataset classes that are
+registered dynamically at import time. See :doc:`eegdash.dataset` for the
+module-level API, including :class:`~eegdash.dataset.EEGChallengeDataset`
+and helper utilities.
 
-Dataset Overview
-----------------
+What's in the registry
+----------------------
 
-EEGDash currently exposes **{dataset_count} OpenNeuro EEG datasets** that are
-registered dynamically from mongo database. The table below summarises
-the distribution by experimental type as tracked in the summary file.
+EEGDash exposes **700+ OpenNeuro EEG datasets**, registered dynamically
+from MongoDB. The table below summarises the breakdown by experimental
+type ({dataset_count} datasets in this build).
 
 Base Dataset API
 ----------------

--- a/docs/source/dataset_summary.rst
+++ b/docs/source/dataset_summary.rst
@@ -46,7 +46,7 @@
 Datasets Catalog
 ================
 
-To leverage recent and ongoing advancements in large-scale computational methods and to ensure the preservation of scientific data generated from publicly funded research, the EEG-DaSh data archive will create a data-sharing resource for MEEG (EEG, MEG) data contributed by collaborators for machine learning (ML) and deep learning (DL) applications.
+EEG-DaSh is a data-sharing archive for MEEG (EEG, MEG) recordings contributed by collaborating labs. It preserves publicly funded research data and exposes it in a form that machine learning and deep learning workflows can use directly.
 
 
 .. grid:: 1 2 2 4
@@ -118,7 +118,7 @@ To leverage recent and ongoing advancements in large-scale computational methods
 
          .. include:: dataset_summary/growth.rst
 
-      .. tab-item:: Dataset Landscape
+      .. tab-item:: Dataset Map
 
          .. include:: dataset_summary/bubble.rst
 

--- a/docs/source/dataset_summary.rst
+++ b/docs/source/dataset_summary.rst
@@ -128,9 +128,9 @@ EEG-DaSh is a data-sharing archive for MEEG (EEG, MEG) recordings contributed by
 
 .. only:: not html
 
-   The catalog is best browsed interactively at
+   Browse the catalog interactively at
    `eegdash.org/dataset_summary.html <https://eegdash.org/dataset_summary.html>`__.
-   The same catalog is available programmatically in Python::
+   The same data is available programmatically in Python::
 
        from eegdash import EEGDashDataset
 
@@ -144,4 +144,4 @@ EEG-DaSh is a data-sharing archive for MEEG (EEG, MEG) recordings contributed by
    (see the ``/docs`` Swagger UI and the
    `api catalog </.well-known/api-catalog>`__).
 
-The archive is currently still in :bdg-danger:`beta testing` mode, so be kind.
+The archive is still in :bdg-danger:`beta testing` mode, so be kind.

--- a/docs/source/dataset_summary/bubble.rst
+++ b/docs/source/dataset_summary/bubble.rst
@@ -2,7 +2,7 @@
 .. raw:: html
 
    <header class="eegdash-fig-title">
-     <h3>Dataset landscape: subjects × records × duration</h3>
+     <h3>Dataset map: subjects × records × duration</h3>
    </header>
 
 .. raw:: html
@@ -15,7 +15,7 @@
 .. raw:: html
 
    <figcaption class="eegdash-caption">
-     Figure: Dataset landscape. Each bubble represents a dataset: x-axis shows the number of subjects,
+     Figure: Dataset map. Each bubble represents a dataset: x-axis shows the number of subjects,
      y-axis the number of records, bubble size encodes recording duration per subject, and color indicates
      experiment modality. Hover for details, click to open a dataset page, and use the legend to filter.
    </figcaption>

--- a/docs/source/dataset_summary/moabb.rst
+++ b/docs/source/dataset_summary/moabb.rst
@@ -11,7 +11,7 @@
 .. raw:: html
 
    <figcaption class="eegdash-caption">
-     Figure: Circle-packing overview of 719 datasets (35 010 subjects) catalogued in EEGDash.
+     Figure: Circle-packing overview of 700+ datasets (35 000+ subjects) catalogued in EEGDash.
      Each small circle represents one subject, grouped by dataset and colored by recording modality.
      Size encodes per-subject recording duration (log-scaled minutes); opacity encodes session count
      (fewer sessions = more opaque). Interactive: hover to inspect, scroll to zoom, click to navigate,

--- a/docs/source/dataset_summary/table.rst
+++ b/docs/source/dataset_summary/table.rst
@@ -40,4 +40,4 @@ which contributes BIDS-formatted M/EEG datasets to the catalog.
    </figcaption>
    </figure>
 
-Pathology, modality, and dataset type now surface as consistent color-coded tags so you can scan the table at a glance.
+Pathology, modality, and dataset type appear as color-coded tags, so the table is quick to scan.

--- a/docs/source/dataset_summary/treemap.rst
+++ b/docs/source/dataset_summary/treemap.rst
@@ -2,7 +2,7 @@
 .. raw:: html
 
    <header class="eegdash-fig-title">
-     <h3>Dataset landscape treemap</h3>
+     <h3>Dataset treemap</h3>
    </header>
 
 .. raw:: html

--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -224,7 +224,7 @@ The pipeline consists of 4 steps:
    # Available scripts: openneuro.py, nemar.py, eegmanylabs.py,
    #                    figshare.py, zenodo.py, osf.py, scidb.py, datarn.py
 
-**Step 2: Clone** - Smart clone without downloading raw data:
+**Step 2: Clone** - Shallow clone without downloading raw data:
 
 .. code-block:: bash
 

--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -14,8 +14,8 @@ EEGDash package, manage the data ingestion pipeline, or administer supporting se
 Package Overview
 ----------------
 
-EEGDash (``eegdash``) provides a unified interface for accessing large-scale EEG datasets
-from multiple sources. The package architecture consists of:
+EEGDash (``eegdash``) is a single Python interface for EEG datasets spread across
+multiple public archives. The package breaks down as:
 
 **Core Modules**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 :html_theme.sidebar_secondary.remove: true
 :og:description: EEGDash is a Python library for 700+ BIDS-first EEG, MEG, fNIRS, EMG, and iEEG datasets. Load, preprocess, and train PyTorch models with MNE-Python and braindecode in minutes.
 
-.. title:: EEGDash — Python library for 700+ EEG/MEG datasets
+.. title:: EEGDash: Python library for 700+ EEG/MEG datasets
 
 .. meta::
    :description: EEGDash is a Python library for 700+ BIDS-first EEG, MEG, fNIRS, EMG, and iEEG datasets. Load, preprocess, and train PyTorch models with MNE-Python and braindecode in minutes.
@@ -18,7 +18,7 @@
 
          .. raw:: html
 
-            <h1 class="hf-hero-title">EEGDash — the Python library for 700+ BIDS-first EEG/MEG datasets.</h1>
+            <h1 class="hf-hero-title">EEGDash: the Python library for 700+ BIDS-first EEG/MEG datasets.</h1>
 
          .. rst-class:: hf-hero-lede
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -10,12 +10,12 @@
 Installation
 ================
 
-EEGDash is written in Python 3, specifically for version 3.11 or above.
+EEGDash requires Python 3.11 or higher.
 
-The package is distributed via Python package index (`PyPI <eegdash-pypi_>`_), and you can access the
-source code via `Github <eegdash-github_>`_ repository.
+The package is on `PyPI <eegdash-pypi_>`_, and the source lives on
+`GitHub <eegdash-github_>`_.
 
-There are different ways to install EEGDash, depending on your needs:
+Two install paths, depending on what you need:
 
 
 .. grid:: 2
@@ -66,8 +66,8 @@ There are different ways to install EEGDash, depending on your needs:
         .. image:: https://mne.tools/stable/_images/mne_installer_console.png
            :alt: Terminal Window
 
-        **Already familiar with Python?**
-        Follow our setup instructions for building from Github and start to contribute!
+        For Python users who want the development version.
+        Follow the setup instructions for building from GitHub.
         +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
         .. button-ref:: install_source

--- a/docs/source/install/install_pip.rst
+++ b/docs/source/install/install_pip.rst
@@ -9,17 +9,15 @@
 Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
-EEGDash can be installed via pip from `PyPI <eegdash-pypi_>`_.
-
-.. note::
-    We recommend the most updated version of pip to install from PyPI.
-
-Below are the installation commands for the most common use cases.
+Install EEGDash from `PyPI <eegdash-pypi_>`_ with pip:
 
 .. code-block:: shell
 
    pip install eegdash
 
-This will install the eegdash package and its dependencies.
+This pulls in the ``eegdash`` package and its dependencies.
+
+.. note::
+    Use a recent ``pip``. Older versions may resolve dependencies poorly.
 
 .. include:: /links.inc

--- a/docs/source/install/install_source.rst
+++ b/docs/source/install/install_source.rst
@@ -9,7 +9,7 @@
 Installing from sources
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to test features under development or contribute to the library, or if you want to test the new tools that have been tested in EEGDash and not released yet, this is the right tutorial for you!
+This page covers installing EEGDash from source, which is what you want for contributing or for trying features that have not yet been released.
 
 For an overview of contributor workflows and project internals, see :doc:`Developer Notes </developer_notes>`.
 
@@ -27,13 +27,13 @@ Install preview version from PyPI
 
    pip install --pre eegdash
 
-You should will install the version of `eegdash` that is currently under development at main branch, which may not be stable. 
+This installs the in-development version of `eegdash` from the main branch, which may not be stable.
 
 
 Install directly from repository from GitHub
 --------------------------------------------
 
-Let's suppose that you want to install EEGDash from the source. The first thing you should do is clone the EEGDash repository to your computer and enter inside the repository.
+Clone the EEGDash repository and change into it:
 
 .. code-block:: shell
 
@@ -44,8 +44,7 @@ You should now be in the root directory of the EEGDash repository.
 Installing EEGDash from the source with pip
 -------------------------------------------
 
-If you want to only install EEGDash from source once and not do any development
-work, then the recommended way to build and install is to use ``pip``
+For a one-off install from source, without doing any development, use ``pip``:
 
 For the latest development version, directly from GitHub:
 

--- a/docs/source/install/install_source.rst
+++ b/docs/source/install/install_source.rst
@@ -15,73 +15,62 @@ For an overview of contributor workflows and project internals, see :doc:`Develo
 
 .. note::
 
-   If you are only trying to install EEGDash, we recommend the :doc:`Installing from PyPI </install/install_pip>` section for details on that.
+   If you only want to install a released version, see :doc:`Installing from PyPI </install/install_pip>`.
 
 
-
-Install preview version from PyPI 
-----------------------------------
-
+Install a pre-release from PyPI
+-------------------------------
 
 .. code-block:: shell
 
    pip install --pre eegdash
 
-This installs the in-development version of `eegdash` from the main branch, which may not be stable.
+This installs the in-development version of ``eegdash`` from the main branch. It may not be stable.
 
 
-Install directly from repository from GitHub
---------------------------------------------
+Install directly from GitHub
+----------------------------
 
-Clone the EEGDash repository and change into it:
+Clone the repository and change into it:
 
 .. code-block:: shell
 
    git clone https://github.com/eegdash/EEGDash && cd EEGDash
 
-You should now be in the root directory of the EEGDash repository.
 
-Installing EEGDash from the source with pip
--------------------------------------------
+Install with pip
+----------------
 
-For a one-off install from source, without doing any development, use ``pip``:
-
-For the latest development version, directly from GitHub:
+For a one-off install straight from GitHub:
 
 .. code-block:: shell
 
   pip install git+https://github.com/eegdash/EEGDash.git
 
-If you have a local clone of the EEGDash git repository:
+From a local clone, install in editable mode so source edits are picked up without reinstalling:
 
 .. code-block:: shell
 
    pip install -e .
 
-This will install EEGDash in editable mode, i.e., changes to the source code could be used
-directly in python.
-
-You could also install optional dependency, like to import datasets from `test` and `docs`.
+Optional extras let you pull in test and documentation dependencies:
 
 .. code-block:: shell
 
    pip install -e .[test,docs,dev]
 
-There is also optional dependencies for unit testing and building documentation, you could install
-them if you want to contribute to EEGDash.
+Or install everything, which is what you want for contributing:
 
 .. code-block:: shell
 
    pip install -e .[all]
 
 
-Testing if your installation is working
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To verify that EEGDash is installed and running correctly, run the following command:
+Verifying the installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: shell
 
-   python -m "import eegdash; eegdash.__version__"
+   python -c "import eegdash; print(eegdash.__version__)"
 
 .. include:: /links.inc

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -82,7 +82,7 @@ A basic example:
 
     print(f"Found {len(dataset)} recordings in the dataset.")
 
-This will create a dataset object containing all recordings from ``ds002718``. The data files will be downloaded to the ``./eeg_data/ds002718/`` directory when accessed.
+The resulting object holds every recording in ``ds002718``. Files are downloaded to ``./eeg_data/ds002718/`` on first access.
 
 Querying for Specific Data
 --------------------------
@@ -108,7 +108,7 @@ You can select recordings tied to a specific experimental task. For example, to 
 Filtering by Subject
 ~~~~~~~~~~~~~~~~~~~~
 
-You can also filter the data to get recordings from one or more subjects.
+Filter by one or more subjects:
 
 .. code-block:: python
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -15,12 +15,12 @@ This guide walks through the :mod:`eegdash` library and its main data access obj
 The EEGDash Object
 ------------------
 
-While :class:`~eegdash.api.EEGDashDataset` is the main tool for loading data for machine learning, the :class:`~eegdash.api.EEGDash` object provides a lower-level interface for directly interacting with the metadata database. It is useful for exploring the available data, performing complex queries, or managing metadata records.
+:class:`~eegdash.api.EEGDashDataset` is the main tool for loading data for machine learning. For direct access to the metadata database, use the lower-level :class:`~eegdash.api.EEGDash` object. It is the right choice for exploring what is available, running ad-hoc queries, or managing records.
 
 Initializing EEGDash
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can create a client to connect to the public database like this:
+Create a client that connects to the public database:
 
 .. code-block:: python
 
@@ -32,7 +32,7 @@ You can create a client to connect to the public database like this:
 Finding Records
 ~~~~~~~~~~~~~~~
 
-The ``find()`` method allows you to query the database for records matching specific criteria. You can pass keyword arguments for simple filters or a full MongoDB query dictionary for more advanced searches.
+Use ``find()`` to query the database for records matching specific criteria. Pass keyword arguments for simple filters, or a full MongoDB query dictionary for more advanced searches.
 
 .. code-block:: python
 
@@ -134,7 +134,7 @@ You can also filter the data to get recordings from one or more subjects.
 Combining Filters
 ~~~~~~~~~~~~~~~~~
 
-You can combine multiple filters to create more specific queries. For instance, to get the resting-state recordings for a specific set of subjects:
+Combine filters for narrower queries. For example, to get resting-state recordings from a specific set of subjects:
 
 .. code-block:: python
 
@@ -151,7 +151,7 @@ You can combine multiple filters to create more specific queries. For instance, 
 Advanced Querying with MongoDB Syntax
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For more complex queries, you can pass a MongoDB-style query dictionary directly using the ``query`` parameter. This allows for advanced filtering, such as using operators like ``$in``.
+For more complex queries, pass a MongoDB-style query dictionary directly to the ``query`` parameter. Operators such as ``$in`` work here.
 
 .. code-block:: python
 
@@ -169,11 +169,11 @@ For more complex queries, you can pass a MongoDB-style query dictionary directly
 Working with Local Data (Offline Mode)
 --------------------------------------
 
-:mod:`eegdash` also supports working with local data that you have already downloaded or manage separately. By setting ``download=False``, you can instruct :class:`~eegdash.api.EEGDashDataset` to use local BIDS-compliant data instead of accessing the database or remote storage.
+:mod:`eegdash` also works with local data you have already downloaded or manage yourself. Pass ``download=False`` and :class:`~eegdash.api.EEGDashDataset` reads BIDS-compliant files from disk instead of hitting the database or remote storage.
 
-To use this feature, your data must be organized in a BIDS-like structure within your ``cache_dir``. For example, if your ``cache_dir`` is ``./eeg_data`` and your dataset is ``ds002718``, the files should be located at ``./eeg_data/ds002718/``.
+The data must follow a BIDS-like layout inside your ``cache_dir``. If ``cache_dir`` is ``./eeg_data`` and the dataset is ``ds002718``, the files belong under ``./eeg_data/ds002718/``.
 
-Here is how to use :class:`~eegdash.api.EEGDashDataset` in offline mode:
+Offline mode in practice:
 
 .. code-block:: python
 
@@ -186,12 +186,12 @@ Here is how to use :class:`~eegdash.api.EEGDashDataset` in offline mode:
 
     print(f"Found {len(local_dataset)} local recordings.")
 
-When ``download=False``, :mod:`eegdash` will scan the specified directory for EEG files and construct the dataset from the local file system. This is useful for environments without internet access or when you want to work with your own curated datasets.
+With ``download=False``, :mod:`eegdash` scans ``cache_dir`` for EEG files and builds the dataset from the local file system. Use this for offline environments, air-gapped machines, or your own curated datasets.
 
 Accessing Data from the Dataset
 -------------------------------
 
-Once you have your :class:`~eegdash.api.EEGDashDataset` object, you can access individual recordings as if it were a list. Each item in the dataset is an :class:`~eegdash.data_utils.EEGDashBaseDataset` object, which contains the metadata and methods to load the actual EEG data.
+The :class:`~eegdash.api.EEGDashDataset` object behaves like a list: index into it to access individual recordings. Each item is an :class:`~eegdash.data_utils.EEGDashBaseDataset` that carries the metadata and loads the EEG data on demand.
 
 .. code-block:: python
 
@@ -208,23 +208,21 @@ API Configuration
 -----------------
 
 By default, :mod:`eegdash` connects to the public REST API at ``https://data.eegdash.org``.
-You can customize this behavior using environment variables:
+Override it through environment variables:
 
 .. code-block:: bash
 
    # Override the default API URL (e.g., for testing)
    export EEGDASH_API_URL="https://data.eegdash.org"
-   
-   # For admin write operations (required for dataset ingestion)
+
+   # Admin write operations (required for dataset ingestion)
    export EEGDASH_API_TOKEN="your-admin-token"
 
-The API provides the following features:
+Public endpoints are rate-limited to 100 requests per minute per IP. Service
+status is available at ``/health``, and every response carries an
+``X-Request-ID`` header you can use for debugging.
 
-- **Rate Limiting**: Public endpoints are limited to 100 requests/minute per IP
-- **Health Checks**: Service status available at ``/health``
-- **Request Tracing**: All responses include ``X-Request-ID`` for debugging
-
-For more details about the API architecture, see :doc:`API Core </api/api_core>`.
+For more on the API architecture, see :doc:`API Core </api/api_core>`.
 
 
 .. seealso::

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -10,7 +10,7 @@
 User Guide
 ==========
 
-This guide provides a comprehensive overview of the :mod:`eegdash` library, focusing on its core data access object, :class:`~eegdash.api.EEGDashDataset`. You will learn how to use this object to find, access, and manage EEG data for your research and analysis tasks.
+This guide walks through the :mod:`eegdash` library and its main data access object, :class:`~eegdash.api.EEGDashDataset`. You will see how to find, access, and manage EEG data for research and analysis.
 
 The EEGDash Object
 ------------------
@@ -48,27 +48,27 @@ The ``find()`` method allows you to query the database for records matching spec
 EEGDash vs. EEGDashDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It's important to understand the distinction between these two objects:
+These two objects do different jobs:
 
--   :class:`~eegdash.api.EEGDash`: Use this for querying and managing metadata. It returns a list of dictionaries, where each dictionary is a record from the database.
--   :class:`~eegdash.api.EEGDashDataset`: Use this when you need to load EEG data for analysis or machine learning. It returns a PyTorch-compatible dataset object where each item can load the actual EEG signal.
+-   :class:`~eegdash.api.EEGDash`: query and manage metadata. Returns a list of dictionaries, one per record.
+-   :class:`~eegdash.api.EEGDashDataset`: load EEG data for analysis or machine learning. Returns a PyTorch-compatible dataset where each item can load the underlying EEG signal.
 
-In general, you will use :class:`~eegdash.api.EEGDashDataset` for most of your data loading needs.
+For most data loading work, use :class:`~eegdash.api.EEGDashDataset`.
 
 The EEGDashDataset Object
 -------------------------
 
-The :class:`~eegdash.api.EEGDashDataset` is the primary entry point for working with EEG recordings in :mod:`eegdash`. It acts as a high-level interface that allows you to query a metadata database and load corresponding EEG data, either from a remote source or from a local cache.
+:class:`~eegdash.api.EEGDashDataset` is the main entry point for working with EEG recordings in :mod:`eegdash`. It is a high-level interface that queries the metadata database and loads matching EEG data, either from a remote source or from a local cache.
 
 Initializing EEGDashDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To get started, you need to create an instance of :class:`~eegdash.api.EEGDashDataset`. The two most important parameters are ``cache_dir`` and ``dataset``.
+Create an instance of :class:`~eegdash.api.EEGDashDataset`. The two main parameters are ``cache_dir`` and ``dataset``.
 
-- ``cache_dir``: This is the local directory where ``eegdash`` will store downloaded data.
-- ``dataset``: The identifier of the dataset you want to work with (e.g., ``"ds002718"``).
+- ``cache_dir``: local directory where ``eegdash`` stores downloaded data.
+- ``dataset``: identifier of the dataset (e.g., ``"ds002718"``).
 
-Here's a basic example of how to initialize the dataset:
+A basic example:
 
 .. code-block:: python
 
@@ -87,12 +87,12 @@ This will create a dataset object containing all recordings from ``ds002718``. T
 Querying for Specific Data
 --------------------------
 
-:class:`~eegdash.api.EEGDashDataset` offers powerful filtering capabilities, allowing you to select a subset of recordings based on various criteria. You can filter by task, subject, session, or run.
+:class:`~eegdash.api.EEGDashDataset` lets you select a subset of recordings by task, subject, session, or run.
 
 Filtering by Task
 ~~~~~~~~~~~~~~~~~
 
-You can easily select recordings associated with a specific experimental task. For example, to get all resting-state recordings:
+You can select recordings tied to a specific experimental task. For example, to get all resting-state recordings:
 
 .. code-block:: python
 
@@ -201,7 +201,7 @@ Once you have your :class:`~eegdash.api.EEGDashDataset` object, you can access i
         
         print(f"Loaded recording for subject: {recording.description['subject']}")
 
-This provides a powerful and flexible way to integrate ``eegdash`` into your data analysis pipelines, whether you are working with remote or local data. For contributor resources, see :doc:`Developer Notes </developer_notes>`.
+This is how ``eegdash`` plugs into a data analysis pipeline, whether the data is remote or local. For contributor resources, see :doc:`Developer Notes </developer_notes>`.
 
 
 API Configuration

--- a/examples/hpc/instructions.md
+++ b/examples/hpc/instructions.md
@@ -1,6 +1,6 @@
-# EEGDash on Expanse — Concise End-to-End Guide
+# EEGDash on Expanse: end-to-end guide
 
-This document captures the **working, minimal, reproducible workflow** for running EEGDash experiments on **SDSC Expanse**, from **local macOS development** to **CPU/GPU Slurm jobs**, using **Docker + Singularity (Apptainer)**.
+This page documents a minimal, reproducible workflow for running EEGDash experiments on SDSC Expanse. It covers local development on macOS, CPU and GPU Slurm jobs, and the Docker plus Singularity (Apptainer) toolchain that links them.
 
 ---
 
@@ -57,13 +57,13 @@ apptainer build eegdash-tutorial.sif docker-daemon://eegdash-tutorial:latest
 scp eegdash-tutorial.sif <username>@login.expanse.sdsc.edu:/path/to/destination/
 ```
 
-This approach can be faster than pulling from Docker Hub on Expanse, especially for large images or slow network connections.
+This is often faster than pulling from Docker Hub on Expanse, especially for large images or slow network connections.
 
 ---
 
-## Additional Notes
+## Tips
 
-- Ensure your Dockerfile includes all Python dependencies and system libraries required by EEGDash
-- Test your Docker image locally before pushing to Docker Hub
-- Allocate appropriate resources (CPU/GPU, memory, time) in your Slurm job scripts
-- Monitor your jobs using `squeue -u $USER` on Expanse
+- Make sure the Dockerfile pulls in every Python dependency and system library EEGDash needs.
+- Test the image locally before pushing to Docker Hub.
+- In your Slurm scripts, request realistic CPU/GPU, memory, and wall-time limits.
+- Track running jobs with `squeue -u $USER` on Expanse.


### PR DESCRIPTION
## Summary

Ran the `avoid-ai-writing` audit over the human-edited documentation and applied targeted rewrites. Prose-only; no code or behavior changes.

### What changed

- **`README.md`** — dropped the `leverage` / "To leverage recent and ongoing advancements..." boilerplate, the "efficient, scalable, flexible" + "batching, shuffling, parallel" triads, `seamless`, `facilitate`, `popular`, and the "In fact, ... This means that ..." filler around the braindecode paragraph. Tightened the data-source paragraph.
- **`CONTRIBUTING.md`** — removed the AI-chatbot opener ("Thank you for your interest in X! This document provides..."), replaced `Tests are comprehensive and passing` with something specific.
- **`CHANGELOG.md`** — replaced every `Robust` / `Comprehensive` in entries, swapped vague performance blurbs for the actual numbers, retired "Added comprehensive examples".
- **`docs/source/index.rst`** — replaced em dashes in the brand/hero title with colons.
- **`docs/source/user_guide.rst`** — removed `comprehensive overview`, `powerful filtering capabilities`, `powerful and flexible way`, `easily`, "It's important to understand...", "In general, you will use...", "Here's a basic example of how to...", `acts as`.
- **`docs/source/dataset_summary.rst`** — rewrote the shared `leverage` boilerplate opener. Renamed tab `Dataset Landscape` → `Dataset Map` (Tier-1 `landscape` metaphor).
- **`docs/source/dataset_summary/bubble.rst`** + **`treemap.rst`** — updated caption/heading to match.
- **`docs/source/install/install_source.rst`** — removed tautology ("test the new tools that have been tested"), dropped "Let's suppose that you want to...".
- **`examples/hpc/instructions.md`** — replaced em-dash + 5-bold-phrase + false-range opener, renamed generic `Additional Notes` header, rewrote the "-ing" bullet list.

### Profile used

`docs` (step-by-step instructions, code blocks, structured guides). Kept legitimate technical vocabulary (`ecosystem` in developer notes, bold action-verb mini-headers) and intentional marketing voice in the hero.

## Test plan

- [ ] `pre-commit run --files <changed files>` passes (verified locally: codespell + blacken-docs OK, ruff skipped because no Python files changed).
- [ ] Sphinx build renders the renamed tab and updated captions correctly.
- [ ] Visual check of the landing page hero titles (em dash → colon).