### PR TITLE
feat(docs): embed electrode-explorer iframe on each dataset page

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ APIDIR := $(SOURCEDIR)/api
 # Shared cache so tutorials find data regardless of sphinx CWD (mirrors CI's EEGDASH_CACHE_DIR).
 EEGDASH_CACHE_DIR ?= $(CURDIR)/../.eegdash_cache
 
-.PHONY: help clean apidoc llms-txt html html-noplot html-fast markdown
+.PHONY: help clean apidoc llms-txt html html-noplot html-fast markdown electrode-layouts
 
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -27,21 +27,28 @@ apidoc:
 llms-txt: apidoc
 	@python generate_llms_txt.py --source "$(SOURCEDIR)" --output "$(SOURCEDIR)/_extra/llms.txt"
 
+# Refresh source/_static/dataset_generated/electrode-layouts.json from the
+# live montage registry. The script fails soft (zero layouts → warning
+# but exit 0) so a transient API outage never blocks the docs build;
+# the --keep-existing-on-empty flag preserves the last good manifest.
+electrode-layouts:
+	@python build_electrode_layouts.py --keep-existing-on-empty || true
 
 # Standard build runs examples
-html: apidoc llms-txt
+html: apidoc llms-txt electrode-layouts
 	EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) python prepare_summary_tables.py --target $(BUILDDIR)
 	EEGDASH_DATASET_REGISTRY_FROM_API=1 EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@python fingerprint_assets.py --html-dir "$(BUILDDIR)/html"
 
 # Fast build: do NOT execute examples (sphinx-gallery)
-html-noplot: apidoc llms-txt
+html-noplot: apidoc llms-txt electrode-layouts
 	@EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) python prepare_summary_tables.py --target $(BUILDDIR)
 	@EEGDASH_DATASET_REGISTRY_FROM_API=1 EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" \
 		$(SPHINXOPTS) -D sphinx_gallery_conf.plot_gallery=0 $(O)
 	@python fingerprint_assets.py --html-dir "$(BUILDDIR)/html"
 
-# Very fast build: limit datasets to 5
+# Very fast build: limit datasets to 5 (skip the electrode registry leg;
+# manifest stays at whatever was last generated)
 html-fast: apidoc llms-txt
 	@EEGDASH_DOC_LIMIT=5 EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) python prepare_summary_tables.py --target $(BUILDDIR)
 	@EEGDASH_DOC_LIMIT=5 EEGDASH_DATASET_REGISTRY_FROM_API=1 EEGDASH_CACHE_DIR=$(EEGDASH_CACHE_DIR) $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" \

--- a/docs/build_electrode_layouts.py
+++ b/docs/build_electrode_layouts.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate ``source/_static/dataset_generated/electrode-layouts.json``.
+
+Sphinx reads this manifest from ``conf.py::_format_electrodes_section``
+to decide which montage (if any) to embed on each dataset page. Until
+now the file was hand-curated; this script replaces that with a
+registry-backed build step.
+
+Pipeline:
+
+1. ``GET /api/{db}/datasets/summary`` → list of all dataset_ids.
+2. ``GET /api/{db}/datasets/{id}/montages`` → distinct montages used by
+   that dataset, sorted by descending subject count. We pick the top
+   one (the cap most subjects actually wore).
+3. Emit a layout entry ``{label, n_channels, modality, montage_id}``
+   keyed by dataset_id. ``montage_id`` is the 16-char registry hash;
+   the viewer resolves it via ``?montage=<hash>`` once the client-side
+   fetcher lands (PLAN step 3).
+
+Datasets with no scalp electrodes (MEG-only, depth iEEG, etc.) are
+omitted — the Sphinx section falls back to a "no layout indexed"
+placeholder in that case.
+
+Run from the repo's ``docs/`` directory::
+
+    python build_electrode_layouts.py
+    python build_electrode_layouts.py --database eegdash_dev
+    python build_electrode_layouts.py --api-url http://localhost:8000
+
+Idempotent: if the registry hasn't changed, the JSON output is
+byte-identical so Sphinx's cache stays warm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parent
+OUTPUT_PATH = (
+    DOCS_DIR / "source" / "_static" / "dataset_generated" / "electrode-layouts.json"
+)
+
+DEFAULT_API_URL = "https://data.eegdash.org/api"
+DEFAULT_DATABASE = "eegdash"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_WORKERS = 8
+
+# Pretty modality label for the iframe caption. Kept small — the viewer
+# itself already shows the full metadata.
+_MODALITY_LABEL = {
+    "eeg": "EEG",
+    "ieeg": "iEEG",
+    "meg": "MEG",
+    "nirs": "fNIRS",
+    "emg": "EMG",
+}
+
+
+def _get_json(url: str, timeout: float = DEFAULT_TIMEOUT) -> dict | None:
+    """Return the JSON body of a GET, or ``None`` on any fetch error.
+
+    We swallow transport errors instead of raising because the docs
+    build should never break on an unreachable or partially-populated
+    registry — missing datasets just get the Sphinx placeholder.
+    """
+    req = urllib.request.Request(
+        url, headers={"Accept": "application/json", "User-Agent": "eegdash-docs/1.0"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+def _fetch_dataset_ids(api_url: str, database: str, limit: int) -> list[str]:
+    url = f"{api_url}/{database}/datasets/summary?limit={limit}"
+    body = _get_json(url)
+    if not body or not body.get("success"):
+        return []
+    ids = [
+        str(ds.get("dataset_id") or "").strip().lower()
+        for ds in body.get("data", [])
+        if ds.get("dataset_id")
+    ]
+    return sorted(set(filter(None, ids)))
+
+
+def _fetch_top_montage(api_url: str, database: str, dataset_id: str) -> dict | None:
+    """Return the most-used montage doc for this dataset, or ``None``."""
+    url = f"{api_url}/{database}/datasets/{dataset_id}/montages"
+    body = _get_json(url)
+    if not body:
+        return None
+    rows = body.get("data") or []
+    if not rows:
+        return None
+    # Endpoint already sorts by subject_count DESC; be defensive anyway.
+    return max(rows, key=lambda r: int(r.get("subject_count") or 0))
+
+
+def _layout_entry(montage: dict) -> dict:
+    """Map a registry montage doc → the shape conf.py reads."""
+    modality = str(montage.get("modality") or "").strip().lower()
+    n = int(montage.get("n_sensors") or 0)
+    mod_label = _MODALITY_LABEL.get(modality, modality.upper() or "Sensors")
+    label = f"{mod_label} · {n} sensors" if n else mod_label
+    return {
+        "label": label,
+        "n_channels": n,
+        "modality": modality or None,
+        "montage_id": str(montage.get("hash") or "").strip(),
+    }
+
+
+def _fetch_dataset_montage(
+    api_url: str, database: str, dataset_id: str
+) -> tuple[str, dict | None]:
+    """Worker for the thread pool — thin wrapper around ``_fetch_top_montage``."""
+    return dataset_id, _fetch_top_montage(api_url, database, dataset_id)
+
+
+def build_manifest(
+    api_url: str,
+    database: str,
+    limit: int = 1000,
+    workers: int = DEFAULT_WORKERS,
+) -> dict:
+    dataset_ids = _fetch_dataset_ids(api_url, database, limit)
+    if not dataset_ids:
+        print(
+            f"[electrode-layouts] no datasets returned from {api_url}/{database}/datasets/summary",
+            file=sys.stderr,
+        )
+
+    layouts: dict[str, dict] = {}
+    skipped: list[str] = []
+
+    if dataset_ids:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(_fetch_dataset_montage, api_url, database, ds_id): ds_id
+                for ds_id in dataset_ids
+            }
+            for i, fut in enumerate(as_completed(futures), 1):
+                ds_id, mont = fut.result()
+                if mont is None or not mont.get("hash"):
+                    skipped.append(ds_id)
+                    continue
+                layouts[ds_id] = _layout_entry(mont)
+                if i % 50 == 0:
+                    print(
+                        f"  [{i}/{len(dataset_ids)}] {len(layouts)} mapped, {len(skipped)} empty",
+                        file=sys.stderr,
+                    )
+
+    return {
+        "_comment": (
+            "Auto-generated by docs/build_electrode_layouts.py from the "
+            "eegdash montage registry. Do not edit by hand."
+        ),
+        "_schema_version": 2,
+        "_generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "_source": {
+            "api_url": api_url,
+            "database": database,
+            "datasets_scanned": len(dataset_ids),
+            "layouts_mapped": len(layouts),
+            "datasets_without_montage": len(skipped),
+        },
+        "layouts": dict(sorted(layouts.items())),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--api-url", default=DEFAULT_API_URL)
+    p.add_argument("--database", default=DEFAULT_DATABASE)
+    p.add_argument("--limit", type=int, default=1000)
+    p.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=OUTPUT_PATH,
+        help=f"Output path (default: {OUTPUT_PATH})",
+    )
+    p.add_argument(
+        "--keep-existing-on-empty",
+        action="store_true",
+        help=(
+            "If the registry returns zero layouts, leave the existing "
+            "manifest file intact. Useful in CI to avoid wiping a "
+            "previously-good build when the API is briefly unreachable."
+        ),
+    )
+    args = p.parse_args()
+
+    manifest = build_manifest(
+        api_url=args.api_url,
+        database=args.database,
+        limit=args.limit,
+        workers=args.workers,
+    )
+
+    n_layouts = len(manifest["layouts"])
+    if n_layouts == 0 and args.keep_existing_on_empty and args.output.exists():
+        print(
+            f"[electrode-layouts] zero layouts from registry; keeping existing {args.output}",
+            file=sys.stderr,
+        )
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n")
+    print(
+        f"Wrote {args.output} — "
+        f"{n_layouts} layouts "
+        f"({manifest['_source']['datasets_without_montage']} datasets without a registered montage)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/source/_static/js/lazy-embed.js
+++ b/docs/source/_static/js/lazy-embed.js
@@ -1,0 +1,34 @@
+/* ============================================================
+   lazy-embed.js — swap `data-src` → `src` on first <details>
+   expansion so embedded iframes only load when users ask.
+
+   Each dataset page may carry a <details class="electrode-explorer">
+   block with a single child <iframe data-src="…"> and no src yet.
+   Expanding the <details> triggers the first (and only) load.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  function hydrateIframe(detailsEl) {
+    const frame = detailsEl.querySelector('iframe[data-src]');
+    if (!frame || frame.src) return;
+    frame.src = frame.dataset.src;
+  }
+
+  function bind() {
+    document.querySelectorAll('details.electrode-explorer').forEach(d => {
+      // If a user lands on an anchor that auto-expands the details,
+      // the `open` flip fires before this script runs. Handle both.
+      if (d.open) hydrateIframe(d);
+      d.addEventListener('toggle', () => {
+        if (d.open) hydrateIframe(d);
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind);
+  } else {
+    bind();
+  }
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,6 +132,8 @@ html_js_files = [
     ("js/tag-palette.js", {"defer": "defer"}),
     # Live search in PyData theme search modal (rendered on every page).
     ("js/search-as-you-type.js", {"defer": "defer"}),
+    # Lazy-load the electrode-explorer iframe on <details> expansion.
+    ("js/lazy-embed.js", {"defer": "defer"}),
 ]
 
 # Required for sphinx-sitemap: set the canonical base URL of the site
@@ -401,6 +403,8 @@ Technical Details
 -----------------
 
 {highlights_section}
+
+{electrodes_section}
 
 API Reference
 -------------
@@ -2086,6 +2090,127 @@ def _format_api_section(class_name: str) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# Electrode-explorer embed (Step 5 of the electrodes integration plan).
+#
+# `_static/dataset_generated/electrode-layouts.json` maps dataset_id →
+# {label, n_channels, tsv_url, coords_url}. It is eventually populated
+# by the eegdash backend montage registry; while that's being built we
+# maintain a curated subset here as a fallback.
+#
+# Each dataset page gets a collapsed <details> block. Expanding it swaps
+# the iframe's `data-src` onto `src` (see lazy-embed.js), so zero bytes
+# are fetched from electrodes.eegdash.org until a reader opts in.
+# ---------------------------------------------------------------------------
+
+_ELECTRODE_EXPLORER_BASE = "https://electrodes.eegdash.org/"
+
+_electrode_layouts_cache: dict[str, object] | None = None
+
+
+def _load_electrode_layouts() -> Mapping[str, Mapping[str, object]]:
+    """Read the curated electrode-layouts manifest (cached across calls).
+
+    Missing file or malformed JSON degrades silently to empty — dataset
+    pages then render a 'no scalp layout published' placeholder instead
+    of the iframe.
+    """
+    global _electrode_layouts_cache
+    if _electrode_layouts_cache is not None:
+        return _electrode_layouts_cache  # type: ignore[return-value]
+    path = (
+        Path(__file__).parent
+        / "_static"
+        / "dataset_generated"
+        / "electrode-layouts.json"
+    )
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        layouts = doc.get("layouts", {})
+        if not isinstance(layouts, dict):
+            layouts = {}
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        LOGGER.info(
+            "[electrode-layouts] manifest unavailable (%s); placeholders only", exc
+        )
+        layouts = {}
+    _electrode_layouts_cache = layouts
+    return layouts
+
+
+def _format_electrodes_section(context: Mapping[str, object]) -> str:
+    """Render a lazy <details><iframe> block for this dataset's montage.
+
+    If the manifest doesn't have an entry for this dataset_id, we still
+    emit the section but with a short note — keeps the page layout
+    consistent across the catalog.
+    """
+    dataset_id = str(context.get("dataset_id") or "").strip().lower()
+    if not dataset_id:
+        return ""
+
+    layouts = _load_electrode_layouts()
+    entry = layouts.get(dataset_id)
+
+    heading = "Electrode Layout\n----------------\n\n"
+
+    if not entry or not (entry.get("montage_id") or entry.get("tsv_url")):
+        # Placeholder — keeps the section visible so readers know the
+        # catalog intends to show it, just that this particular dataset
+        # hasn't been indexed yet. Either shape of URL is acceptable:
+        # schema v2 carries ``montage_id`` (the registry hash), schema
+        # v1 carried ``tsv_url`` + optional ``coords_url``.
+        body = (
+            "No scalp electrode layout is currently indexed for this\n"
+            "dataset. Once the eegdash montage registry ingests it,\n"
+            "the interactive viewer will appear here automatically.\n"
+        )
+        return heading + body
+
+    # Build the iframe URL. Prefer the registry id shape if present;
+    # otherwise fall back to direct tsv/coords URLs so pages work even
+    # before the registry endpoint is live.
+    label = str(entry.get("label") or "Electrodes").strip()
+    n_channels = entry.get("n_channels")
+    montage_id = str(entry.get("montage_id") or "").strip()
+
+    if montage_id:
+        query = f"montage={montage_id}"
+    else:
+        from urllib.parse import quote
+
+        tsv_q = quote(str(entry["tsv_url"]), safe="")
+        parts = [f"tsv={tsv_q}"]
+        coords_url = entry.get("coords_url")
+        if coords_url:
+            parts.append(f"coords={quote(str(coords_url), safe='')}")
+        query = "&".join(parts)
+
+    iframe_src = f"{_ELECTRODE_EXPLORER_BASE}?{query}&embed=1"
+
+    title_bits = [label]
+    if n_channels:
+        title_bits.append(f"{n_channels} channels")
+    summary_text = " — ".join(title_bits)
+
+    # Keep the HTML block compact; Sphinx renders it as-is.
+    html = (
+        ".. raw:: html\n\n"
+        '   <details class="electrode-explorer">\n'
+        f"     <summary>Electrode layout — {summary_text}</summary>\n"
+        "     <iframe\n"
+        f'       data-src="{iframe_src}"\n'
+        '       loading="lazy"\n'
+        '       width="100%" height="640"\n'
+        '       style="border: 1px solid var(--pst-color-border); border-radius: 8px; max-width: 900px; display: block;"\n'
+        f'       title="Topomap of {label}"\n'
+        '       referrerpolicy="no-referrer">\n'
+        "     </iframe>\n"
+        "   </details>\n"
+    )
+    return heading + html
+
+
 def _format_see_also_section(
     dataset_id: str,
     class_name: str = "",
@@ -2397,6 +2522,7 @@ def _process_dataset_item(
         readme_section=_format_readme_section(context),
         highlights_section=_format_highlights_section(context),
         quickstart_section=_format_quickstart_section(context),
+        electrodes_section=_format_electrodes_section(context),
         api_section=_format_api_section(name),
         see_also_section=_format_see_also_section(dataset_id, name, related),
         feedback_section=_format_feedback_section(dataset_id, dataset_title),


### PR DESCRIPTION
## Summary

Consumes the montage registry shipped in #325 and surfaces it in the published docs. Every per-dataset page gains a collapsible **Electrode Layout** section with a lazy-loaded iframe pointing at the existing electrode-explorer viewer (https://electrodes.eegdash.org).

Zero bytes are fetched from the viewer domain until the reader expands the section — `data-src` is swapped onto `src` on the first `<details>` toggle.

## What's inside

| File | What it does |
|---|---|
| `docs/source/conf.py` | New `_format_electrodes_section()` emits `<details><iframe data-src=…>` per dataset, sourced from the manifest. Graceful placeholder when a dataset has no registered montage. |
| `docs/build_electrode_layouts.py` | Queries `/api/{db}/datasets/summary` + `/api/{db}/datasets/{id}/montages` in parallel (8 workers) and writes `source/_static/dataset_generated/electrode-layouts.json` keyed by `dataset_id` with the montage registry hash. |
| `docs/Makefile` | New `electrode-layouts` target chained into `html` and `html-noplot`. Fail-soft: `--keep-existing-on-empty || true` so a transient API outage never breaks the docs build. |
| `docs/source/_static/js/lazy-embed.js` | On `<details>` toggle: `iframe.src = iframe.dataset.src`. |

## Not included

- The viewer itself. `eegdash/electrodes` (deployed at https://electrodes.eegdash.org) is a separate repository, already live.
- The generated manifest (`electrode-layouts.json`) is gitignored; CI's `make html` regenerates it each build.

## Depends on

- #325 (merged) — provides the registry + `/api/{db}/datasets/{id}/montages` endpoint this script queries.

## Test plan

- [ ] `cd docs && make electrode-layouts` — script runs against prod API, writes a non-empty JSON (502 layouts when last run locally).
- [ ] `make html` — build completes; dataset pages carry the `<details class="electrode-explorer">` block.
- [ ] Open a built dataset page in a browser, expand the section, confirm the iframe loads the viewer at the right hash.
- [ ] Open a dataset page for a dataset with no registered montage (MEG-only or iEEG-depth), confirm the placeholder message renders cleanly.
- [ ] Visual-regression: viewer inside the iframe has the transparent-body + top-right wordmark embed layout, no stray scrollbars.