### PR TITLE
fix(docs): align hero badge row by pinning each :width: to SVG natural size

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -2125,7 +2125,8 @@ html[data-theme="dark"] .hf-search-submit {
 }
 
 .hf-badges img {
-  height: 26px;
+  /* height + width are set inline per-badge in index.rst (SEO/CLS);
+     do not override here, or the browser will stretch SVGs off-ratio. */
   filter: saturate(0.9);
 }
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -119,53 +119,62 @@
 .. container:: hf-badges
 
    .. Badges come from shield/badge services (GitHub Actions, img.shields.io,
-      pepy.tech, codecov) whose SVGs have variable natural widths driven by
-      the text content. Hard-coding ``:width:`` + ``:height:`` to nice
-      round numbers distorts the aspect ratio — PSI flagged e.g. PyPI
-      versions 140x20 displayed vs 198x20 natural. Only ``:width:`` is
-      set; browsers compute height from the SVG's own aspect ratio, which
-      still reserves layout space thanks to the SVG's intrinsic
-      dimensions. No CLS regression.
+      pepy.tech, codecov) whose SVGs all share the same natural height (20)
+      but have different natural widths driven by their text content. Each
+      ``:width:`` below matches the exact natural width of its SVG; every
+      ``:height:`` is 20. Rendering at 1:1 scale avoids the aspect-ratio
+      distortion that PSI flagged (e.g. Python versions badge: natural
+      198x20), and every ``<img>`` ships with explicit width+height so the
+      browser reserves accurate layout space — no CLS regression, SEO
+      contract preserved.
 
    .. image:: https://github.com/eegdash/EEGDash/actions/workflows/tests.yml/badge.svg
       :alt: Test Status
       :target: https://github.com/eegdash/EEGDash/actions/workflows/tests.yml
-      :width: 90
+      :width: 104
+      :height: 20
 
    .. image:: https://github.com/eegdash/EEGDash/actions/workflows/doc.yaml/badge.svg
       :alt: Doc Status
       :target: https://github.com/eegdash/EEGDash/actions/workflows/doc.yaml
-      :width: 90
+      :width: 102
+      :height: 20
 
    .. image:: https://img.shields.io/pypi/v/eegdash?color=blue&style=flat-square
       :alt: PyPI
       :target: https://pypi.org/project/eegdash/
-      :width: 120
+      :width: 78
+      :height: 20
 
    .. image:: https://img.shields.io/pypi/pyversions/eegdash?style=flat-square
       :alt: Python Versions
       :target: https://pypi.org/project/eegdash/
-      :width: 140
+      :width: 198
+      :height: 20
 
    .. image:: https://pepy.tech/badge/eegdash
       :alt: Downloads
       :target: https://pepy.tech/project/eegdash
-      :width: 120
+      :width: 106
+      :height: 20
 
    .. image:: https://codecov.io/gh/eegdash/EEGDash/branch/main/graph/badge.svg
       :alt: Code Coverage
       :target: https://codecov.io/gh/eegdash/EEGDash
-      :width: 120
+      :width: 112
+      :height: 20
 
    .. image:: https://img.shields.io/pypi/l/eegdash?style=flat-square
       :alt: License
       :target: https://github.com/eegdash/EEGDash/blob/main/LICENSE
-      :width: 120
+      :width: 134
+      :height: 20
 
    .. image:: https://img.shields.io/github/stars/eegdash/eegdash?style=flat-square
       :alt: GitHub Stars
       :target: https://github.com/eegdash/EEGDash
-      :width: 120
+      :width: 60
+      :height: 20
 
 
 .. grid:: 1 2 4 4


### PR DESCRIPTION
## Summary

- The badge row on the docs homepage rendered at **visibly different heights** — PR #322 removed `:height: 20` from each image directive but left `.hf-badges img { height: 26px }` in `custom.css`, so the browser stretched/squished each SVG off-ratio (PyPI 1.54×, Stars 2×, Python 0.71×).
- This PR fixes it **per badge, with `width`+`height` still on every `<img>`** (SEO/CLS contract preserved):
  - `docs/source/index.rst`: set `:width:` to each SVG's **exact** natural width (104 / 102 / 78 / 198 / 106 / 112 / 134 / 60) and `:height: 20` on all eight.
  - `docs/source/_static/custom.css`: drop `height: 26px` from `.hf-badges img`; keep `filter: saturate(0.9)`.

## Test plan

- [x] `make html-noplot` rebuild succeeds.
- [x] `grep -oE 'style="width: [0-9]+px; height: [0-9]+px;"'` on rebuilt `_build/html/index.html` returns 8 lines, all with `height: 20px;` and widths `104/102/78/198/106/112/134/60`.
- [x] Runtime `getBoundingClientRect()` on every `.hf-badges img` yields identical `height = 20` and identical `top` baseline across all 8 badges; `boundingW == naturalW` per badge (no browser re-scaling, no aspect distortion).
- [x] Each `<img>` still advertises explicit width+height → reserved CLS layout box matches rendered box.