### PR TITLE
fix(sitemap): restore _rewrite_sitemap_index dropped during #318 rebase

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2700,6 +2700,65 @@ def _copy_dataset_summary(app, exception) -> None:
         LOGGER.warning("Unable to copy dataset_summary.csv to _static: %s", exc)
 
 
+def _rewrite_sitemap_index(app, exception) -> None:
+    """Rewrite the homepage entry in ``sitemap.xml`` to the canonical
+    bare-host URL.
+
+    ``sphinx-sitemap`` emits ``https://eegdash.org/index.html`` for the
+    homepage because that's the page's filename. We set a
+    ``<link rel="canonical">`` override to ``https://eegdash.org/`` in
+    ``_inject_seo_context``, which creates a mismatch Ahrefs flags as
+    "Non-canonical page in sitemap". The two fixes must stay in sync —
+    so we patch the emitted sitemap here at ``build-finished`` rather
+    than fighting sphinx-sitemap's URL-construction logic.
+
+    Originally shipped in #319 but silently dropped during the #318
+    rebase conflict resolution (``git checkout --theirs`` on conf.py
+    took the pre-#319 branch version). Re-adding here so the sitemap
+    emitted on each deploy stays canonical.
+
+    Safe no-op on: missing sitemap, non-HTML builder, already-canonical
+    sitemap.
+    """
+    if exception is not None:
+        return
+    builder = getattr(app, "builder", None)
+    if builder is None or builder.name != "html":
+        return
+
+    sitemap_path = Path(app.outdir) / "sitemap.xml"
+    if not sitemap_path.exists():
+        return
+
+    try:
+        text = sitemap_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        LOGGER.warning("Unable to read %s: %s", sitemap_path, exc)
+        return
+
+    base = getattr(app.config, "html_baseurl", "") or ""
+    if not base.endswith("/"):
+        base += "/"
+    index_url = f"{base}index.html"
+    canonical = base
+
+    if index_url not in text:
+        return
+
+    updated = text.replace(f"<loc>{index_url}</loc>", f"<loc>{canonical}</loc>")
+    if updated == text:
+        return
+    try:
+        sitemap_path.write_text(updated, encoding="utf-8")
+        LOGGER.info(
+            "sitemap.xml: rewrote %s -> %s for canonical alignment",
+            index_url,
+            canonical,
+        )
+    except OSError as exc:
+        LOGGER.warning("Unable to write %s: %s", sitemap_path, exc)
+
+
 def _inject_counter_values(app, docname, source) -> None:
     if docname != "dataset_summary":
         return
@@ -3302,6 +3361,10 @@ def setup(app):
     app.connect("builder-inited", _assert_dataset_table_inlines_datatables)
     app.connect("builder-inited", _generate_dataset_docs)
     app.connect("build-finished", _copy_dataset_summary)
+    # Align sitemap homepage entry with the canonical emitted in
+    # `_inject_seo_context`. Must run after `sphinx-sitemap` writes
+    # the file; using `build-finished` is the safest hook for that.
+    app.connect("build-finished", _rewrite_sitemap_index)
     app.connect("source-read", _inject_counter_values)
     app.connect("html-page-context", _inject_seo_context)
     # Must run last — see docstring on ``_cap_descriptions_hook``.


### PR DESCRIPTION
## Why

While resolving conflicts for #318 I ran `git checkout --theirs docs/source/conf.py` — which took the seo-batch-2 branch's full file. That branch predated #319, so the 58-line `_rewrite_sitemap_index` function and its `app.connect('build-finished', …)` call were silently wiped when #318 merged on top of #319.

Effect: the post-#318 deploy emitted `<loc>https://eegdash.org/index.html</loc>` again, which is exactly what #319 was supposed to fix.

## Fix

Re-add the function verbatim from commit `b55126260` (#319's merge) and re-register it on `build-finished` in `setup(app)`.

## Verification

```
$ make html-fast
...
$ python3 -c 'open("_build/html/sitemap.xml").read().count("<loc>https://eegdash.org/</loc>")'
1
$ python3 -c 'open("_build/html/sitemap.xml").read().count("<loc>https://eegdash.org/index.html</loc>")'
0
```

Pre-commit clean; no other changes in the diff.