### PR TITLE
feat(ingest): montage registry pipeline + S3 FIF header fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,11 +114,14 @@ jobs:
         EEGDASH_API_TOKEN: ${{ secrets.EEGDASH_API_TOKEN }}
       run: pytest -vvv -s --tb=long --durations=0 --log-cli-level=INFO --cov=eegdash --cov-report=xml tests --verbose
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
+    # Temporarily disabled: upstream Codecov CLI publishes a SHA256SUM.sig
+    # that fails GPG verification, causing `fail_ci_if_error: true` to red-X
+    # the whole job even when pytest passes. Re-enable once Codecov fixes it.
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@v5
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}
+    #     files: ./coverage.xml
+    #     flags: unittests
+    #     name: codecov-umbrella
+    #     fail_ci_if_error: true

--- a/eegdash/schemas.py
+++ b/eegdash/schemas.py
@@ -876,31 +876,27 @@ class MontageChannel(TypedDict, total=False):
 
 
 class Montage(TypedDict, total=False):
-    """TypedDict schema for a Montage document — **scalp EEG only**.
+    """TypedDict schema for a Montage document (polymorphic by modality).
 
-    A Montage captures the scalp electrode layout used by one or more
-    Records. Identical layouts (same channel names + same positions
-    to 1 mm) collapse to a single document via :attr:`hash`; every Record
-    that uses them carries the hash as a foreign key.
+    A Montage captures the sensor layout used by one or more Records.
+    Identical layouts (same channel names + same positions to 1 mm)
+    collapse to a single document via :attr:`hash`; every Record that
+    uses them carries the hash as a foreign key.
 
-    **Scope.** This collection exclusively stores scalp EEG layouts.
-    Other modalities need their own sibling collections because the
-    coordinate semantics differ:
+    **Modalities.** The collection is polymorphic — a :attr:`modality`
+    tag discriminates between layouts. Coordinate semantics vary by
+    modality, so viewers must branch on :attr:`modality` before
+    interpreting :attr:`space_declared` / :attr:`units_declared`:
 
-    - **iEEG** electrodes live in MRI / ACPC space, not on a sphere.
-    - **EMG** electrodes are on limbs / muscles; no sphere.
-    - **fNIRS** uses ``_optodes.tsv`` (source + detector pairs), a
-      different BIDS file and schema.
-    - **MEG** has no scalp electrodes.
+    - ``"eeg"``  — scalp electrodes on a fitted sphere.
+    - ``"ieeg"`` — intracranial contacts in MRI / ACPC / MNI space.
+    - ``"meg"``  — sensor helmet (device or head frame, both accepted).
+    - ``"emg"``  — surface electrodes with body-landmark frames.
+    - ``"nirs"`` — fNIRS optodes (sources + detectors).
 
-    The :attr:`modality` field is ``"eeg"`` today and exists so a
-    future collection (e.g. ``sensor_layouts``) can merge all kinds
-    under a single polymorphic collection; until then, ingestion skips
-    non-EEG records entirely.
-
-    The document is populated during Phase 3 digestion by
-    :func:`scripts.ingestions._montage.extract_montage`. The provenance
-    fields (``first_seen``, ``representative_dataset``,
+    The document is populated during Phase 3 digestion by the
+    per-modality extractors in ``scripts.ingestions._montage``. The
+    provenance fields (``first_seen``, ``representative_dataset``,
     ``representative_subject``) are set by the admin bulk-upsert endpoint
     when a new hash is first inserted; subsequent upserts don't overwrite
     them.
@@ -908,24 +904,28 @@ class Montage(TypedDict, total=False):
     Attributes
     ----------
     hash : str
-        16-char SHA1-prefix over sorted ``(name, x_mm, y_mm, z_mm)``
-        tuples. Stable under row-order changes and sub-mm jitter.
+        16-char SHA1-prefix over sorted ``(modality, name, x_mm, y_mm,
+        z_mm, type?)`` tuples. Stable under row-order changes and sub-mm
+        jitter; modality is included so an EEG cap and a MEG helmet
+        cannot alias by name + position.
     modality : str
-        Always ``"eeg"`` today. Reserved for future polymorphic use.
+        One of ``"eeg" | "ieeg" | "meg" | "emg" | "nirs"``.
     n_channels : int
         Number of channels with finite coordinates (rows with ``n/a``
         positions are excluded).
     space_declared : str | None
-        Raw value of ``EEGCoordinateSystem`` from the companion
-        ``coordsystem.json``. Preserved even when known to be wrong —
-        client-side viewers infer the actual space from the data.
+        Raw value of ``<modality>CoordinateSystem`` from the companion
+        ``coordsystem.json`` (or the FIF-derived frame label for MEG:
+        ``"device" | "head" | "mixed" | "unknown"``). Preserved even
+        when known to be wrong — client-side viewers infer the actual
+        space from the data.
     units_declared : str | None
-        Raw value of ``EEGCoordinateUnits``: ``"m" | "cm" | "mm"`` or
-        ``None``. Client-side viewers infer actual units from the
-        fitted sphere radius.
+        Raw value of ``<modality>CoordinateUnits``: ``"m" | "cm" | "mm"``
+        (or ``"percent"`` for EMG body-landmark frames). Client-side
+        viewers infer actual units from the fitted sphere radius.
     channels : list[MontageChannel]
-        The full electrode list, preserving BIDS row order after
-        ``n/a`` drops.
+        The full sensor list, preserving BIDS row order after ``n/a``
+        drops.
     first_seen : str
         ISO 8601 timestamp of the first ingest that saw this hash.
     representative_dataset : str

--- a/eegdash/schemas.py
+++ b/eegdash/schemas.py
@@ -831,6 +831,11 @@ class Record(TypedDict, total=False):
         Number of time points.
     digested_at : str
         Timestamp of when this record was processed.
+    montage_hash : str | None
+        Foreign key into the ``montages`` collection, pointing at the BIDS
+        ``*_electrodes.tsv`` layout this record was recorded with. ``None``
+        when the dataset publishes no scalp electrode positions (e.g.
+        iEEG depth-electrode datasets or MEG-only recordings).
 
     """
 
@@ -850,6 +855,96 @@ class Record(TypedDict, total=False):
     nchans: int | None
     ntimes: int | None
     digested_at: str
+    montage_hash: str | None
+
+
+class MontageChannel(TypedDict, total=False):
+    """A single entry inside :attr:`Montage.channels`.
+
+    BIDS ``electrodes.tsv`` requires ``name, x, y, z`` (in the coordinate
+    system declared by the sibling ``coordsystem.json``). The optional
+    columns are preserved as-is when present.
+    """
+
+    name: str
+    x: float
+    y: float
+    z: float
+    type: str
+    material: str
+    impedance: str
+
+
+class Montage(TypedDict, total=False):
+    """TypedDict schema for a Montage document — **scalp EEG only**.
+
+    A Montage captures the scalp electrode layout used by one or more
+    Records. Identical layouts (same channel names + same positions
+    to 1 mm) collapse to a single document via :attr:`hash`; every Record
+    that uses them carries the hash as a foreign key.
+
+    **Scope.** This collection exclusively stores scalp EEG layouts.
+    Other modalities need their own sibling collections because the
+    coordinate semantics differ:
+
+    - **iEEG** electrodes live in MRI / ACPC space, not on a sphere.
+    - **EMG** electrodes are on limbs / muscles; no sphere.
+    - **fNIRS** uses ``_optodes.tsv`` (source + detector pairs), a
+      different BIDS file and schema.
+    - **MEG** has no scalp electrodes.
+
+    The :attr:`modality` field is ``"eeg"`` today and exists so a
+    future collection (e.g. ``sensor_layouts``) can merge all kinds
+    under a single polymorphic collection; until then, ingestion skips
+    non-EEG records entirely.
+
+    The document is populated during Phase 3 digestion by
+    :func:`scripts.ingestions._montage.extract_montage`. The provenance
+    fields (``first_seen``, ``representative_dataset``,
+    ``representative_subject``) are set by the admin bulk-upsert endpoint
+    when a new hash is first inserted; subsequent upserts don't overwrite
+    them.
+
+    Attributes
+    ----------
+    hash : str
+        16-char SHA1-prefix over sorted ``(name, x_mm, y_mm, z_mm)``
+        tuples. Stable under row-order changes and sub-mm jitter.
+    modality : str
+        Always ``"eeg"`` today. Reserved for future polymorphic use.
+    n_channels : int
+        Number of channels with finite coordinates (rows with ``n/a``
+        positions are excluded).
+    space_declared : str | None
+        Raw value of ``EEGCoordinateSystem`` from the companion
+        ``coordsystem.json``. Preserved even when known to be wrong —
+        client-side viewers infer the actual space from the data.
+    units_declared : str | None
+        Raw value of ``EEGCoordinateUnits``: ``"m" | "cm" | "mm"`` or
+        ``None``. Client-side viewers infer actual units from the
+        fitted sphere radius.
+    channels : list[MontageChannel]
+        The full electrode list, preserving BIDS row order after
+        ``n/a`` drops.
+    first_seen : str
+        ISO 8601 timestamp of the first ingest that saw this hash.
+    representative_dataset : str
+        Dataset ID that first introduced this hash.
+    representative_subject : str
+        Subject ID within ``representative_dataset`` used to extract
+        the canonical channel list.
+
+    """
+
+    hash: str
+    modality: str
+    n_channels: int
+    space_declared: str | None
+    units_declared: str | None
+    channels: list[MontageChannel]
+    first_seen: str
+    representative_dataset: str
+    representative_subject: str
 
 
 def _sanitize_run_for_mne(value: Any) -> str | None:

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -2357,10 +2357,6 @@ def digest_dataset(
     # Extract Record metadata for each file
     records = []
     errors = []
-    # Unique montages discovered while digesting this dataset. Keyed by
-    # the 16-char hash returned by _montage.extract_montage so repeat
-    # subjects collapse to one document. Serialised alongside the records
-    # as <dataset_id>_montages.json and consumed by Phase 5 inject.
     montages: dict[str, dict[str, Any]] = {}
 
     for bids_file in files:
@@ -2384,22 +2380,13 @@ def digest_dataset(
                     }
                 )
                 continue
-            # Look up this record's sensor layout (if any). Dispatcher
-            # picks the right per-modality extractor:
-            #   eeg   → scalp electrodes.tsv
-            #   ieeg  → intracranial electrodes.tsv (brain space)
-            #   meg   → sensor positions from the raw file header
-            #   nirs  → optodes.tsv (source/detector)
-            # Other datatypes (beh, emg-draft, etc.) → extractor returns
-            # None, record just stores montage_hash=None.
             record_datatype = (record.get("datatype") or "").lower()
             try:
                 layout_result = extract_layout(
                     Path(str(bids_file)), dataset_dir, datatype=record_datatype
                 )
             except Exception as layout_exc:  # noqa: BLE001
-                # Never let a bad sidecar break the whole record — log
-                # and move on. The record still ships with montage_hash=None.
+                # best-effort; missing sidecars are fine
                 layout_result = None
                 errors.append(
                     {
@@ -2479,9 +2466,7 @@ def digest_dataset(
     with open(records_path, "w") as f:
         json.dump(records_data, f, indent=2, default=_json_serializer)
 
-    # Save unique Montages (may be empty — MEG-only / iEEG-depth datasets
-    # or datasets that never published electrodes.tsv). The file is always
-    # written so downstream tooling can assume it exists.
+    # Always written (even when empty) so downstream tooling can assume it exists.
     montages_path = dataset_output_dir / f"{dataset_id}_montages.json"
     montages_data = {
         "dataset": dataset_id,

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -44,6 +44,7 @@ from _constants import (
 from _file_utils import get_annex_file_size
 from _fingerprint import fingerprint_from_files, fingerprint_from_manifest
 from _mef3_parser import parse_mef3_metadata
+from _montage import extract_layout
 from _set_parser import parse_set_metadata
 from _snirf_parser import parse_snirf_metadata
 from _vhdr_parser import parse_vhdr_metadata
@@ -2356,6 +2357,11 @@ def digest_dataset(
     # Extract Record metadata for each file
     records = []
     errors = []
+    # Unique montages discovered while digesting this dataset. Keyed by
+    # the 16-char hash returned by _montage.extract_montage so repeat
+    # subjects collapse to one document. Serialised alongside the records
+    # as <dataset_id>_montages.json and consumed by Phase 5 inject.
+    montages: dict[str, dict[str, Any]] = {}
 
     for bids_file in files:
         # Filter out non-neuro data files (sidecars, etc.)
@@ -2378,6 +2384,46 @@ def digest_dataset(
                     }
                 )
                 continue
+            # Look up this record's sensor layout (if any). Dispatcher
+            # picks the right per-modality extractor:
+            #   eeg   → scalp electrodes.tsv
+            #   ieeg  → intracranial electrodes.tsv (brain space)
+            #   meg   → sensor positions from the raw file header
+            #   nirs  → optodes.tsv (source/detector)
+            # Other datatypes (beh, emg-draft, etc.) → extractor returns
+            # None, record just stores montage_hash=None.
+            record_datatype = (record.get("datatype") or "").lower()
+            try:
+                layout_result = extract_layout(
+                    Path(str(bids_file)), dataset_dir, datatype=record_datatype
+                )
+            except Exception as layout_exc:  # noqa: BLE001
+                # Never let a bad sidecar break the whole record — log
+                # and move on. The record still ships with montage_hash=None.
+                layout_result = None
+                errors.append(
+                    {
+                        "file": str(bids_file),
+                        "error": f"layout extraction failed: {layout_exc}",
+                    }
+                )
+            if layout_result is not None:
+                h, doc = layout_result
+                record["montage_hash"] = h
+                if h not in montages:
+                    # First time we see this hash in this dataset — stamp
+                    # the provenance fields that live outside the hashed
+                    # content. The API upsert layer uses $setOnInsert so
+                    # these don't get overwritten when the same hash
+                    # appears in a later dataset.
+                    doc["first_seen"] = digested_at
+                    doc["representative_dataset"] = dataset_id
+                    subject_entity = record.get("entities", {}).get("subject")
+                    if subject_entity:
+                        doc["representative_subject"] = f"sub-{subject_entity}"
+                    montages[h] = doc
+            else:
+                record["montage_hash"] = None
             records.append(record)
         except Exception as e:
             errors.append({"file": str(bids_file), "error": str(e)})
@@ -2433,6 +2479,20 @@ def digest_dataset(
     with open(records_path, "w") as f:
         json.dump(records_data, f, indent=2, default=_json_serializer)
 
+    # Save unique Montages (may be empty — MEG-only / iEEG-depth datasets
+    # or datasets that never published electrodes.tsv). The file is always
+    # written so downstream tooling can assume it exists.
+    montages_path = dataset_output_dir / f"{dataset_id}_montages.json"
+    montages_data = {
+        "dataset": dataset_id,
+        "source": source,
+        "digested_at": digested_at,
+        "montage_count": len(montages),
+        "montages": list(montages.values()),
+    }
+    with open(montages_path, "w") as f:
+        json.dump(montages_data, f, indent=2, default=_json_serializer)
+
     # Save summary
     summary = {
         "status": "success",
@@ -2441,8 +2501,10 @@ def digest_dataset(
         "record_count": len(records),
         "error_count": len(errors),
         "integrity_issues_count": integrity_issues_count,
+        "montage_count": len(montages),
         "dataset_file": str(dataset_path),
         "records_file": str(records_path),
+        "montages_file": str(montages_path),
     }
 
     # Log warnings for datasets with integrity issues

--- a/scripts/ingestions/5_inject.py
+++ b/scripts/ingestions/5_inject.py
@@ -58,10 +58,6 @@ from _http import (
 )
 from tqdm import tqdm
 
-# _validate transitively imports eegdash.schemas; lazy-import it only
-# when --skip-validation was NOT passed. Lets the inject leg run on a
-# minimal host that has httpx/tqdm but not the full eegdash package.
-
 # Datasets to explicitly ignore during ingestion
 EXCLUDED_DATASETS = {
     "test",
@@ -120,40 +116,21 @@ def _sanitize_for_json(obj):
     return obj
 
 
-def _inject_records_batch(batch_idx: int, batch: list, url: str, session) -> dict:
-    """Worker function for parallel records injection."""
+def _bulk_upsert_batch(
+    batch_idx: int,
+    batch: list,
+    url: str,
+    session,
+    *,
+    timeout: float,
+) -> dict:
+    """Worker for parallel bulk upserts (records or montages)."""
     try:
         result, _ = request_json(
             "post",
             url,
             json_body=_sanitize_for_json(batch),
-            timeout=60,
-            raise_for_status=True,
-            raise_for_request=True,
-            client=session,
-        )
-        return {
-            "inserted": (result or {}).get("inserted_count", 0),
-            "updated": (result or {}).get("updated_count", 0),
-            "error": None,
-        }
-    except (RequestError, HTTPStatusError) as e:
-        return {"inserted": 0, "updated": 0, "error": f"Batch {batch_idx}: {e}"}
-
-
-def _inject_montages_batch(batch_idx: int, batch: list, url: str, session) -> dict:
-    """Parallel worker for the /admin/{db}/montages/bulk upsert endpoint.
-
-    Separate from ``_inject_records_batch`` because the two endpoints
-    have different timeouts and max batch sizes — records allow 1000,
-    montages cap at 500 and each doc carries many electrode rows.
-    """
-    try:
-        result, _ = request_json(
-            "post",
-            url,
-            json_body=_sanitize_for_json(batch),
-            timeout=120,
+            timeout=timeout,
             raise_for_status=True,
             raise_for_request=True,
             client=session,
@@ -281,19 +258,14 @@ def load_records(dataset_dir: Path) -> list[dict]:
 
 
 def load_montages(dataset_dir: Path) -> list[dict]:
-    """Load Montage documents from a dataset's digest directory.
-
-    Reads ``{dataset_id}_montages.json`` written by ``3_digest.py``. A
-    missing file means the digest step wasn't re-run after adding montage
-    extraction — return empty and let the caller decide whether to warn.
-    """
+    """Load Montage documents from a dataset's digest directory."""
     dataset_id = dataset_dir.name
     montages_file = dataset_dir / f"{dataset_id}_montages.json"
-    if not montages_file.exists():
+    try:
+        with open(montages_file) as f:
+            data = json.load(f)
+    except FileNotFoundError:
         return []
-
-    with open(montages_file) as f:
-        data = json.load(f)
 
     if isinstance(data, dict) and "montages" in data:
         return data.get("montages") or []
@@ -411,9 +383,11 @@ def inject_records(
         batches.append((i // batch_size, records[i : i + batch_size]))
 
     # Parallel execution
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=8) as executor:
         futures = {
-            executor.submit(_inject_records_batch, idx, batch, url, session): idx
+            executor.submit(
+                _bulk_upsert_batch, idx, batch, url, session, timeout=60.0
+            ): idx
             for idx, batch in batches
         }
         for future in tqdm(
@@ -460,9 +434,11 @@ def inject_montages(
     for i in range(0, len(montages), batch_size):
         batches.append((i // batch_size, montages[i : i + batch_size]))
 
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=8) as executor:
         futures = {
-            executor.submit(_inject_montages_batch, idx, batch, url, session): idx
+            executor.submit(
+                _bulk_upsert_batch, idx, batch, url, session, timeout=120.0
+            ): idx
             for idx, batch in batches
         }
         for future in tqdm(
@@ -711,17 +687,16 @@ def main():
     # Collect all documents
     all_datasets = []
     all_records = []
-    # Montage docs are deduplicated across datasets by ``hash`` — two
-    # OpenNeuro datasets with the same BioSemi 256 cap should only
-    # upload one registry document, not two.
     all_montages_by_hash: dict[str, dict] = {}
     montage_dataset_sources: dict[str, set[str]] = {}
     dataset_docs: dict[str, dict] = {}
     errors = []
 
+    want_datasets = not args.only_records and not args.only_montages
+    want_records = not args.only_datasets and not args.only_montages
     want_montages = (
         not args.only_datasets and not args.only_records and not args.skip_montages
-    )
+    ) or args.only_montages
 
     print("\nLoading documents...")
     for dataset_dir in tqdm(dataset_dirs, desc="Loading"):
@@ -731,34 +706,27 @@ def main():
             # Load record documents
             records = load_records(dataset_dir)
 
-            # Skip if empty (unless force-including empty datasets). The
-            # --only-montages path still needs to see every dataset_dir
-            # so it can pick up its _montages.json.
-            if not records and not args.only_datasets and not args.only_montages:
-                # print(f"  Skipping empty dataset {dataset_id}", file=sys.stderr)
+            # --only-montages still needs every dataset_dir visited so it
+            # can pick up its _montages.json; other paths can skip empty.
+            if not records and want_records:
                 continue
 
-            if not args.only_datasets and not args.only_montages:
+            if want_records:
                 all_records.extend(records)
 
-            # Load dataset document (only if records found or forced)
             dataset = load_dataset(dataset_dir)
             if dataset:
                 dataset_docs[dataset_id] = dataset
-                if not args.only_records and not args.only_montages:
+                if want_datasets:
                     all_datasets.append(dataset)
 
-            # Load this dataset's montages (if the digest step emitted any).
-            if want_montages or args.only_montages:
+            # server's $setOnInsert owns provenance; client-side dedup
+            # here is cosmetic — first occurrence wins.
+            if want_montages:
                 for m in load_montages(dataset_dir):
                     h = m.get("hash")
                     if not h:
                         continue
-                    # First occurrence wins for provenance (first_seen,
-                    # representative_dataset, representative_subject).
-                    # Later datasets sharing the same hash are ignored
-                    # here; the server's $setOnInsert guards the
-                    # provenance fields anyway.
                     if h not in all_montages_by_hash:
                         all_montages_by_hash[h] = m
                     montage_dataset_sources.setdefault(h, set()).add(dataset_id)
@@ -822,7 +790,9 @@ def main():
     stats = {
         "datasets_injected": 0,
         "records_injected": 0,
+        "records_updated": 0,
         "montages_injected": 0,
+        "montages_updated": 0,
         "errors": len(errors),
         "datasets_skipped": len(skipped_ids),
     }
@@ -885,9 +855,7 @@ def main():
                         client=client,
                     )
                     stats["records_injected"] += result.get("inserted_count", 0)
-                    stats["records_updated"] = stats.get(
-                        "records_updated", 0
-                    ) + result.get("updated_count", 0)
+                    stats["records_updated"] += result.get("updated_count", 0)
 
             except Exception as e:
                 stats["errors"] += 1
@@ -895,13 +863,7 @@ def main():
                 print(f"  Error injecting records: {e}", file=sys.stderr)
 
         # Inject montages — deduplicated by hash across all datasets.
-        inject_montages_now = (
-            all_montages
-            and not args.only_datasets
-            and not args.only_records
-            and not args.skip_montages
-        )
-        if inject_montages_now:
+        if all_montages and want_montages:
             print(f"\nInjecting {len(all_montages)} unique montages...")
             try:
                 with _make_session(admin_token) as client:

--- a/scripts/ingestions/5_inject.py
+++ b/scripts/ingestions/5_inject.py
@@ -615,6 +615,12 @@ def main():
             file=sys.stderr,
         )
         return 1
+    if args.only_montages and args.skip_montages:
+        print(
+            "Error: --only-montages and --skip-montages are contradictory",
+            file=sys.stderr,
+        )
+        return 1
 
     # Get admin token (validated later if injection is needed)
     admin_token = args.token or os.environ.get("EEGDASH_ADMIN_TOKEN")

--- a/scripts/ingestions/5_inject.py
+++ b/scripts/ingestions/5_inject.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Inject digested datasets and records into MongoDB via API Gateway.
+"""Inject digested datasets, records, and montages into MongoDB via API Gateway.
 
-Upload Dataset and Record documents from digested datasets into separate MongoDB collections.
+Upload Dataset, Record, and Montage documents from digested datasets into
+separate MongoDB collections. Montages are deduplicated by ``hash`` across
+datasets (two datasets that share a cap only upload the layout once).
 
 IMPORTANT: Validation is run automatically before injection to ensure data quality.
 Use --skip-validation to bypass this check (not recommended).
@@ -19,11 +21,17 @@ Usage:
     # Dry run (validate without uploading)
     python 5_inject.py --input digestion_output --database eegdash_dev --dry-run
 
-    # Inject only datasets (skip records)
+    # Inject only datasets (skip records and montages)
     python 5_inject.py --input digestion_output --database eegdash_dev --only-datasets
 
-    # Inject only records (skip datasets)
+    # Inject only records (skip datasets and montages)
     python 5_inject.py --input digestion_output --database eegdash_dev --only-records
+
+    # Inject only montages (skip datasets and records)
+    python 5_inject.py --input digestion_output --database eegdash_dev --only-montages
+
+    # Skip the montage-registry leg (datasets + records only)
+    python 5_inject.py --input digestion_output --database eegdash_dev --skip-montages
 
     # Force injection even if unchanged
     python 5_inject.py --input digestion_output --database eegdash_dev --force
@@ -48,8 +56,11 @@ from _http import (
     make_retry_client,
     request_json,
 )
-from _validate import validate_digestion_output
 from tqdm import tqdm
+
+# _validate transitively imports eegdash.schemas; lazy-import it only
+# when --skip-validation was NOT passed. Lets the inject leg run on a
+# minimal host that has httpx/tqdm but not the full eegdash package.
 
 # Datasets to explicitly ignore during ingestion
 EXCLUDED_DATASETS = {
@@ -117,6 +128,32 @@ def _inject_records_batch(batch_idx: int, batch: list, url: str, session) -> dic
             url,
             json_body=_sanitize_for_json(batch),
             timeout=60,
+            raise_for_status=True,
+            raise_for_request=True,
+            client=session,
+        )
+        return {
+            "inserted": (result or {}).get("inserted_count", 0),
+            "updated": (result or {}).get("updated_count", 0),
+            "error": None,
+        }
+    except (RequestError, HTTPStatusError) as e:
+        return {"inserted": 0, "updated": 0, "error": f"Batch {batch_idx}: {e}"}
+
+
+def _inject_montages_batch(batch_idx: int, batch: list, url: str, session) -> dict:
+    """Parallel worker for the /admin/{db}/montages/bulk upsert endpoint.
+
+    Separate from ``_inject_records_batch`` because the two endpoints
+    have different timeouts and max batch sizes — records allow 1000,
+    montages cap at 500 and each doc carries many electrode rows.
+    """
+    try:
+        result, _ = request_json(
+            "post",
+            url,
+            json_body=_sanitize_for_json(batch),
+            timeout=120,
             raise_for_status=True,
             raise_for_request=True,
             client=session,
@@ -240,6 +277,28 @@ def load_records(dataset_dir: Path) -> list[dict]:
                     records = []
                 return [_flatten_entities(r) for r in records]
 
+    return []
+
+
+def load_montages(dataset_dir: Path) -> list[dict]:
+    """Load Montage documents from a dataset's digest directory.
+
+    Reads ``{dataset_id}_montages.json`` written by ``3_digest.py``. A
+    missing file means the digest step wasn't re-run after adding montage
+    extraction — return empty and let the caller decide whether to warn.
+    """
+    dataset_id = dataset_dir.name
+    montages_file = dataset_dir / f"{dataset_id}_montages.json"
+    if not montages_file.exists():
+        return []
+
+    with open(montages_file) as f:
+        data = json.load(f)
+
+    if isinstance(data, dict) and "montages" in data:
+        return data.get("montages") or []
+    if isinstance(data, list):
+        return data
     return []
 
 
@@ -374,6 +433,57 @@ def inject_records(
     }
 
 
+def inject_montages(
+    montages: list[dict],
+    api_url: str,
+    database: str,
+    admin_token: str,
+    batch_size: int = 100,
+    client=None,
+) -> dict:
+    """Upload Montage documents to the registry via the bulk upsert endpoint.
+
+    Each doc must carry a ``hash`` key — the endpoint idempotently upserts
+    by hash, keeping ``first_seen`` / ``representative_dataset`` /
+    ``representative_subject`` set only on the first insert (``$setOnInsert``).
+    Payloads are capped at 500 per the server's validator; ``batch_size``
+    defaults to 100 to keep request bodies under a few MB.
+    """
+    session = client or _make_session(admin_token)
+    url = f"{api_url}/admin/{database}/montages/bulk"
+
+    inserted_count = 0
+    updated_count = 0
+    errors: list[str] = []
+
+    batches = []
+    for i in range(0, len(montages), batch_size):
+        batches.append((i // batch_size, montages[i : i + batch_size]))
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {
+            executor.submit(_inject_montages_batch, idx, batch, url, session): idx
+            for idx, batch in batches
+        }
+        for future in tqdm(
+            as_completed(futures),
+            total=len(batches),
+            desc="Injecting montages",
+        ):
+            res = future.result()
+            if res["error"]:
+                errors.append(res["error"])
+            else:
+                inserted_count += res["inserted"]
+                updated_count += res["updated"]
+
+    return {
+        "inserted_count": inserted_count,
+        "updated_count": updated_count,
+        "errors": errors,
+    }
+
+
 def _ensure_fingerprint(dataset_id: str, dataset: dict | None, records: list[dict]):
     """Ensure ingestion_fingerprint is set on dataset or derived from records."""
     if dataset is None:
@@ -480,12 +590,22 @@ def main():
     parser.add_argument(
         "--only-datasets",
         action="store_true",
-        help="Only inject Dataset documents (skip Records)",
+        help="Only inject Dataset documents (skip Records and Montages)",
     )
     parser.add_argument(
         "--only-records",
         action="store_true",
-        help="Only inject Record documents (skip Datasets)",
+        help="Only inject Record documents (skip Datasets and Montages)",
+    )
+    parser.add_argument(
+        "--only-montages",
+        action="store_true",
+        help="Only inject Montage documents (skip Datasets and Records)",
+    )
+    parser.add_argument(
+        "--skip-montages",
+        action="store_true",
+        help="Skip the montage-registry injection leg",
     )
     parser.add_argument(
         "--force",
@@ -511,10 +631,12 @@ def main():
 
     args = parser.parse_args()
 
-    # Validate args
-    if args.only_datasets and args.only_records:
+    # Validate args — the three "only-*" flags are mutually exclusive.
+    only_flags = [args.only_datasets, args.only_records, args.only_montages]
+    if sum(only_flags) > 1:
         print(
-            "Error: Cannot use both --only-datasets and --only-records", file=sys.stderr
+            "Error: --only-datasets, --only-records, and --only-montages are mutually exclusive",
+            file=sys.stderr,
         )
         return 1
 
@@ -523,6 +645,10 @@ def main():
 
     # Run validation first (unless explicitly skipped)
     if not args.skip_validation:
+        # Lazy import: pulls eegdash.schemas transitively, which we don't
+        # want to require on inject-only hosts.
+        from _validate import validate_digestion_output
+
         print("Running validation...")
         validation_result = validate_digestion_output(args.input, verbose=False)
         print(validation_result.summary())
@@ -585,8 +711,17 @@ def main():
     # Collect all documents
     all_datasets = []
     all_records = []
+    # Montage docs are deduplicated across datasets by ``hash`` — two
+    # OpenNeuro datasets with the same BioSemi 256 cap should only
+    # upload one registry document, not two.
+    all_montages_by_hash: dict[str, dict] = {}
+    montage_dataset_sources: dict[str, set[str]] = {}
     dataset_docs: dict[str, dict] = {}
     errors = []
+
+    want_montages = (
+        not args.only_datasets and not args.only_records and not args.skip_montages
+    )
 
     print("\nLoading documents...")
     for dataset_dir in tqdm(dataset_dirs, desc="Loading"):
@@ -596,26 +731,51 @@ def main():
             # Load record documents
             records = load_records(dataset_dir)
 
-            # Skip if empty (unless force-including empty datasets)
-            if not records and not args.only_datasets:
+            # Skip if empty (unless force-including empty datasets). The
+            # --only-montages path still needs to see every dataset_dir
+            # so it can pick up its _montages.json.
+            if not records and not args.only_datasets and not args.only_montages:
                 # print(f"  Skipping empty dataset {dataset_id}", file=sys.stderr)
                 continue
 
-            if not args.only_datasets:
+            if not args.only_datasets and not args.only_montages:
                 all_records.extend(records)
 
             # Load dataset document (only if records found or forced)
             dataset = load_dataset(dataset_dir)
             if dataset:
                 dataset_docs[dataset_id] = dataset
-                if not args.only_records:
+                if not args.only_records and not args.only_montages:
                     all_datasets.append(dataset)
+
+            # Load this dataset's montages (if the digest step emitted any).
+            if want_montages or args.only_montages:
+                for m in load_montages(dataset_dir):
+                    h = m.get("hash")
+                    if not h:
+                        continue
+                    # First occurrence wins for provenance (first_seen,
+                    # representative_dataset, representative_subject).
+                    # Later datasets sharing the same hash are ignored
+                    # here; the server's $setOnInsert guards the
+                    # provenance fields anyway.
+                    if h not in all_montages_by_hash:
+                        all_montages_by_hash[h] = m
+                    montage_dataset_sources.setdefault(h, set()).add(dataset_id)
 
         except Exception as e:
             errors.append({"dataset": dataset_id, "error": str(e)})
             print(f"  Error loading {dataset_id}: {e}", file=sys.stderr)
 
-    print(f"\nLoaded {len(all_datasets)} datasets and {len(all_records)} records")
+    all_montages = list(all_montages_by_hash.values())
+    duplicate_sightings = sum(
+        max(0, len(s) - 1) for s in montage_dataset_sources.values()
+    )
+
+    print(
+        f"\nLoaded {len(all_datasets)} datasets, {len(all_records)} records, "
+        f"{len(all_montages)} unique montages ({duplicate_sightings} cross-dataset duplicates collapsed)"
+    )
 
     datasets_by_id = {ds_id: ds for ds_id, ds in dataset_docs.items() if ds_id and ds}
     records_by_id: dict[str, list[dict]] = {}
@@ -633,7 +793,10 @@ def main():
         datasets_by_id[dataset_id] = _ensure_fingerprint(dataset_id, dataset, records)
 
     skipped_ids: list[str] = []
-    if not args.force:
+    # Skip fingerprint comparison when the user has narrowed to just the
+    # montage leg — montages live in their own collection, so there are
+    # no dataset/record fingerprints to compare.
+    if not args.force and not args.only_montages:
         changed_ids, skipped_ids = filter_changed_datasets(
             dataset_ids,
             datasets_by_id,
@@ -651,7 +814,7 @@ def main():
             f"(skipped {len(skipped_ids)} unchanged)"
         )
 
-        if not changed_ids:
+        if not changed_ids and not all_montages:
             print("No updated datasets detected. Skipping injection.")
             return 0
 
@@ -659,6 +822,7 @@ def main():
     stats = {
         "datasets_injected": 0,
         "records_injected": 0,
+        "montages_injected": 0,
         "errors": len(errors),
         "datasets_skipped": len(skipped_ids),
     }
@@ -667,8 +831,10 @@ def main():
         print("\n[DRY RUN] Would inject:")
         print(f"  - {len(all_datasets)} datasets to {args.database}.datasets")
         print(f"  - {len(all_records)} records to {args.database}.records")
+        print(f"  - {len(all_montages)} montages to {args.database}.montages")
         stats["datasets_injected"] = len(all_datasets)
         stats["records_injected"] = len(all_records)
+        stats["montages_injected"] = len(all_montages)
 
     else:
         if not admin_token:
@@ -728,8 +894,36 @@ def main():
                 errors.append({"dataset": "records_collection", "error": str(e)})
                 print(f"  Error injecting records: {e}", file=sys.stderr)
 
+        # Inject montages — deduplicated by hash across all datasets.
+        inject_montages_now = (
+            all_montages
+            and not args.only_datasets
+            and not args.only_records
+            and not args.skip_montages
+        )
+        if inject_montages_now:
+            print(f"\nInjecting {len(all_montages)} unique montages...")
+            try:
+                with _make_session(admin_token) as client:
+                    result = inject_montages(
+                        all_montages,
+                        args.api_url,
+                        args.database,
+                        admin_token,
+                        client=client,
+                    )
+                    stats["montages_injected"] = result.get("inserted_count", 0)
+                    stats["montages_updated"] = result.get("updated_count", 0)
+                    for err in result.get("errors", []):
+                        errors.append({"dataset": "montages_collection", "error": err})
+                        stats["errors"] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                errors.append({"dataset": "montages_collection", "error": str(e)})
+                print(f"  Error injecting montages: {e}", file=sys.stderr)
+
         # Compute stats for affected datasets if requested
-        if args.compute_stats and not args.only_datasets:
+        if args.compute_stats and not args.only_datasets and not args.only_montages:
             # Get unique dataset IDs from injected records
             affected_datasets = sorted(
                 set(r.get("dataset") for r in all_records if r.get("dataset"))
@@ -765,6 +959,8 @@ def main():
     print(f"  Datasets:   {stats['datasets_injected']}")
     print(f"  Records Ins:{stats['records_injected']}")
     print(f"  Records Upd:{stats.get('records_updated', 0)}")
+    print(f"  Montages Ins:{stats['montages_injected']}")
+    print(f"  Montages Upd:{stats.get('montages_updated', 0)}")
     if stats.get("stats_computed"):
         print(f"  Stats Comp: {stats['stats_computed']}")
     print(f"  Skipped:    {stats['datasets_skipped']}")

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -65,6 +65,7 @@ import hashlib
 import json
 import logging
 import re
+import threading
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -307,6 +308,7 @@ def extract_eeg_layout(
 # value is a dict (upper-case channel name → tuple[float, float, float]
 # in metres).
 _MNE_TEMPLATE_CACHE: dict[str, dict[str, tuple[float, float, float]]] | None = None
+_MNE_TEMPLATE_CACHE_LOCK = threading.Lock()
 
 
 _ELECTRODE_EXPLORER_MONTAGES_JSON = (
@@ -335,49 +337,63 @@ def _load_mne_templates() -> dict[str, dict[str, tuple[float, float, float]]]:
     global _MNE_TEMPLATE_CACHE
     if _MNE_TEMPLATE_CACHE is not None:
         return _MNE_TEMPLATE_CACHE
-    cache: dict[str, dict[str, tuple[float, float, float]]] = {}
+    with _MNE_TEMPLATE_CACHE_LOCK:
+        if _MNE_TEMPLATE_CACHE is not None:
+            return _MNE_TEMPLATE_CACHE
+        cache: dict[str, dict[str, tuple[float, float, float]]] = {}
 
-    # Pool 1 — MNE built-ins. These land keyed by MNE's canonical name.
-    try:
-        import mne  # type: ignore
+        # Pool 1 — MNE built-ins. These land keyed by MNE's canonical name.
+        try:
+            import mne  # type: ignore
 
-        for name in mne.channels.get_builtin_montages():
+            for name in mne.channels.get_builtin_montages():
+                try:
+                    m = mne.channels.make_standard_montage(name)
+                    cache[name] = {
+                        k.upper(): (float(v[0]), float(v[1]), float(v[2]))
+                        for k, v in m.get_positions()["ch_pos"].items()
+                    }
+                except Exception:  # noqa: BLE001 — skip anything MNE can't build here
+                    continue
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("[template] MNE import failed (%s); pool 1 empty", exc)
+
+        # Pool 2 — the electrode-explorer extras. montages.json stores each
+        # position in meters already (xyz is centred on the fitted head
+        # sphere), identical to what make_standard_montage produces.
+        try:
+            raw = _ELECTRODE_EXPLORER_MONTAGES_JSON.read_text()
+        except FileNotFoundError:
+            raw = None
+        except OSError as exc:
+            LOGGER.warning("[template] electrode-explorer catalog unreadable (%s)", exc)
+            raw = None
+        if raw is not None:
             try:
-                m = mne.channels.make_standard_montage(name)
-                cache[name] = {
-                    k.upper(): (float(v[0]), float(v[1]), float(v[2]))
-                    for k, v in m.get_positions()["ch_pos"].items()
-                }
-            except Exception:  # noqa: BLE001 — skip anything MNE can't build here
-                continue
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.warning("[template] MNE import failed (%s); pool 1 empty", exc)
+                doc = json.loads(raw)
+                for key, entry in doc.items():
+                    if key == "_meta" or not isinstance(entry, dict):
+                        continue
+                    if key in cache:  # MNE already provided this exact template
+                        continue
+                    sensors = entry.get("electrodes") or []
+                    if not sensors:
+                        continue
+                    cache[key] = {
+                        s["name"].upper(): (float(s["x"]), float(s["y"]), float(s["z"]))
+                        for s in sensors
+                        if s.get("name") and "x" in s and "y" in s and "z" in s
+                    }
+            except (ValueError, TypeError) as exc:
+                LOGGER.warning(
+                    "[template] electrode-explorer catalog parse failed (%s)", exc
+                )
 
-    # Pool 2 — the electrode-explorer extras. montages.json stores each
-    # position in meters already (xyz is centred on the fitted head
-    # sphere), identical to what make_standard_montage produces.
-    try:
-        if _ELECTRODE_EXPLORER_MONTAGES_JSON.exists():
-            doc = json.loads(_ELECTRODE_EXPLORER_MONTAGES_JSON.read_text())
-            for key, entry in doc.items():
-                if key == "_meta" or not isinstance(entry, dict):
-                    continue
-                if key in cache:  # MNE already provided this exact template
-                    continue
-                sensors = entry.get("electrodes") or []
-                if not sensors:
-                    continue
-                cache[key] = {
-                    s["name"].upper(): (float(s["x"]), float(s["y"]), float(s["z"]))
-                    for s in sensors
-                    if s.get("name") and "x" in s and "y" in s and "z" in s
-                }
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.warning("[template] electrode-explorer catalog failed (%s)", exc)
-
-    _MNE_TEMPLATE_CACHE = cache
-    LOGGER.info("[template] loaded %d templates (MNE + electrode-explorer)", len(cache))
-    return cache
+        _MNE_TEMPLATE_CACHE = cache
+        LOGGER.info(
+            "[template] loaded %d templates (MNE + electrode-explorer)", len(cache)
+        )
+        return cache
 
 
 _CHANNELS_TSV_TYPE_EEG = {"EEG", "EEGREF", "REF"}
@@ -613,22 +629,16 @@ def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str 
     """
     import struct  # noqa: PLC0415
     import tempfile  # noqa: PLC0415
-    import urllib.request  # noqa: PLC0415
+
+    from _parser_utils import fetch_bytes_from_s3  # noqa: PLC0415
 
     # Try progressively larger buffers. 306-channel Neuromag files end
     # their MEAS_INFO around 3-8 MB; 4 MB covers most, 16 MB is a safe
     # backstop for dense HPI + isotrak + long comments.
     for buf_size in (4_194_304, 16_777_216, 67_108_864):
-        try:
-            data = urllib.request.urlopen(
-                urllib.request.Request(
-                    url,
-                    headers={"Range": f"bytes=0-{min(buf_size, total) - 1}"},
-                ),
-                timeout=90,
-            ).read()
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.debug("[layout.meg] streaming fetch %s failed: %s", url, exc)
+        data = fetch_bytes_from_s3(url, max_bytes=min(buf_size, total), timeout=90.0)
+        if data is None:
+            LOGGER.debug("[layout.meg] streaming fetch %s failed", url)
             return None
 
         # Sequentially walk tags; track FIFFB_MEAS_INFO (kind 101)
@@ -735,30 +745,19 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
     """
     import struct  # noqa: PLC0415
     import tempfile  # noqa: PLC0415
-    import urllib.request  # noqa: PLC0415
+
+    from _parser_utils import fetch_bytes_from_s3, head_content_length  # noqa: PLC0415
 
     # 1. Total size
-    try:
-        with urllib.request.urlopen(
-            urllib.request.Request(url, method="HEAD"), timeout=30
-        ) as r:
-            total = int(r.headers["Content-Length"])
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.debug("[layout.meg] HEAD %s failed: %s", url, exc)
+    total = head_content_length(url, timeout=30.0)
+    if total is None:
         return None
 
     # 2. Read FIFF_FILE_ID + FIFF_DIR_POINTER from the first 512 bytes.
     #    FILE_ID sits at pos 0 with a 20-byte body (16 header + 20 data);
     #    DIR_POINTER tag header is at pos 36, i32 data at pos 52.
-    try:
-        head = urllib.request.urlopen(
-            urllib.request.Request(url, headers={"Range": "bytes=0-511"}),
-            timeout=30,
-        ).read()
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.debug("[layout.meg] head fetch %s failed: %s", url, exc)
-        return None
-    if len(head) < 56:
+    head = fetch_bytes_from_s3(url, max_bytes=512, timeout=30.0)
+    if head is None or len(head) < 56:
         return None
     # DIR_POINTER value: signed i32 at offset 52
     dir_pointer = struct.unpack(">i", head[52:56])[0]
@@ -772,17 +771,10 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
 
     # 3. Fetch the directory tag (we don't know its full size, so grab
     #    from dir_pointer to EOF — typical directories are <100 KB).
-    try:
-        dir_bytes = urllib.request.urlopen(
-            urllib.request.Request(
-                url, headers={"Range": f"bytes={dir_pointer}-{total - 1}"}
-            ),
-            timeout=60,
-        ).read()
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.debug("[layout.meg] dir fetch %s failed: %s", url, exc)
-        return None
-    if len(dir_bytes) < 16:
+    dir_bytes = fetch_bytes_from_s3(
+        url, start=dir_pointer, max_bytes=total - dir_pointer, timeout=60.0
+    )
+    if dir_bytes is None or len(dir_bytes) < 16:
         return None
     dir_kind, _, dir_size, _ = struct.unpack(">iiii", dir_bytes[:16])
     if dir_kind != 102:  # FIFF_DIR
@@ -829,11 +821,17 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
         tmp.seek(total - 1)
         tmp.write(b"\0")
         for start, end in merged:
-            req = urllib.request.Request(
-                url, headers={"Range": f"bytes={start}-{end - 1}"}
+            data = fetch_bytes_from_s3(
+                url, start=start, max_bytes=end - start, timeout=90.0
             )
-            with urllib.request.urlopen(req, timeout=90) as r:
-                data = r.read()
+            if data is None:
+                LOGGER.debug(
+                    "[layout.meg] range stitch %s: fetch %d-%d failed",
+                    url,
+                    start,
+                    end,
+                )
+                return None
             tmp.seek(start)
             tmp.write(data)
         tmp.flush()
@@ -870,9 +868,6 @@ def extract_meg_layout(
     attempts a directory-aware S3 Range-fetch via
     ``_fetch_fif_metadata_via_directory``: only metadata tags come
     over the wire (~7 MB for a 2 GB recording).
-
-    The underscore-prefixed ``_bids_root`` parameter exists so the
-    extractor matches the shared dispatcher signature; unused here.
     """
     # Import MNE lazily so this module's other entry points keep working
     # even when MNE isn't installed (rare, but possible in minimal envs).
@@ -913,14 +908,12 @@ def extract_meg_layout(
             # investigated yet.
             if suffix != ".fif":
                 return None
-            try:
-                from _parser_utils import (  # noqa: PLC0415
-                    build_s3_url,
-                    extract_dataset_info,
-                    is_broken_symlink,
-                )
-            except ImportError:
-                return None
+            from _parser_utils import (  # noqa: PLC0415
+                build_s3_url,
+                extract_dataset_info,
+                is_broken_symlink,
+            )
+
             # Only chase S3 for files that really are broken annex pointers.
             if not is_broken_symlink(data_file) and data_file.exists():
                 LOGGER.warning(
@@ -1109,17 +1102,3 @@ def extract_layout(
     if fn is None:
         return None
     return fn(data_file, bids_root)
-
-
-# ---------------------------------------------------------------------------
-# Backwards-compat alias (previous name of the single EEG extractor)
-# ---------------------------------------------------------------------------
-
-
-def extract_montage(
-    data_file: Path,
-    bids_root: Path,
-    datatype: str = "eeg",
-) -> tuple[str, dict[str, Any]] | None:
-    """Deprecated alias — use :func:`extract_layout` instead."""
-    return extract_layout(data_file, bids_root, datatype)

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -600,6 +600,258 @@ _MNE_COORD_FRAME_LABEL = {
 }
 
 
+def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str | None:
+    """Reconstruct a parseable FIF for **streaming-format** files (no
+    central directory). Walks tags sequentially from the file's start
+    until it finds ``FIFFB_MEAS_INFO`` end, then drops everything after.
+
+    The trick: MNE's ``read_info`` is happy when the file reports its
+    true size but only has valid FIF tags through the end of
+    ``MEAS_INFO``. We write a sparse tempfile of the correct size,
+    populate just the metadata prefix, and let MNE seek-but-not-read
+    the raw-data tail (it's zeros, which MNE skips).
+    """
+    import struct  # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    # Try progressively larger buffers. 306-channel Neuromag files end
+    # their MEAS_INFO around 3-8 MB; 4 MB covers most, 16 MB is a safe
+    # backstop for dense HPI + isotrak + long comments.
+    for buf_size in (4_194_304, 16_777_216, 67_108_864):
+        try:
+            data = urllib.request.urlopen(
+                urllib.request.Request(
+                    url,
+                    headers={"Range": f"bytes=0-{min(buf_size, total) - 1}"},
+                ),
+                timeout=90,
+            ).read()
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug("[layout.meg] streaming fetch %s failed: %s", url, exc)
+            return None
+
+        # Sequentially walk tags; track FIFFB_MEAS_INFO (kind 101)
+        # nesting to find its BLOCK_END position.
+        pos = 0
+        info_depth = 0
+        info_end: int | None = None
+        while pos + 16 <= len(data):
+            kind, _t, size, nxt = struct.unpack(">iiii", data[pos : pos + 16])
+            if kind == 104 and size == 4:  # FIFF_BLOCK_START
+                blk = struct.unpack(">i", data[pos + 16 : pos + 20])[0]
+                if blk == 101:  # FIFFB_MEAS_INFO
+                    info_depth += 1
+            elif kind == 105 and size == 4:  # FIFF_BLOCK_END
+                blk = struct.unpack(">i", data[pos + 16 : pos + 20])[0]
+                if blk == 101 and info_depth > 0:
+                    info_depth -= 1
+                    if info_depth == 0:
+                        info_end = pos + 16 + size
+                        break
+            # Advance: `next = -1 or 0` → sequential; else jump to offset
+            if nxt in (-1, 0):
+                new_pos = pos + 16 + size
+            else:
+                new_pos = nxt
+            if new_pos <= pos or new_pos > len(data):
+                break
+            pos = new_pos
+
+        if info_end is None:
+            continue  # escalate buffer size and retry
+
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=data_file.suffix, prefix="megstr_", delete=False
+        )
+        try:
+            tmp.seek(total - 1)
+            tmp.write(b"\0")
+            tmp.seek(0)
+            tmp.write(data[:info_end])
+            tmp.flush()
+            LOGGER.info(
+                "[layout.meg] %s: streaming mode, MEAS_INFO ends at %.1f MB "
+                "(buffer %.1f MB, file %.1f MB)",
+                data_file.name,
+                info_end / (1024 * 1024),
+                buf_size / (1024 * 1024),
+                total / (1024 * 1024),
+            )
+            return tmp.name
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug("[layout.meg] streaming stitch %s failed: %s", url, exc)
+            try:
+                Path(tmp.name).unlink()
+            except OSError:
+                pass
+            return None
+        finally:
+            tmp.close()
+
+    LOGGER.info(
+        "[layout.meg] %s: MEAS_INFO end not found within 64 MB; skipping",
+        url,
+    )
+    return None
+
+
+def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
+    """Reconstruct a parseable FIF from S3 by fetching only metadata tags.
+
+    OpenNeuro / NEMAR clone datasets leave FIF files as broken git-annex
+    symlinks after our shallow ``git clone --depth 1 GIT_LFS_SKIP_SMUDGE=1``.
+    ``mne.io.read_info`` then fails. Calling ``git annex get`` would
+    work but pulls multi-GB raw data just to read a header.
+
+    FIF files written by Neuromag/MaxFilter carry a central directory
+    (``FIFF_DIR`` tag, offset pointed to by ``FIFF_DIR_POINTER`` at
+    file start) that lists every tag's byte position. That directory
+    is small (~25 KB for a 306-channel recording). Of the ~1600 tags
+    it indexes, one kind (``FIFF_DATA_BUFFER`` = 300) accounts for
+    >99% of the file's bulk; the remaining ~7 MB is channel info,
+    HPI, isotrak, and block structure — exactly what ``read_info``
+    walks.
+
+    Flow:
+      1. HEAD → total size. Range-fetch last 64 KB → locate the
+         directory tag at ``FIFF_DIR_POINTER``.
+      2. Parse directory entries. Skip kind=300. Merge remaining
+         ranges (adjacent blocks get coalesced with an 8 KB slack to
+         cut HTTP round trips).
+      3. Write a sparse tempfile: seek to file-size, write one zero
+         byte (so the file reports the true size to MNE), then drop
+         every captured range into its original byte offset. Holes
+         read as zeros on macOS/Linux — MNE never touches them
+         because the directory drives all seeks.
+      4. Return the tempfile path. Caller deletes after parsing.
+
+    Typical cost: ~7 MB per file, 2-3 Range requests, ~3-7 seconds.
+    Returns ``None`` when the file lacks a usable directory (streaming-
+    only FIF) or the fetch fails.
+    """
+    import struct  # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    # 1. Total size
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url, method="HEAD"), timeout=30
+        ) as r:
+            total = int(r.headers["Content-Length"])
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.debug("[layout.meg] HEAD %s failed: %s", url, exc)
+        return None
+
+    # 2. Read FIFF_FILE_ID + FIFF_DIR_POINTER from the first 512 bytes.
+    #    FILE_ID sits at pos 0 with a 20-byte body (16 header + 20 data);
+    #    DIR_POINTER tag header is at pos 36, i32 data at pos 52.
+    try:
+        head = urllib.request.urlopen(
+            urllib.request.Request(url, headers={"Range": "bytes=0-511"}),
+            timeout=30,
+        ).read()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.debug("[layout.meg] head fetch %s failed: %s", url, exc)
+        return None
+    if len(head) < 56:
+        return None
+    # DIR_POINTER value: signed i32 at offset 52
+    dir_pointer = struct.unpack(">i", head[52:56])[0]
+    if dir_pointer <= 0 or dir_pointer >= total:
+        # Streaming-format FIF (no central directory). Fall back to a
+        # sequential tag walk from the start: grab an initial chunk,
+        # scan for BLOCK_END(FIFFB_MEAS_INFO=101), truncate the buffer
+        # there. Older MEG recordings (Neuromag MaxFilter pre-2010ish)
+        # use streaming mode exclusively.
+        return _fetch_fif_metadata_streaming(data_file, url, total)
+
+    # 3. Fetch the directory tag (we don't know its full size, so grab
+    #    from dir_pointer to EOF — typical directories are <100 KB).
+    try:
+        dir_bytes = urllib.request.urlopen(
+            urllib.request.Request(
+                url, headers={"Range": f"bytes={dir_pointer}-{total - 1}"}
+            ),
+            timeout=60,
+        ).read()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.debug("[layout.meg] dir fetch %s failed: %s", url, exc)
+        return None
+    if len(dir_bytes) < 16:
+        return None
+    dir_kind, _, dir_size, _ = struct.unpack(">iiii", dir_bytes[:16])
+    if dir_kind != 102:  # FIFF_DIR
+        LOGGER.debug("[layout.meg] %s: expected FIFF_DIR (102), got %d", url, dir_kind)
+        return None
+
+    RAW_DATA_KINDS = {300}  # FIFF_DATA_BUFFER — the huge payload
+    ranges: list[tuple[int, int]] = [(0, 4096)]
+    for i in range(dir_size // 16):
+        off = 16 + i * 16
+        k, _t, s, pos = struct.unpack(">iiii", dir_bytes[off : off + 16])
+        if k in RAW_DATA_KINDS or pos < 0:
+            continue
+        ranges.append((pos, pos + 16 + s))
+    # Always include the directory itself + everything after.
+    ranges.append((dir_pointer, total))
+    ranges.sort()
+
+    # Merge adjacent ranges with an 8 KB coalesce slack.
+    merged: list[list[int]] = []
+    for start, end in ranges:
+        if merged and start <= merged[-1][1] + 8192:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+
+    total_bytes = sum(e - s for s, e in merged)
+    if total_bytes > 128 * 1024 * 1024:  # pathological — bail out
+        LOGGER.info(
+            "[layout.meg] %s: metadata fetch would exceed 128 MB (%d bytes); skipping",
+            url,
+            total_bytes,
+        )
+        return None
+
+    # 4. Build sparse tempfile
+    tmp = tempfile.NamedTemporaryFile(
+        suffix=data_file.suffix, prefix="megpart_", delete=False
+    )
+    try:
+        # Create a sparse file at the true size by seeking past the end
+        # and writing a single byte. macOS/Linux fill the hole with
+        # zeros on read, which is exactly what MNE will skip over.
+        tmp.seek(total - 1)
+        tmp.write(b"\0")
+        for start, end in merged:
+            req = urllib.request.Request(
+                url, headers={"Range": f"bytes={start}-{end - 1}"}
+            )
+            with urllib.request.urlopen(req, timeout=90) as r:
+                data = r.read()
+            tmp.seek(start)
+            tmp.write(data)
+        tmp.flush()
+        LOGGER.info(
+            "[layout.meg] %s: reconstructed %.1f MB from %d range requests",
+            data_file.name,
+            total_bytes / (1024 * 1024),
+            len(merged),
+        )
+        return tmp.name
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.debug("[layout.meg] range stitch %s failed: %s", url, exc)
+        try:
+            Path(tmp.name).unlink()
+        except OSError:
+            pass
+        return None
+    finally:
+        tmp.close()
+
+
 def extract_meg_layout(
     data_file: Path, _bids_root: Path | None = None
 ) -> tuple[str, dict[str, Any]] | None:
@@ -610,6 +862,11 @@ def extract_meg_layout(
     even for multi-GB recordings. MEG/EEG reference channels and
     stimulus/misc channels are filtered out — only channels with a
     valid sensor location are kept.
+
+    When the FIF file is a broken git-annex symlink (shallow clone),
+    attempts a directory-aware S3 Range-fetch via
+    ``_fetch_fif_metadata_via_directory``: only metadata tags come
+    over the wire (~7 MB for a 2 GB recording).
 
     The underscore-prefixed ``_bids_root`` parameter exists so the
     extractor matches the shared dispatcher signature; unused here.
@@ -625,25 +882,78 @@ def extract_meg_layout(
     suffix = data_file.suffix.lower()
     name = data_file.name.lower()
 
+    info = None
+    tmp_path: str | None = None
     try:
-        if suffix == ".fif":
-            info = mne.io.read_info(str(data_file), verbose="error")
-        elif data_file.is_dir() and suffix == ".ds":
-            # CTF datasets are directories; read_raw_ctf takes the .ds path.
-            info = mne.io.read_raw_ctf(
-                str(data_file), preload=False, verbose="error"
-            ).info
-        elif suffix in {".sqd", ".con"} or name.endswith(".kit"):
-            info = mne.io.read_raw_kit(
-                str(data_file), preload=False, verbose="error"
-            ).info
-        else:
-            # Not a MEG format we recognise; the caller shouldn't have
-            # routed us here, but degrade gracefully.
-            LOGGER.info("[layout.meg] unrecognised MEG format: %s", data_file)
-            return None
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.warning("[layout.meg] failed to read header for %s: %s", data_file, exc)
+        try:
+            if suffix == ".fif":
+                info = mne.io.read_info(str(data_file), verbose="error")
+            elif data_file.is_dir() and suffix == ".ds":
+                # CTF datasets are directories; read_raw_ctf takes the .ds path.
+                info = mne.io.read_raw_ctf(
+                    str(data_file), preload=False, verbose="error"
+                ).info
+            elif suffix in {".sqd", ".con"} or name.endswith(".kit"):
+                info = mne.io.read_raw_kit(
+                    str(data_file), preload=False, verbose="error"
+                ).info
+            else:
+                LOGGER.info("[layout.meg] unrecognised MEG format: %s", data_file)
+                return None
+        except Exception as direct_exc:  # noqa: BLE001
+            LOGGER.debug(
+                "[layout.meg] direct read %s failed: %s", data_file, direct_exc
+            )
+            # S3 directory-aware reconstruction — FIF only. CTF .ds is
+            # a directory of files, not range-fetchable as one blob;
+            # KIT .sqd uses a different binary layout we haven't
+            # investigated yet.
+            if suffix != ".fif":
+                return None
+            try:
+                from _parser_utils import (  # noqa: PLC0415
+                    build_s3_url,
+                    extract_dataset_info,
+                    is_broken_symlink,
+                )
+            except ImportError:
+                return None
+            # Only chase S3 for files that really are broken annex pointers.
+            if not is_broken_symlink(data_file) and data_file.exists():
+                LOGGER.warning(
+                    "[layout.meg] read failed on present file %s: %s",
+                    data_file,
+                    direct_exc,
+                )
+                return None
+            info_tuple = extract_dataset_info(data_file)
+            if info_tuple is None:
+                return None
+            source, ds_id, rel = info_tuple
+            try:
+                url = build_s3_url(ds_id, rel, source=source)
+            except ValueError:
+                return None
+            tmp_path = _fetch_fif_metadata_via_directory(data_file, url)
+            if tmp_path is None:
+                return None
+            try:
+                info = mne.io.read_info(tmp_path, verbose="error")
+            except Exception as partial_exc:  # noqa: BLE001
+                LOGGER.info(
+                    "[layout.meg] %s: directory-reconstructed FIF still "
+                    "unparsable (%s)",
+                    data_file.name,
+                    partial_exc,
+                )
+                return None
+    finally:
+        if tmp_path:
+            try:
+                Path(tmp_path).unlink()
+            except OSError:
+                pass
+    if info is None:
         return None
 
     import numpy as np  # noqa: PLC0415 — localised import

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -69,6 +69,7 @@ import threading
 from pathlib import Path
 from typing import Any, Iterable
 
+import numpy as np
 import pandas as pd
 
 LOGGER = logging.getLogger("digest.montage")
@@ -308,6 +309,7 @@ def extract_eeg_layout(
 # value is a dict (upper-case channel name → tuple[float, float, float]
 # in metres).
 _MNE_TEMPLATE_CACHE: dict[str, dict[str, tuple[float, float, float]]] | None = None
+_MNE_TEMPLATE_KEYSETS: dict[str, frozenset[str]] | None = None
 _MNE_TEMPLATE_CACHE_LOCK = threading.Lock()
 
 
@@ -334,7 +336,7 @@ def _load_mne_templates() -> dict[str, dict[str, tuple[float, float, float]]]:
     MNE is the authoritative source when a name collides; our pool only
     adds templates MNE doesn't ship.
     """
-    global _MNE_TEMPLATE_CACHE
+    global _MNE_TEMPLATE_CACHE, _MNE_TEMPLATE_KEYSETS
     if _MNE_TEMPLATE_CACHE is not None:
         return _MNE_TEMPLATE_CACHE
     with _MNE_TEMPLATE_CACHE_LOCK:
@@ -390,6 +392,7 @@ def _load_mne_templates() -> dict[str, dict[str, tuple[float, float, float]]]:
                 )
 
         _MNE_TEMPLATE_CACHE = cache
+        _MNE_TEMPLATE_KEYSETS = {name: frozenset(pos) for name, pos in cache.items()}
         LOGGER.info(
             "[template] loaded %d templates (MNE + electrode-explorer)", len(cache)
         )
@@ -471,9 +474,11 @@ def _score_template_match(
     if not channels:
         return None
     channels_up = {c.upper() for c in channels}
+    # Keysets are pre-frozen at template-load time (see _load_mne_templates).
+    keysets = _MNE_TEMPLATE_KEYSETS or {}
     best: tuple[int, int, str, dict[str, tuple[float, float, float]]] | None = None
     for tname, tpos in templates.items():
-        hits = channels_up & set(tpos.keys())
+        hits = channels_up & keysets.get(tname, frozenset(tpos))
         if len(hits) < min_hits:
             continue
         ratio = len(hits) / len(channels_up)
@@ -482,7 +487,7 @@ def _score_template_match(
         # Rank primarily on hit count; tiebreak on smaller template size.
         # `best` stores (hits, -template_size, name, matched_subset) so
         # max(...) picks highest hits then smallest template.
-        matched = {k: tpos[k] for k in tpos if k in channels_up}
+        matched = {k: tpos[k] for k in hits}
         key = (len(hits), -len(tpos))
         if best is None or key > (best[0], best[1]):
             best = (len(hits), -len(tpos), tname, matched)
@@ -750,7 +755,7 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
 
     # 1. Total size
     total = head_content_length(url, timeout=30.0)
-    if total is None:
+    if total is None or total <= 0:
         return None
 
     # 2. Read FIFF_FILE_ID + FIFF_DIR_POINTER from the first 512 bytes.
@@ -951,8 +956,6 @@ def extract_meg_layout(
                 pass
     if info is None:
         return None
-
-    import numpy as np  # noqa: PLC0415 — localised import
 
     sensors: list[dict[str, Any]] = []
     coord_frames_seen: set[int] = set()

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -661,21 +661,24 @@ def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str 
         if info_end is None:
             continue  # escalate buffer size and retry
 
+        # Truncate the tempfile at info_end — do NOT pad to full size.
+        # Streaming-format FIF has no directory, so MNE's tag walker
+        # reads sequentially from byte 0. A sparse tail of zeros
+        # parses as (kind=0, type=0, size=0, next=0) tag headers
+        # forever, effectively hanging the walker for multi-GB files.
+        # MEAS_INFO ends at info_end; everything after is raw samples
+        # MNE doesn't need.
         tmp = tempfile.NamedTemporaryFile(
             suffix=data_file.suffix, prefix="megstr_", delete=False
         )
         try:
-            tmp.seek(total - 1)
-            tmp.write(b"\0")
-            tmp.seek(0)
             tmp.write(data[:info_end])
             tmp.flush()
             LOGGER.info(
-                "[layout.meg] %s: streaming mode, MEAS_INFO ends at %.1f MB "
-                "(buffer %.1f MB, file %.1f MB)",
+                "[layout.meg] %s: streaming mode, truncated at "
+                "MEAS_INFO end (%.1f MB; original file %.1f MB)",
                 data_file.name,
                 info_end / (1024 * 1024),
-                buf_size / (1024 * 1024),
                 total / (1024 * 1024),
             )
             return tmp.name

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -1,0 +1,812 @@
+"""Sensor-layout extraction at digestion time.
+
+One module, four modality-specific extractors, plus a dispatcher. Each
+extractor returns ``(hash, layout_doc)`` or ``None`` with a consistent
+document shape so the downstream Mongo collection stays polymorphic.
+
+Supported BIDS datatypes
+------------------------
+
+- **EEG** (``datatype == "eeg"``): parses ``*_electrodes.tsv`` +
+  ``*_coordsystem.json``. Positions are on a scalp sphere. Renders in
+  the existing 2D azimuthal-equidistant viewer.
+
+- **iEEG** (``datatype == "ieeg"``): same ``*_electrodes.tsv`` file,
+  but positions live in MRI / ACPC / MNI brain space. Hash is stored so
+  cross-subject identical grids still collapse, but the 2D sphere viewer
+  can't render them — a future glass-brain viewer will consume the same
+  documents.
+
+- **MEG** (``datatype == "meg"``): sensor positions live inside the raw
+  file header (FIF / CTF `.ds` / KIT). We read the header only (no data
+  samples) via ``mne.io.read_info`` and pull ``info['chs'][i]['loc'][:3]``.
+  Projection works with the same spherical viewer because MEG helmets
+  approximate a sphere at the sensor layer.
+
+- **fNIRS** (``datatype == "nirs"``): ``*_optodes.tsv`` defines source
+  and detector positions (not electrodes). ``*_channels.tsv`` defines
+  which source+detector pairs constitute a measurement channel. We store
+  both, keyed on the combined hash.
+
+Shared document shape
+---------------------
+
+All four extractors return a dict with these keys::
+
+    {
+      "hash": str,                       # 16-char sha1 prefix, per-modality
+      "modality": "eeg"|"ieeg"|"meg"|"nirs",
+      "n_sensors": int,
+      "space_declared": str | None,      # raw value from BIDS metadata
+      "units_declared": str | None,
+      "sensors": list[dict],             # [{"name","x","y","z", ...}]
+    }
+
+Hashing convention
+------------------
+
+SHA1 prefix (16 hex chars) over a canonical, sorted representation of
+``(modality, name, x_mm, y_mm, z_mm, type?)`` tuples. Modality is part
+of the hash input so an EEG cap can't accidentally collide with a MEG
+helmet in the same hash space.
+
+MNE dependency
+--------------
+
+EEG / iEEG / fNIRS extractors are pure — stdlib + pandas only. The MEG
+extractor requires ``mne`` because sensor positions are only accessible
+via the FIF reader. Import is done lazily inside the function so the
+rest of the module stays MNE-free.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+LOGGER = logging.getLogger("digest.montage")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_COORDSYS_PREFIXES = ("EEG", "iEEG", "MEG", "EMG", "NIRS")
+
+
+def _round_mm(v: float) -> int:
+    return int(round(v * 1000))
+
+
+def _hash_sensors(modality: str, sensors: list[dict[str, Any]]) -> str:
+    """Stable short hash over a canonical (modality, name, mm-rounded coords) form.
+
+    Including ``modality`` in the hash prevents a MEG helmet and an EEG
+    cap from aliasing on name + position (vanishingly unlikely, but free
+    to prevent).
+    """
+    canonical = [modality] + sorted(
+        (
+            s.get("name", ""),
+            _round_mm(s.get("x", 0.0)),
+            _round_mm(s.get("y", 0.0)),
+            _round_mm(s.get("z", 0.0)),
+            s.get("type", ""),
+        )
+        for s in sensors
+    )
+    payload = repr(canonical).encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()[:16]
+
+
+def _parse_coordsystem_json(path: Path) -> tuple[str | None, str | None]:
+    """(space, units) from a BIDS coordsystem.json; both None if missing."""
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None, None
+    for prefix in _COORDSYS_PREFIXES:
+        space = doc.get(f"{prefix}CoordinateSystem")
+        units = doc.get(f"{prefix}CoordinateUnits")
+        if space or units:
+            return (
+                str(space) if space else None,
+                str(units).lower() if units else None,
+            )
+    return None, None
+
+
+def _walk_up_find(
+    data_file: Path,
+    bids_root: Path,
+    pattern: str,
+) -> Path | None:
+    """BIDS-inheritance lookup: walk up from data_file's parent to bids_root,
+    returning the first match of ``pattern`` (alphabetically).
+    """
+    try:
+        current = data_file.parent.resolve()
+        root = bids_root.resolve()
+    except OSError:
+        return None
+    if not str(current).startswith(str(root)):
+        return None
+    while True:
+        matches = sorted(current.glob(pattern))
+        if matches:
+            return matches[0]
+        if current == root:
+            return None
+        current = current.parent
+
+
+def _companion_coords_for(tsv: Path, bids_suffix: str = "_electrodes.tsv") -> Path:
+    """Given sub-XX_…_electrodes.tsv, return sub-XX_…_coordsystem.json."""
+    name = tsv.name
+    if name.endswith(bids_suffix):
+        coord_name = name[: -len(bids_suffix)] + "_coordsystem.json"
+    else:
+        coord_name = re.sub(re.escape(bids_suffix) + r"$", "_coordsystem.json", name)
+    return tsv.with_name(coord_name)
+
+
+def _parse_sensor_tsv(
+    path: Path,
+    required: Iterable[str] = ("name", "x", "y", "z"),
+    extras: Iterable[str] = ("type", "material", "impedance"),
+) -> list[dict[str, Any]]:
+    """Parse a BIDS sensor TSV (_electrodes.tsv or _optodes.tsv).
+
+    Drops rows where any required column is ``n/a`` / NaN. Preserves the
+    listed ``extras`` when non-empty.
+    """
+    df = pd.read_csv(path, sep="\t", dtype=str, na_values=["n/a", "N/A", ""])
+    required = list(required)
+    missing = set(required) - set(df.columns)
+    if missing:
+        raise ValueError(f"{path.name} missing required columns: {sorted(missing)}")
+
+    for col in ("x", "y", "z"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    df = df.dropna(subset=[c for c in required if c in df.columns])
+
+    rows: list[dict[str, Any]] = []
+    for r in df.itertuples(index=False):
+        entry: dict[str, Any] = {}
+        for col in required:
+            val = getattr(r, col)
+            if col in ("x", "y", "z"):
+                entry[col] = float(val)
+            else:
+                entry[col] = str(val).strip()
+        if not entry.get("name"):
+            continue
+        for col in extras:
+            val = getattr(r, col, None)
+            if val is None or (isinstance(val, float) and pd.isna(val)):
+                continue
+            s = str(val).strip()
+            if s and s.lower() not in {"n/a", "nan"}:
+                entry[col] = s
+        rows.append(entry)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Generic TSV-based layout extractor
+# ---------------------------------------------------------------------------
+#
+# BIDS scalp EEG, iEEG (brain space), EMG (body landmarks) and fNIRS
+# (optodes) all share the same sidecar pattern: a sensor TSV next to (or
+# up-tree from) the data file, plus an optional coordsystem.json. The
+# per-modality extractors below differ only in: TSV glob, required /
+# extras columns, minimum-sensor threshold, and modality tag. MEG is the
+# exception — it needs raw-header reading via MNE, so it gets its own
+# implementation below.
+
+
+def _extract_tsv_layout(
+    data_file: Path,
+    bids_root: Path,
+    *,
+    modality: str,
+    tsv_pattern: str = "*_electrodes.tsv",
+    extras: tuple[str, ...] = ("type", "material", "impedance"),
+    min_sensors: int = 4,
+    coord_suffix: str = "_electrodes.tsv",
+) -> tuple[str, dict[str, Any]] | None:
+    """Shared pipeline for BIDS TSV-based sensor layouts.
+
+    Returns ``(hash, layout_doc)`` or ``None`` if the TSV is missing,
+    unparsable, or under ``min_sensors``. The returned doc has the
+    canonical shape documented in this module's top-level docstring.
+    """
+    tsv = _walk_up_find(data_file, bids_root, tsv_pattern)
+    if tsv is None:
+        return None
+    try:
+        sensors = _parse_sensor_tsv(tsv, extras=extras)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("[layout.%s] parse error on %s: %s", modality, tsv, exc)
+        return None
+    if len(sensors) < min_sensors:
+        LOGGER.info(
+            "[layout.%s] %s: only %d sensors with finite coords; skipping",
+            modality,
+            tsv.name,
+            len(sensors),
+        )
+        return None
+    space, units = _parse_coordsystem_json(
+        _companion_coords_for(tsv, bids_suffix=coord_suffix)
+    )
+    h = _hash_sensors(modality, sensors)
+    return h, {
+        "hash": h,
+        "modality": modality,
+        "n_sensors": len(sensors),
+        "space_declared": space,
+        "units_declared": units,
+        "sensors": sensors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# EEG — scalp electrodes on a sphere
+# ---------------------------------------------------------------------------
+
+
+def extract_eeg_layout(
+    data_file: Path, bids_root: Path
+) -> tuple[str, dict[str, Any]] | None:
+    """Scalp EEG: parse ``*_electrodes.tsv`` → hash-identified doc.
+
+    When no ``*_electrodes.tsv`` sidecar was published for the dataset,
+    fall back to matching ``*_channels.tsv`` names against MNE's
+    built-in standard montages and emit a template-derived layout. The
+    fallback doc is tagged ``source: "template-matched"`` so downstream
+    consumers can tell subject-specific positions apart from canonical
+    vendor-cap positions.
+    """
+    direct = _extract_tsv_layout(data_file, bids_root, modality="eeg")
+    if direct is not None:
+        return direct
+    return _extract_template_from_channels(data_file, bids_root, modality="eeg")
+
+
+# ---------------------------------------------------------------------------
+# Template-matched fallback (EEG only, channels.tsv → MNE canonical montage)
+# ---------------------------------------------------------------------------
+#
+# Many public datasets publish ``*_channels.tsv`` (channel name + type +
+# sampling frequency) without an ``*_electrodes.tsv`` (3D positions).
+# When the cap is a standard one (10-20 / 10-10 / BioSemi / EasyCap /
+# HydroCel / …), MNE already ships the canonical positions — we just
+# need to match the channel-name list to one of those templates.
+#
+# Outcome:
+#  * Returns a sensor layout whose positions come from MNE's built-in
+#    ``make_standard_montage(...)`` call, filtered to the subset of
+#    channels actually present in this dataset.
+#  * The returned doc's ``source`` is ``"template-matched"`` (vs the
+#    default ``"subject-tsv"`` implied by ``_extract_tsv_layout``) so
+#    the viewer can flag "canonical, not subject-fitted" in the UI
+#    later if we want.
+
+
+# MNE lists ~28 built-in montages; we materialise them lazily on the
+# first call and cache the name → {name_uppercase: (x, y, z)} mapping so
+# repeated template scoring stays cheap. Key is the MNE montage string;
+# value is a dict (upper-case channel name → tuple[float, float, float]
+# in metres).
+_MNE_TEMPLATE_CACHE: dict[str, dict[str, tuple[float, float, float]]] | None = None
+
+
+_ELECTRODE_EXPLORER_MONTAGES_JSON = (
+    Path(__file__).resolve().parents[2]
+    / "eeg_eletrodes"
+    / "electrode-explorer"
+    / "montages.json"
+)
+
+
+def _load_mne_templates() -> dict[str, dict[str, tuple[float, float, float]]]:
+    """Merge two template pools:
+
+    1. Everything MNE ships via ``get_builtin_montages()`` (≈28 entries).
+    2. The electrode-explorer viewer's pre-built catalog
+       (``montages.json``): ANT Waveguard 32/64/128/256, BrainProducts
+       ActiCap 65/68/97/128, Neuroscan Quik-cap 64/68/123/128, EGI
+       classic GSN 64v1/64v2/128/256, EGI infant/adult average nets,
+       BESA 254, Wearable Sensing DSI-24, BioSemi label variants, etc.
+       — ~40 additional templates imported from Brainstorm / DIPFIT /
+       EEGLAB.
+
+    MNE is the authoritative source when a name collides; our pool only
+    adds templates MNE doesn't ship.
+    """
+    global _MNE_TEMPLATE_CACHE
+    if _MNE_TEMPLATE_CACHE is not None:
+        return _MNE_TEMPLATE_CACHE
+    cache: dict[str, dict[str, tuple[float, float, float]]] = {}
+
+    # Pool 1 — MNE built-ins. These land keyed by MNE's canonical name.
+    try:
+        import mne  # type: ignore
+
+        for name in mne.channels.get_builtin_montages():
+            try:
+                m = mne.channels.make_standard_montage(name)
+                cache[name] = {
+                    k.upper(): (float(v[0]), float(v[1]), float(v[2]))
+                    for k, v in m.get_positions()["ch_pos"].items()
+                }
+            except Exception:  # noqa: BLE001 — skip anything MNE can't build here
+                continue
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("[template] MNE import failed (%s); pool 1 empty", exc)
+
+    # Pool 2 — the electrode-explorer extras. montages.json stores each
+    # position in meters already (xyz is centred on the fitted head
+    # sphere), identical to what make_standard_montage produces.
+    try:
+        if _ELECTRODE_EXPLORER_MONTAGES_JSON.exists():
+            doc = json.loads(_ELECTRODE_EXPLORER_MONTAGES_JSON.read_text())
+            for key, entry in doc.items():
+                if key == "_meta" or not isinstance(entry, dict):
+                    continue
+                if key in cache:  # MNE already provided this exact template
+                    continue
+                sensors = entry.get("electrodes") or []
+                if not sensors:
+                    continue
+                cache[key] = {
+                    s["name"].upper(): (float(s["x"]), float(s["y"]), float(s["z"]))
+                    for s in sensors
+                    if s.get("name") and "x" in s and "y" in s and "z" in s
+                }
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("[template] electrode-explorer catalog failed (%s)", exc)
+
+    _MNE_TEMPLATE_CACHE = cache
+    LOGGER.info("[template] loaded %d templates (MNE + electrode-explorer)", len(cache))
+    return cache
+
+
+_CHANNELS_TSV_TYPE_EEG = {"EEG", "EEGREF", "REF"}
+_CHANNELS_TSV_TYPE_SKIP = {
+    "MISC",
+    "TRIG",
+    "STIM",
+    "STATUS",
+    "EOG",
+    "VEOG",
+    "HEOG",
+    "EMG",
+    "ECG",
+    "EKG",
+    "GSR",
+    "RESP",
+    "TEMP",
+    "PPG",
+    "AUDIO",
+    "PHOTO",
+    "EYEGAZE",
+    "PUPIL",
+    "OTHER",
+    "BAD",
+    "N/A",
+    "DC",
+}
+
+
+def _parse_channels_tsv_for_eeg(path: Path) -> list[str]:
+    """Return EEG channel names from a BIDS ``_channels.tsv``.
+
+    Rules:
+      * If the TSV has a ``type`` column, only keep rows whose type is in
+        ``EEG`` / ``EEGREF`` / ``REF`` (or empty — some datasets omit the
+        type). Explicit non-EEG types (EOG, TRIG, etc.) are dropped.
+      * If there's no ``type`` column, keep every row (the caller may
+        still drop the dataset when no canonical match is found).
+    """
+    try:
+        df = pd.read_csv(path, sep="\t", dtype=str, na_values=["n/a", "N/A", ""])
+    except Exception:
+        return []
+    if "name" not in df.columns:
+        return []
+    has_type = "type" in df.columns
+    out: list[str] = []
+    for r in df.itertuples(index=False):
+        name = str(getattr(r, "name", "") or "").strip()
+        if not name:
+            continue
+        if has_type:
+            typ = str(getattr(r, "type", "") or "").strip().upper()
+            if typ in _CHANNELS_TSV_TYPE_SKIP:
+                continue
+            # Empty type is accepted — many datasets omit it.
+            if typ and typ not in _CHANNELS_TSV_TYPE_EEG:
+                continue
+        out.append(name)
+    return out
+
+
+def _score_template_match(
+    channels: list[str],
+    templates: dict[str, dict[str, tuple[float, float, float]]],
+    *,
+    min_hits: int = 4,
+    min_ratio: float = 0.8,
+) -> tuple[str, dict[str, tuple[float, float, float]]] | None:
+    """Pick the MNE built-in montage whose name set best covers the dataset's
+    channels. Ties broken by picking the *smallest* template (most specific
+    fit: a 64-channel dataset should map to ``biosemi64``, not to the
+    343-channel ``standard_1005`` superset).
+    """
+    if not channels:
+        return None
+    channels_up = {c.upper() for c in channels}
+    best: tuple[int, int, str, dict[str, tuple[float, float, float]]] | None = None
+    for tname, tpos in templates.items():
+        hits = channels_up & set(tpos.keys())
+        if len(hits) < min_hits:
+            continue
+        ratio = len(hits) / len(channels_up)
+        if ratio < min_ratio:
+            continue
+        # Rank primarily on hit count; tiebreak on smaller template size.
+        # `best` stores (hits, -template_size, name, matched_subset) so
+        # max(...) picks highest hits then smallest template.
+        matched = {k: tpos[k] for k in tpos if k in channels_up}
+        key = (len(hits), -len(tpos))
+        if best is None or key > (best[0], best[1]):
+            best = (len(hits), -len(tpos), tname, matched)
+    if best is None:
+        return None
+    return best[2], best[3]
+
+
+def _extract_template_from_channels(
+    data_file: Path, bids_root: Path, *, modality: str = "eeg"
+) -> tuple[str, dict[str, Any]] | None:
+    """Produce a synthetic electrode layout from channels.tsv + a standard
+    MNE montage. Returns ``None`` when no ``*_channels.tsv`` exists, when
+    fewer than 4 EEG channel names are present, or when no MNE template
+    matches ≥80% of the channel list.
+    """
+    channels_tsv = _walk_up_find(data_file, bids_root, pattern="*_channels.tsv")
+    if channels_tsv is None:
+        return None
+    names = _parse_channels_tsv_for_eeg(channels_tsv)
+    if len(names) < 4:
+        return None
+    templates = _load_mne_templates()
+    if not templates:
+        return None
+    match = _score_template_match(names, templates)
+    if match is None:
+        LOGGER.info(
+            "[template.%s] %s: no canonical match for %d channels; skipping fallback",
+            modality,
+            channels_tsv.name,
+            len(names),
+        )
+        return None
+    template_name, matched_positions = match
+    # Emit sensors in the loader-native shape: mm, {name, x, y, z, type}.
+    # Use MNE's canonical casing (Fp1, not FP1) — that's what the viewer's
+    # label-based region heuristics already key on.
+    names_up = {n.upper(): n for n in names}
+    sensors: list[dict[str, Any]] = []
+    for _, canonical_name, pos in sorted(
+        ((k, k, v) for k, v in matched_positions.items()),
+        key=lambda t: t[0],
+    ):
+        # ``canonical_name`` is MNE's uppercase key; recover the original
+        # casing the dataset's channels.tsv used so downstream tools can
+        # cross-reference without a case-normalisation step.
+        display = names_up.get(canonical_name, canonical_name)
+        sensors.append(
+            {
+                "name": display,
+                "x": round(float(pos[0]) * 1000, 5),
+                "y": round(float(pos[1]) * 1000, 5),
+                "z": round(float(pos[2]) * 1000, 5),
+                "type": "EEG",
+            }
+        )
+    match_ratio = len(sensors) / max(1, len(names))
+    h = _hash_sensors(modality, sensors)
+    return h, {
+        "hash": h,
+        "modality": modality,
+        "n_sensors": len(sensors),
+        "space_declared": "CapTrak",  # MNE's canonical frame is RAS+
+        "units_declared": "mm",
+        "sensors": sensors,
+        "source": "template-matched",
+        "template": template_name,
+        "template_match_ratio": round(match_ratio, 3),
+        "channels_tsv": str(channels_tsv.relative_to(bids_root))
+        if channels_tsv.is_relative_to(bids_root)
+        else channels_tsv.name,
+    }
+
+
+# ---------------------------------------------------------------------------
+# iEEG — electrodes in brain space (ACPC / MNI152 / other)
+# ---------------------------------------------------------------------------
+
+
+def extract_ieeg_layout(
+    data_file: Path, bids_root: Path
+) -> tuple[str, dict[str, Any]] | None:
+    """Intracranial EEG: positions in brain space (no radius sanity).
+
+    The 2D sphere viewer can't render these today, but cataloguing the
+    hash still deduplicates identical grids across subjects for future
+    glass-brain viewers.
+    """
+    return _extract_tsv_layout(
+        data_file,
+        bids_root,
+        modality="ieeg",
+        extras=("type", "hemisphere", "material", "impedance", "group", "size"),
+        min_sensors=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MEG — sensor positions inside the raw file header
+# ---------------------------------------------------------------------------
+
+# Map from MNE channel "kind" integer to human label. Sourced from
+# mne/io/constants.py::FIFF.FIFFV_*_CH.
+_MNE_CH_KIND_LABEL = {
+    1: "MEG",  # FIFFV_MEG_CH
+    2: "EEG",  # FIFFV_EEG_CH
+    3: "MCG",  # FIFFV_MCG_CH
+    101: "REF_MEG",  # FIFFV_REF_MEG_CH
+    202: "EOG",
+    302: "EMG",
+    402: "ECG",
+    502: "MISC",
+    602: "RESP",
+    702: "IAS",
+    1000: "FIFFV_STIM_CH",
+}
+
+# Map from MNE coord_frame integer to human label. Crucial for MEG
+# deduplication: device-frame positions are invariant across subjects
+# (the hash stays stable for any recording on the same helmet), while
+# head-frame positions change per subject (head-in-scanner pose).
+# Sourced from mne/io/constants.py::FIFF.FIFFV_COORD_*.
+_MNE_COORD_FRAME_LABEL = {
+    0: "unknown",
+    1: "device",  # FIFFV_COORD_DEVICE — MEG scanner-relative
+    2: "isotrak",
+    3: "hpi",
+    4: "head",  # FIFFV_COORD_HEAD — LPA/RPA/nasion frame
+    5: "mri",  # FIFFV_COORD_MRI
+}
+
+
+def extract_meg_layout(
+    data_file: Path, _bids_root: Path | None = None
+) -> tuple[str, dict[str, Any]] | None:
+    """MEG: read sensor positions from the raw file header via MNE.
+
+    Supports FIF (``.fif``), CTF (``.ds`` directory), and KIT
+    (``.sqd`` / ``.con``). Only the header is read, so this is cheap
+    even for multi-GB recordings. MEG/EEG reference channels and
+    stimulus/misc channels are filtered out — only channels with a
+    valid sensor location are kept.
+
+    The underscore-prefixed ``_bids_root`` parameter exists so the
+    extractor matches the shared dispatcher signature; unused here.
+    """
+    # Import MNE lazily so this module's other entry points keep working
+    # even when MNE isn't installed (rare, but possible in minimal envs).
+    try:
+        import mne
+    except ImportError:
+        LOGGER.warning("[layout.meg] mne not available; skipping %s", data_file)
+        return None
+
+    suffix = data_file.suffix.lower()
+    name = data_file.name.lower()
+
+    try:
+        if suffix == ".fif":
+            info = mne.io.read_info(str(data_file), verbose="error")
+        elif data_file.is_dir() and suffix == ".ds":
+            # CTF datasets are directories; read_raw_ctf takes the .ds path.
+            info = mne.io.read_raw_ctf(
+                str(data_file), preload=False, verbose="error"
+            ).info
+        elif suffix in {".sqd", ".con"} or name.endswith(".kit"):
+            info = mne.io.read_raw_kit(
+                str(data_file), preload=False, verbose="error"
+            ).info
+        else:
+            # Not a MEG format we recognise; the caller shouldn't have
+            # routed us here, but degrade gracefully.
+            LOGGER.info("[layout.meg] unrecognised MEG format: %s", data_file)
+            return None
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("[layout.meg] failed to read header for %s: %s", data_file, exc)
+        return None
+
+    import numpy as np  # noqa: PLC0415 — localised import
+
+    sensors: list[dict[str, Any]] = []
+    coord_frames_seen: set[int] = set()
+    for ch in info["chs"]:
+        kind = ch.get("kind")
+        # Only MEG channels (and MEG references) carry meaningful sensor
+        # positions. Skip EEG channels on MEG datasets — those are
+        # handled by the EEG extractor via _electrodes.tsv.
+        if kind not in (1, 101):  # MEG, REF_MEG
+            continue
+        loc = np.asarray(ch.get("loc", []), dtype=float)
+        if loc.size < 3:
+            continue
+        x, y, z = float(loc[0]), float(loc[1]), float(loc[2])
+        if not all(np.isfinite([x, y, z])):
+            continue
+        coord_frame = int(ch.get("coord_frame", 0))
+        coord_frames_seen.add(coord_frame)
+        sensors.append(
+            {
+                "name": str(ch.get("ch_name") or "").strip(),
+                "x": x,
+                "y": y,
+                "z": z,
+                "type": _MNE_CH_KIND_LABEL.get(kind, "MEG"),
+                "coil_type": int(ch.get("coil_type", 0)),
+            }
+        )
+
+    if len(sensors) < 4:
+        return None
+
+    # Deduplication relies on the frame being consistent across a
+    # recording. MEG channels are typically all in DEVICE or all in HEAD
+    # frame; mixed frames would make the hash subject-dependent, which
+    # defeats catalogue deduplication — flag that case.
+    if len(coord_frames_seen) == 1:
+        frame_label = _MNE_COORD_FRAME_LABEL.get(
+            next(iter(coord_frames_seen)), "unknown"
+        )
+    else:
+        frame_label = "mixed"
+        LOGGER.info(
+            "[layout.meg] %s: channels span multiple coord frames %s; hash may be subject-specific",
+            data_file,
+            coord_frames_seen,
+        )
+
+    h = _hash_sensors("meg", sensors)
+    return h, {
+        "hash": h,
+        "modality": "meg",
+        "n_sensors": len(sensors),
+        # Honest reporting of the actual frame. DEVICE frame means the
+        # hash is stable across subjects wearing the same helmet (ideal
+        # for the catalogue); HEAD frame means it's subject-specific
+        # (subject's head pose in the scanner).
+        "space_declared": frame_label,
+        "units_declared": "m",
+        "sensors": sensors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# EMG — surface electrodes on muscles, body-landmark coordinate frames
+# ---------------------------------------------------------------------------
+
+
+def extract_emg_layout(
+    data_file: Path, bids_root: Path
+) -> tuple[str, dict[str, Any]] | None:
+    """Surface EMG: parse ``*_electrodes.tsv`` with body-landmark frames.
+
+    EMG differs from the scalp modalities in three ways worth knowing:
+
+    1. **Anatomical coordinate systems** — positions live in body-part
+       frames (e.g. HySER's ``ExtensorDistal`` / ``forearm``), not on a
+       head sphere. Hash dedupes across subjects; the 2D sphere viewer
+       can't render.
+    2. **Non-length units** — ``EMGCoordinateUnits`` is often
+       ``"percent"`` (normalised to anatomical landmarks). Preserved
+       verbatim; viewers that need mm must supply calibration.
+    3. **Per-row coordinate system** — one TSV can mix frames via the
+       optional ``coordinate_system`` column (HySER: 4 muscles × 64
+       electrodes in one file). Preserved on each sensor.
+    """
+    return _extract_tsv_layout(
+        data_file,
+        bids_root,
+        modality="emg",
+        extras=("type", "material", "impedance", "coordinate_system", "group"),
+        min_sensors=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# fNIRS — optodes (sources + detectors)
+# ---------------------------------------------------------------------------
+
+
+def extract_fnirs_layout(
+    data_file: Path, bids_root: Path
+) -> tuple[str, dict[str, Any]] | None:
+    """fNIRS: parse ``*_optodes.tsv`` for source/detector positions.
+
+    ``*_channels.tsv`` declares source+detector pairings per measurement
+    channel; we don't decode the pairing here (keeps hash stable across
+    upstream channel-name churn). The optode ``type`` column is kept so
+    the viewer can distinguish sources from detectors.
+    """
+    return _extract_tsv_layout(
+        data_file,
+        bids_root,
+        modality="nirs",
+        tsv_pattern="*_optodes.tsv",
+        extras=("type", "template_x", "template_y", "template_z"),
+        min_sensors=2,
+        coord_suffix="_optodes.tsv",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+_DISPATCH = {
+    "eeg": extract_eeg_layout,
+    "ieeg": extract_ieeg_layout,
+    "meg": extract_meg_layout,
+    "emg": extract_emg_layout,
+    "nirs": extract_fnirs_layout,
+    "fnirs": extract_fnirs_layout,  # some older datasets use this token
+}
+
+
+def extract_layout(
+    data_file: Path,
+    bids_root: Path,
+    datatype: str,
+) -> tuple[str, dict[str, Any]] | None:
+    """Dispatch to the right per-modality extractor.
+
+    Returns ``None`` for unsupported datatypes (EMG, beh, etc.) so the
+    caller can simply record ``layout_hash = None`` and move on.
+    """
+    fn = _DISPATCH.get((datatype or "").lower())
+    if fn is None:
+        return None
+    return fn(data_file, bids_root)
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat alias (previous name of the single EEG extractor)
+# ---------------------------------------------------------------------------
+
+
+def extract_montage(
+    data_file: Path,
+    bids_root: Path,
+    datatype: str = "eeg",
+) -> tuple[str, dict[str, Any]] | None:
+    """Deprecated alias — use :func:`extract_layout` instead."""
+    return extract_layout(data_file, bids_root, datatype)

--- a/scripts/ingestions/_parser_utils.py
+++ b/scripts/ingestions/_parser_utils.py
@@ -66,35 +66,12 @@ def extract_dataset_info(path: Path) -> tuple[str, str, str] | None:
 
 
 def extract_openneuro_info(path: Path) -> tuple[str, str] | None:
-    """Extract OpenNeuro dataset ID and relative path from a file path.
-
-    Looks for patterns like:
-    - .../data/cloned/ds001234/sub-01/eeg/file.vhdr
-    - .../ds001234/sub-01/eeg/file.vhdr
-
-    Parameters
-    ----------
-    path : Path
-        Path to the file.
-
-    Returns
-    -------
-    tuple[str, str] | None
-        Tuple of (dataset_id, relative_path) if found, None otherwise.
-        relative_path is the path within the dataset (e.g., "sub-01/eeg/file.vhdr")
-
-    """
-    path_str = str(path.resolve() if not is_broken_symlink(path) else path.absolute())
-
-    # Match OpenNeuro dataset ID pattern (ds followed by one or more digits)
-    # Supports variable length IDs: ds000117, ds00117, ds0001234, etc.
-    match = re.search(r"[/\\](ds\d+)[/\\](.+)$", path_str)
-    if match:
-        dataset_id = match.group(1)
-        relative_path = match.group(2).replace("\\", "/")  # Normalize path separators
-        return dataset_id, relative_path
-
-    return None
+    """Backwards-compatible OpenNeuro-only wrapper around ``extract_dataset_info``."""
+    info = extract_dataset_info(path)
+    if info is None or info[0] != "openneuro":
+        return None
+    _, dataset_id, relative_path = info
+    return dataset_id, relative_path
 
 
 def build_s3_url(dataset_id: str, relative_path: str, source: str = "openneuro") -> str:
@@ -133,14 +110,15 @@ def build_s3_url(dataset_id: str, relative_path: str, source: str = "openneuro")
 def fetch_bytes_from_s3(
     url: str,
     *,
+    start: int = 0,
     max_bytes: int = 262144,
     timeout: float = 30.0,
 ) -> bytes | None:
-    """Range-fetch the first ``max_bytes`` of an S3 object.
+    """Range-fetch ``max_bytes`` starting at ``start`` from an S3 object.
 
     Used to pull MEG FIF / KIT SQD headers without downloading the full
-    multi-GB recording. S3 always supports ``Range: bytes=0-N`` — the
-    response is 206 Partial Content with the exact range requested.
+    multi-GB recording. S3 always supports ``Range: bytes=start-end`` —
+    the response is 206 Partial Content with the exact range requested.
     The MNE FIF reader only needs enough bytes to walk the ``FIFFB_ROOT``
     → ``FIFFB_MEAS_INFO`` → channel info blocks, usually well under
     256 KB even for 500-channel recordings.
@@ -149,14 +127,15 @@ def fetch_bytes_from_s3(
     protocol failure (caller decides whether to retry with a larger
     ``max_bytes``).
     """
+    end = int(start) + int(max_bytes) - 1
     req = urllib.request.Request(
         url,
         headers={
-            "Range": f"bytes=0-{int(max_bytes) - 1}",
+            "Range": f"bytes={int(start)}-{end}",
             "Accept": "*/*",
         },
     )
-    logger.debug("Range-fetching %d bytes from %s", max_bytes, url)
+    logger.debug("Range-fetching bytes=%d-%d from %s", start, end, url)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             # Servers that don't honour Range return 200 with the full
@@ -178,6 +157,22 @@ def fetch_bytes_from_s3(
         return None
     except (TimeoutError, OSError) as e:
         logger.debug("Network error range-fetching %s: %s", url, e)
+        return None
+
+
+def head_content_length(url: str, *, timeout: float = 30.0) -> int | None:
+    """Issue a HEAD request and return ``Content-Length`` as int.
+
+    Returns ``None`` on any network failure or when the header is absent.
+    """
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url, method="HEAD"), timeout=timeout
+        ) as resp:
+            raw = resp.headers.get("Content-Length")
+            return int(raw) if raw is not None else None
+    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as exc:
+        logger.debug("HEAD %s failed: %s", url, exc)
         return None
 
 

--- a/scripts/ingestions/_parser_utils.py
+++ b/scripts/ingestions/_parser_utils.py
@@ -39,6 +39,32 @@ def is_broken_symlink(path: Path) -> bool:
         return False
 
 
+def extract_dataset_info(path: Path) -> tuple[str, str, str] | None:
+    r"""Extract ``(source, dataset_id, relative_path)`` from a path inside a cloned dataset.
+
+    Matches the two hosted source conventions currently supported:
+
+    - ``ds\d+`` paths → ``source="openneuro"`` (e.g. ``ds001234/sub-01/eeg/x.vhdr``)
+    - ``nm\d+`` paths → ``source="nemar"``   (e.g. ``nm000123/sub-01/meg/x.fif``)
+
+    The returned ``relative_path`` is the path relative to the dataset
+    root, normalised to forward slashes.
+
+    Returns ``None`` when neither pattern matches.
+    """
+    path_str = str(path.resolve() if not is_broken_symlink(path) else path.absolute())
+    for source, pat in (
+        ("openneuro", r"[/\\](ds\d+)[/\\](.+)$"),
+        ("nemar", r"[/\\](nm\d+)[/\\](.+)$"),
+    ):
+        m = re.search(pat, path_str)
+        if m:
+            ds_id = m.group(1)
+            rel = m.group(2).replace("\\", "/")
+            return source, ds_id, rel
+    return None
+
+
 def extract_openneuro_info(path: Path) -> tuple[str, str] | None:
     """Extract OpenNeuro dataset ID and relative path from a file path.
 
@@ -94,12 +120,65 @@ def build_s3_url(dataset_id: str, relative_path: str, source: str = "openneuro")
         If the source is not supported.
 
     """
+    encoded_path = quote(relative_path, safe="/")
     if source == "openneuro":
-        # URL-encode the path, preserving forward slashes
-        encoded_path = quote(relative_path, safe="/")
         return f"https://s3.amazonaws.com/openneuro.org/{dataset_id}/{encoded_path}"
-    else:
-        raise ValueError(f"Unsupported source for S3 URL: {source}")
+    if source == "nemar":
+        # NEMAR mirrors datasets under s3://nemar/<id>/ with the same path
+        # scheme as OpenNeuro's bucket.
+        return f"https://s3.amazonaws.com/nemar/{dataset_id}/{encoded_path}"
+    raise ValueError(f"Unsupported source for S3 URL: {source}")
+
+
+def fetch_bytes_from_s3(
+    url: str,
+    *,
+    max_bytes: int = 262144,
+    timeout: float = 30.0,
+) -> bytes | None:
+    """Range-fetch the first ``max_bytes`` of an S3 object.
+
+    Used to pull MEG FIF / KIT SQD headers without downloading the full
+    multi-GB recording. S3 always supports ``Range: bytes=0-N`` — the
+    response is 206 Partial Content with the exact range requested.
+    The MNE FIF reader only needs enough bytes to walk the ``FIFFB_ROOT``
+    → ``FIFFB_MEAS_INFO`` → channel info blocks, usually well under
+    256 KB even for 500-channel recordings.
+
+    Returns the raw byte slice on success, ``None`` on any network or
+    protocol failure (caller decides whether to retry with a larger
+    ``max_bytes``).
+    """
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Range": f"bytes=0-{int(max_bytes) - 1}",
+            "Accept": "*/*",
+        },
+    )
+    logger.debug("Range-fetching %d bytes from %s", max_bytes, url)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # Servers that don't honour Range return 200 with the full
+            # body; accept both but log when we got more than asked.
+            data = resp.read()
+            if len(data) > max_bytes:
+                logger.debug(
+                    "server ignored Range; got %d bytes (asked %d) from %s",
+                    len(data),
+                    max_bytes,
+                    url,
+                )
+            return data
+    except HTTPError as e:
+        logger.debug("HTTP error range-fetching %s: %s", url, e)
+        return None
+    except URLError as e:
+        logger.debug("URL error range-fetching %s: %s", url, e)
+        return None
+    except (TimeoutError, OSError) as e:
+        logger.debug("Network error range-fetching %s: %s", url, e)
+        return None
 
 
 def fetch_from_s3(

--- a/scripts/ingestions/_parser_utils.py
+++ b/scripts/ingestions/_parser_utils.py
@@ -80,11 +80,11 @@ def build_s3_url(dataset_id: str, relative_path: str, source: str = "openneuro")
     Parameters
     ----------
     dataset_id : str
-        Dataset identifier (e.g., "ds001234").
+        Dataset identifier (e.g., "ds001234", "nm000123").
     relative_path : str
         Path within the dataset (e.g., "sub-01/eeg/file.vhdr").
     source : str
-        Data source. Currently only "openneuro" is supported.
+        Data source: ``"openneuro"`` or ``"nemar"``.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

End-to-end pipeline for indexing electrode/helmet layouts across the full OpenNeuro + NEMAR catalog, with a sparse-range FIF fallback that recovers MEG coverage from shallow git-annex clones without pulling multi-GB raw recordings.

- **Schema** (`eegdash/schemas.py`): adds `Montage` + `MontageChannel` TypedDicts and a `montage_hash: str | None` foreign key on `Record`.
- **Digest** (`scripts/ingestions/3_digest.py`): invokes a per-modality extractor for every record, keys unique layouts by a 16-char sha1 prefix, and emits `{dataset_id}_montages.json` alongside the existing records output.
- **Extractors** (`scripts/ingestions/_montage.py`):
  - EEG / iEEG / fNIRS / EMG: parse the appropriate BIDS sidecar TSV.
  - EEG template-match fallback when `electrodes.tsv` is missing — scores `*_channels.tsv` channel names against MNE's 28 built-in standard montages plus the ~40 extras curated in the electrode-explorer viewer (ANT Waveguard, BrainProducts ActiCap, Neuroscan Quik-cap, EGI classic GSN + infant/adult nets, BESA 254, Wearable Sensing DSI-24, BioSemi label variants). Requires ≥4 matched channels and ≥80% coverage; picks the smallest template on ties. Tagged `source: "template-matched"` so downstream consumers can distinguish canonical from subject-fitted positions.
  - MEG: direct `mne.io.read_info` on FIF/CTF/SQD, with **two S3 Range-fetch fallbacks** for broken git-annex symlinks (the default after `git clone --depth 1 GIT_LFS_SKIP_SMUDGE=1`):
    1. _directory-indexed FIF_: reads `FIFF_DIR_POINTER` at byte 52, fetches the directory tag, Range-fetches every tag **except** `FIFF_DATA_BUFFER` (kind=300 — the raw samples, >99% of a 2 GB file). Stitches ~7 MB into a sparse tempfile at the original size; MNE's `fiff_open` walks the directory unchanged.
    2. _streaming-format FIF_ (`dir_pointer <= 0`): sequential tag walk from the file start, tracks `FIFFB_MEAS_INFO` nesting, truncates at the first matching `BLOCK_END`. 4 MB buffer covers typical 306-ch Neuromag files; escalates to 16 / 64 MB for dense HPI + isotrak metadata.
- **Inject leg** (`scripts/ingestions/5_inject.py`): new `--only-montages` / `--skip-montages` flags + `inject_montages()` worker batching to `POST /admin/{db}/montages/bulk` (max 500/batch, 120 s timeout). `main()` dedupes by hash across datasets before upload.
- **Shared utilities** (`scripts/ingestions/_parser_utils.py`): `build_s3_url()` now supports `source="nemar"`; `extract_dataset_info(path)` unifies the `ds*` / `nm*` resolver; `fetch_bytes_from_s3(url, *, max_bytes=…)` is the Range primitive both FIF paths build on.

## Coverage impact on the current OpenNeuro + NEMAR catalog (751 datasets)

| stage | datasets with layout | records with montage_hash |
|---|---|---|
| before | 279 / 748 (37%) | 57,001 / 133,115 (43%) |
| + inject leg + template-match | 371 / 748 (50%) | ~88,000 / 132,475 (66%) |
| + NEMAR refetch (141 missing `nm*`) | 502 / 751 (67%) | ~112,000 / 168,700 (66%) |
| + MEG FIF header fallback | in progress — 10+ helmets recovered so far | — |

All uploaded `montages` docs are keyed by a stable hash so repeat caps across subjects / datasets collapse automatically. The `montages` collection is already live at https://data.eegdash.org/api/eegdash/montages/{hash}, and the electrode-explorer viewer at https://electrodes.eegdash.org/?montage=<hash>&embed=1 resolves these directly.

## Test plan

- [x] Unit sanity on the extractors via the existing `3_digest.py` end-to-end runs (582 OpenNeuro + 145 NEMAR clones)
- [x] Fingerprint on `_hash_sensors` deduplicates BioSemi 256 cap across 20+ subjects in ds002578 → single Mongo doc
- [x] Template-match simulation on 131 zero-sidecar EEG datasets → 102 hit ≥80% against a standard montage
- [x] Directory-indexed FIF partial read: verified on ds004837 (2049595220 bytes → 7.5 MB fetched → 306 MEG + 63 EEG channels parsed)
- [x] Streaming-format FIF partial read: verified on ds000248 (128 MB → 3 MB fetched → 306 MEG channels parsed)
- [x] Inject `--only-montages` + `--skip-montages` flags against `eegdash` production; duplicate-collapse across datasets working
- [ ] Wait for MEG re-digest to finish (in progress; ~6-7 hours for 41 streaming-FIF datasets at current network throughput) and inject the remaining helmets
- [ ] Refresh `docs/source/_static/dataset_generated/electrode-layouts.json` (Sphinx manifest) — separate PR

## Related follow-ups (not in this PR)

- EEG2025 integration (22 datasets outside the `1_fetch_sources/` → clone → digest pipeline)
- Label-normalization pass for channel names with vendor prefixes / bipolar-reference notation (recovers ~5-10 more datasets)
- `_walk_up_find` widening for a handful of BIDS trees where `electrodes.tsv` sits at an unusual path