### PR TITLE
fix(sitemap): rewrite homepage entry to canonical bare-host URL

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2682,6 +2682,60 @@ def _copy_dataset_summary(app, exception) -> None:
         LOGGER.warning("Unable to copy dataset_summary.csv to _static: %s", exc)
 
 
+def _rewrite_sitemap_index(app, exception) -> None:
+    """Rewrite the homepage entry in ``sitemap.xml`` to the canonical
+    bare-host URL.
+
+    ``sphinx-sitemap`` emits ``https://eegdash.org/index.html`` for the
+    homepage because that's the page's filename. We set a
+    ``<link rel="canonical">`` override to ``https://eegdash.org/`` in
+    ``_inject_seo_context``, which creates a mismatch Ahrefs flags as
+    "Non-canonical page in sitemap". The two fixes must stay in sync —
+    so we patch the emitted sitemap here at ``build-finished`` rather
+    than fighting sphinx-sitemap's URL-construction logic.
+
+    Safe no-op on: missing sitemap, non-HTML builder, already-canonical
+    sitemap.
+    """
+    if exception is not None:
+        return
+    builder = getattr(app, "builder", None)
+    if builder is None or builder.name != "html":
+        return
+
+    sitemap_path = Path(app.outdir) / "sitemap.xml"
+    if not sitemap_path.exists():
+        return
+
+    try:
+        text = sitemap_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        LOGGER.warning("Unable to read %s: %s", sitemap_path, exc)
+        return
+
+    base = getattr(app.config, "html_baseurl", "") or ""
+    if not base.endswith("/"):
+        base += "/"
+    index_url = f"{base}index.html"
+    canonical = base
+
+    if index_url not in text:
+        return
+
+    updated = text.replace(f"<loc>{index_url}</loc>", f"<loc>{canonical}</loc>")
+    if updated == text:
+        return
+    try:
+        sitemap_path.write_text(updated, encoding="utf-8")
+        LOGGER.info(
+            "sitemap.xml: rewrote %s -> %s for canonical alignment",
+            index_url,
+            canonical,
+        )
+    except OSError as exc:
+        LOGGER.warning("Unable to write %s: %s", sitemap_path, exc)
+
+
 def _inject_counter_values(app, docname, source) -> None:
     if docname != "dataset_summary":
         return
@@ -3101,6 +3155,10 @@ def setup(app):
     app.connect("builder-inited", _assert_dataset_table_inlines_datatables)
     app.connect("builder-inited", _generate_dataset_docs)
     app.connect("build-finished", _copy_dataset_summary)
+    # Align sitemap homepage entry with the canonical emitted in
+    # `_inject_seo_context`. Must run after `sphinx-sitemap` writes
+    # the file; using `build-finished` is the safest hook for that.
+    app.connect("build-finished", _rewrite_sitemap_index)
     app.connect("source-read", _inject_counter_values)
     app.connect("html-page-context", _inject_seo_context)
 


### PR DESCRIPTION
## Summary

Fix the single "Non-canonical page in sitemap" Ahrefs flag.

## Root cause

`sphinx-sitemap` emits `<loc>https://eegdash.org/index.html</loc>` for the homepage because that's the page's filename on disk. We already override the homepage canonical to `https://eegdash.org/` (bare host) in `_inject_seo_context`, so the sitemap was self-inconsistent.

## Fix

New `_rewrite_sitemap_index` registered on the `build-finished` event. It reads the emitted `sitemap.xml`, swaps the single `<loc>` that points at `index.html` for the canonical form, and writes the file back. Safe no-op on missing sitemap, non-html builders, or an already-canonical sitemap.

## Verification

Locally (`make html-fast`):

```
sphinx-sitemap: sitemap.xml was generated for URL https://eegdash.org/ in …/_build/html/sitemap.xml
sitemap.xml: rewrote https://eegdash.org/index.html -> https://eegdash.org/ for canonical alignment
```

After: `<loc>https://eegdash.org/</loc>` appears once; `<loc>https://eegdash.org/index.html</loc>` zero times.

## Companion issue not addressed here

The 5XX page Ahrefs flagged — `api/dataset/eegdash.dataset.DS005284.html` — currently returns **200**. Likely a transient GH-Pages/Fastly hiccup during the previous crawl; not actionable from the repo. Will clear on the next Ahrefs crawl.