### PR TITLE
fix(ingest): reconcile source/storage.base against dataset_id pattern

### DIFF
--- a/eegdash/dataset/_source_inference.py
+++ b/eegdash/dataset/_source_inference.py
@@ -1,0 +1,111 @@
+"""Source / storage inference shared by runtime and ingestion.
+
+Records and dataset documents both carry a ``source`` field and a
+``storage.base`` URI. They were sometimes written with the wrong values
+(e.g. NEMAR datasets digested as ``source="openneuro"`` and
+``storage.base="s3://openneuro.org/<id>"`` before PR #327). This module
+centralises the pattern-based recovery rules so:
+
+* the runtime client can self-heal already-ingested records, and
+* the digestion pipeline can refuse to commit a source that disagrees
+  with the dataset_id pattern.
+
+Keep ``STORAGE_CONFIGS`` aligned with ``scripts/ingestions/3_digest.py``.
+"""
+
+from __future__ import annotations
+
+# Source -> remote storage prefix. Mirrors STORAGE_CONFIGS in
+# scripts/ingestions/3_digest.py and the patterns in
+# scripts/ingestions/_validate.py::SOURCE_STORAGE_PATTERNS.
+STORAGE_CONFIGS: dict[str, dict[str, str]] = {
+    "openneuro": {"backend": "s3", "base": "s3://openneuro.org"},
+    "nemar": {"backend": "s3", "base": "s3://nemar"},
+    "gin": {"backend": "https", "base": "https://gin.g-node.org"},
+    "figshare": {"backend": "https", "base": "https://figshare.com/ndownloader/files"},
+    "zenodo": {"backend": "https", "base": "https://zenodo.org/records"},
+    "osf": {"backend": "https", "base": "https://files.osf.io"},
+    "scidb": {"backend": "https", "base": "https://www.scidb.cn"},
+    "datarn": {"backend": "webdav", "base": "https://webdav.data.ru.nl"},
+}
+
+
+def infer_source_from_dataset_id(dataset_id: str) -> str | None:
+    """Return the source implied by ``dataset_id``, or ``None`` if unknown.
+
+    OpenNeuro IDs are ``dsNNNNNN``; NEMAR IDs are ``nmNNNNNN``. The
+    ``EEGManyLabs`` projects live on GIN, and the HBN ``EEG2025*``
+    releases are mirrored on NEMAR.
+    """
+    if not dataset_id:
+        return None
+    if dataset_id.startswith("ds") and dataset_id[2:].isdigit():
+        return "openneuro"
+    if dataset_id.startswith("nm") and dataset_id[2:].isdigit():
+        return "nemar"
+    if "EEGManyLabs" in dataset_id:
+        return "gin"
+    if dataset_id.startswith("EEG2025"):
+        return "nemar"
+    return None
+
+
+def expected_storage_base(dataset_id: str) -> str | None:
+    """Return the canonical ``storage.base`` for ``dataset_id``.
+
+    Only returns a value for dataset IDs whose pattern unambiguously
+    determines the source (OpenNeuro and NEMAR). Returns ``None`` for
+    sources that need extra metadata to build the URL (figshare/zenodo/
+    osf use per-record IDs that aren't derivable from ``dataset_id``).
+    """
+    source = infer_source_from_dataset_id(dataset_id)
+    if source not in {"openneuro", "nemar"}:
+        return None
+    return f"{STORAGE_CONFIGS[source]['base']}/{dataset_id}"
+
+
+def expected_backend(dataset_id: str) -> str | None:
+    """Return the canonical ``storage.backend`` for ``dataset_id``."""
+    source = infer_source_from_dataset_id(dataset_id)
+    if source is None:
+        return None
+    return STORAGE_CONFIGS[source]["backend"]
+
+
+def correct_storage_inplace(
+    record: dict, dataset_id: str | None = None
+) -> tuple[bool, str | None]:
+    """Rewrite a record's ``storage.base``/``backend`` if it is misrouted.
+
+    A record is "misrouted" when its dataset_id pattern (e.g. ``nm*``)
+    implies one source but ``storage.base`` points at a different source's
+    bucket (e.g. ``s3://openneuro.org/...``). This is the residual fallout
+    from the pre-PR-#327 ingestion bug.
+
+    Returns
+    -------
+    (corrected, old_base)
+        ``corrected`` is ``True`` when ``storage.base`` was rewritten.
+        ``old_base`` is the previous value (only when corrected).
+    """
+    dsid = dataset_id or record.get("dataset")
+    expected = expected_storage_base(dsid) if dsid else None
+    if expected is None:
+        return False, None
+
+    storage = record.setdefault("storage", {})
+    current_base = (storage.get("base") or "").rstrip("/")
+    if not current_base or current_base == expected:
+        return False, None
+
+    # Only auto-correct when the current base matches a *known* foreign
+    # bucket — never silently rewrite arbitrary user-supplied URIs.
+    foreign_prefixes = {
+        cfg["base"] for src, cfg in STORAGE_CONFIGS.items() if src != "local"
+    }
+    if not any(current_base.startswith(p + "/") for p in foreign_prefixes):
+        return False, None
+
+    storage["base"] = expected
+    storage["backend"] = expected_backend(dsid) or storage.get("backend") or "s3"
+    return True, current_base

--- a/eegdash/dataset/_source_inference.py
+++ b/eegdash/dataset/_source_inference.py
@@ -115,6 +115,7 @@ def correct_storage_inplace(
         ``corrected`` is ``True`` when *either* field was rewritten.
         ``old_base`` is the previous ``storage.base`` value when it was
         rewritten, otherwise ``None`` (even if backend was rewritten).
+
     """
     dsid = dataset_id or record.get("dataset")
     if not dsid:
@@ -156,10 +157,7 @@ def correct_storage_inplace(
         storage["base"] = expected_base
         old_base = current_base
 
-    if (
-        expected_backend_value is not None
-        and current_backend != expected_backend_value
-    ):
+    if expected_backend_value is not None and current_backend != expected_backend_value:
         storage["backend"] = expected_backend_value
 
     return True, old_base

--- a/eegdash/dataset/_source_inference.py
+++ b/eegdash/dataset/_source_inference.py
@@ -10,6 +10,13 @@ centralises the pattern-based recovery rules so:
 * the digestion pipeline can refuse to commit a source that disagrees
   with the dataset_id pattern.
 
+The ``"nemar"`` backend identifier is *logical only* — NEMAR's S3 bucket
+has ``s3:ListBucket`` and ``s3:GetObject`` closed by design and filenames
+are SHA-resolved by git-annex, so the URI ``s3://nemar/<id>/<file>`` is
+never directly fetchable. EEGDash treats ``backend="nemar"`` as a marker
+that means "do not attempt a public S3 fetch; surface an actionable
+``StorageAccessError`` if the file is not already in cache."
+
 Keep ``STORAGE_CONFIGS`` aligned with ``scripts/ingestions/3_digest.py``.
 """
 
@@ -20,7 +27,10 @@ from __future__ import annotations
 # scripts/ingestions/_validate.py::SOURCE_STORAGE_PATTERNS.
 STORAGE_CONFIGS: dict[str, dict[str, str]] = {
     "openneuro": {"backend": "s3", "base": "s3://openneuro.org"},
-    "nemar": {"backend": "s3", "base": "s3://nemar"},
+    # NEMAR uses a dedicated, non-fetchable backend tag. The ``base`` is
+    # kept for traceability/error messages; the actual data must be
+    # obtained via git-annex / nemar CLI / NEMAR API.
+    "nemar": {"backend": "nemar", "base": "s3://nemar"},
     "gin": {"backend": "https", "base": "https://gin.g-node.org"},
     "figshare": {"backend": "https", "base": "https://figshare.com/ndownloader/files"},
     "zenodo": {"backend": "https", "base": "https://zenodo.org/records"},
@@ -28,6 +38,13 @@ STORAGE_CONFIGS: dict[str, dict[str, str]] = {
     "scidb": {"backend": "https", "base": "https://www.scidb.cn"},
     "datarn": {"backend": "webdav", "base": "https://webdav.data.ru.nl"},
 }
+
+# Hot-path: a record is "misrouted" only when its base sits under one of
+# these known foreign buckets. Frozen at module load; consulted in
+# ``correct_storage_inplace`` on every record.
+_FOREIGN_PREFIXES: frozenset[str] = frozenset(
+    cfg["base"] for cfg in STORAGE_CONFIGS.values()
+)
 
 
 def infer_source_from_dataset_id(dataset_id: str) -> str | None:
@@ -75,37 +92,74 @@ def expected_backend(dataset_id: str) -> str | None:
 def correct_storage_inplace(
     record: dict, dataset_id: str | None = None
 ) -> tuple[bool, str | None]:
-    """Rewrite a record's ``storage.base``/``backend`` if it is misrouted.
+    """Rewrite a record's ``storage.base`` / ``storage.backend`` if misrouted.
 
-    A record is "misrouted" when its dataset_id pattern (e.g. ``nm*``)
-    implies one source but ``storage.base`` points at a different source's
-    bucket (e.g. ``s3://openneuro.org/...``). This is the residual fallout
-    from the pre-PR-#327 ingestion bug.
+    Two distinct corrections happen here:
+
+    1. **Base mismatch** — when the dataset_id pattern (e.g. ``nm*``)
+       implies one source but ``storage.base`` points at a different
+       known foreign bucket (e.g. ``s3://openneuro.org/...``). Residual
+       fallout from the pre-PR-#327 ingestion bug.
+    2. **Backend mismatch** — when the dataset_id pattern implies a
+       backend (e.g. ``"nemar"``) that differs from what was stored
+       (e.g. ``"s3"``). Records ingested between the source fix
+       (PR #327) and the nemar-backend split still claim ``s3``.
+
+    The two corrections are independent: a record with the right base
+    but the wrong backend (very common for already-digested NEMAR
+    records) still gets fixed.
 
     Returns
     -------
     (corrected, old_base)
-        ``corrected`` is ``True`` when ``storage.base`` was rewritten.
-        ``old_base`` is the previous value (only when corrected).
+        ``corrected`` is ``True`` when *either* field was rewritten.
+        ``old_base`` is the previous ``storage.base`` value when it was
+        rewritten, otherwise ``None`` (even if backend was rewritten).
     """
     dsid = dataset_id or record.get("dataset")
-    expected = expected_storage_base(dsid) if dsid else None
-    if expected is None:
+    if not dsid:
+        return False, None
+
+    expected_base = expected_storage_base(dsid)
+    expected_backend_value = expected_backend(dsid)
+    if expected_base is None:
+        # Source can't be derived unambiguously from the dataset_id —
+        # be conservative and leave both fields alone.
         return False, None
 
     storage = record.setdefault("storage", {})
     current_base = (storage.get("base") or "").rstrip("/")
-    if not current_base or current_base == expected:
+    current_backend = storage.get("backend")
+
+    if not current_base:
+        # No base to reason about — don't flip backend in isolation.
         return False, None
 
-    # Only auto-correct when the current base matches a *known* foreign
-    # bucket — never silently rewrite arbitrary user-supplied URIs.
-    foreign_prefixes = {
-        cfg["base"] for src, cfg in STORAGE_CONFIGS.items() if src != "local"
-    }
-    if not any(current_base.startswith(p + "/") for p in foreign_prefixes):
+    # Hot-path early-out for the dominant case (canonical base + correct
+    # backend). Avoids the foreign-prefix scan on every healthy record.
+    if current_base == expected_base and current_backend == expected_backend_value:
         return False, None
 
-    storage["base"] = expected
-    storage["backend"] = expected_backend(dsid) or storage.get("backend") or "s3"
-    return True, current_base
+    # We rewrite only when the base is canonical (legacy backend may
+    # still be stale) or a known foreign bucket (mis-routed by the
+    # pre-PR-#327 ingestion bug). User-supplied bases are left alone.
+    is_canonical = current_base == expected_base
+    is_known_foreign = not is_canonical and any(
+        current_base.startswith(p + "/") for p in _FOREIGN_PREFIXES
+    )
+
+    if not is_canonical and not is_known_foreign:
+        return False, None
+
+    old_base: str | None = None
+    if is_known_foreign:
+        storage["base"] = expected_base
+        old_base = current_base
+
+    if (
+        expected_backend_value is not None
+        and current_backend != expected_backend_value
+    ):
+        storage["backend"] = expected_backend_value
+
+    return True, old_base

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -12,8 +12,10 @@ braindecode for machine learning workflows and handles data loading from both lo
 import configparser
 import re
 import shutil
+import urllib.error
+import urllib.request
 from contextlib import contextmanager
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -30,7 +32,8 @@ from ..const import MODALITY_ALIASES
 from ..logging import logger
 from ..schemas import validate_record
 from .bids_dataset import _COMPANION_FILES
-from .exceptions import DataIntegrityError
+from ._source_inference import correct_storage_inplace
+from .exceptions import DataIntegrityError, StorageAccessError
 from .io import (
     _ANNEX_KEY_RE,
     _convert_time_with_numeric_dash,
@@ -226,6 +229,151 @@ def _make_tolerant_get_sample_info(orig_fn):
     return _tolerant_get_sample_info
 
 
+# NEMAR's S3 bucket allows anonymous GET on SHA-keyed objects under
+# ``s3://nemar/<id>/objects/<KEY>`` but not on BIDS-named paths (git-annex
+# stores by content hash). The BIDS-path → SHA-key mapping lives in the
+# dataset's git-annex pointer file, fetched here from GitHub raw.
+
+_NEMAR_RAW_URL = "https://raw.githubusercontent.com/NEMARDatasets/{dataset_id}/HEAD/{relpath}"
+_NEMAR_POINTER_TIMEOUT = 30  # seconds — pointer files are tiny
+_NEMAR_USER_AGENT = "eegdash-runtime/nemar-resolver"
+
+
+def _fetch_nemar_pointer(dataset_id: str, relpath: str) -> bytes:
+    """Fetch the raw bytes of a NEMAR-tracked file from GitHub.
+
+    For annex-managed files this returns the git-annex symlink target
+    string; for files committed directly to git (sidecars) it returns
+    the actual file content.
+    """
+    url = _NEMAR_RAW_URL.format(dataset_id=dataset_id, relpath=relpath.lstrip("/"))
+    req = urllib.request.Request(url, headers={"User-Agent": _NEMAR_USER_AGENT})
+    with urllib.request.urlopen(req, timeout=_NEMAR_POINTER_TIMEOUT) as resp:
+        return resp.read()
+
+
+@lru_cache(maxsize=4096)
+def _resolve_nemar_pointer(dataset_id: str, relpath: str) -> tuple[str | None, bytes]:
+    """Return ``(annex_key, raw_bytes)`` for a NEMAR-tracked file.
+
+    ``annex_key`` is the SHA-keyed object name when the file is
+    annex-managed, ``None`` when the file is committed directly to git
+    (in which case ``raw_bytes`` is the actual content).
+    """
+    raw = _fetch_nemar_pointer(dataset_id, relpath)
+    try:
+        text = raw.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        return None, raw
+    # git-annex pointers/symlinks always reference ``/annex/objects/``;
+    # everything else is a directly-tracked file (sidecar JSON/TSV).
+    if "/annex/objects/" not in text:
+        return None, raw
+    candidate = text.rsplit("/", 1)[-1]
+    if _ANNEX_KEY_RE.match(candidate):
+        return candidate, raw
+    return None, raw
+
+
+def _resolve_nemar_uris(
+    record: dict, raw_dest: Path, dep_keys: list[str], dep_dests: list[Path]
+) -> tuple[str | None, list[str]]:
+    """Resolve SHA-keyed S3 URIs for a NEMAR record.
+
+    Direct-git sidecars are written to disk as a side effect and excluded
+    from the returned URI list. When ``storage.annex_keys[<relpath>]`` is
+    populated at digest time we use it and skip the GitHub round-trip.
+    """
+    storage = record.get("storage") or {}
+    base = (storage.get("base") or "").rstrip("/")
+    raw_key = storage.get("raw_key", "")
+    dataset_id = record.get("dataset", "")
+    stored_annex_keys: dict[str, str] = storage.get("annex_keys") or {}
+    if not (base and raw_key and dataset_id):
+        return None, []
+
+    raw_uri = _resolve_one_nemar_entry(
+        dataset_id=dataset_id,
+        relpath=raw_key,
+        base=base,
+        dest=raw_dest,
+        stored_key=stored_annex_keys.get(raw_key),
+        is_required=True,
+    )
+
+    dep_uris: list[str] = []
+    for dep_key, dep_dest in zip(dep_keys, dep_dests, strict=False):
+        try:
+            uri = _resolve_one_nemar_entry(
+                dataset_id=dataset_id,
+                relpath=dep_key,
+                base=base,
+                dest=dep_dest,
+                stored_key=stored_annex_keys.get(dep_key),
+                is_required=False,
+            )
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            # Sidecar resolution failures are best-effort: log and skip,
+            # so a missing sidecar doesn't take out the whole load.
+            logger.warning(
+                "Could not resolve NEMAR sidecar %s/%s: %s",
+                dataset_id,
+                dep_key,
+                e,
+            )
+            continue
+        if uri:
+            dep_uris.append(uri)
+
+    return raw_uri, dep_uris
+
+
+def _resolve_one_nemar_entry(
+    *,
+    dataset_id: str,
+    relpath: str,
+    base: str,
+    dest: Path,
+    stored_key: str | None,
+    is_required: bool,
+) -> str | None:
+    """Return the S3 URI for one entry, or ``None`` if it was inlined.
+
+    When ``stored_key`` is provided (digest-time fast path) we trust it
+    and skip the GitHub raw fetch entirely. Otherwise we fall back to
+    the pointer-resolution path.
+    """
+    if stored_key:
+        return f"{base}/objects/{stored_key}"
+
+    try:
+        annex_key, payload = _resolve_nemar_pointer(dataset_id, relpath)
+    except urllib.error.URLError as e:
+        if not is_required:
+            raise
+        detail = (
+            f"HTTP {e.code} {e.reason}"
+            if isinstance(e, urllib.error.HTTPError)
+            else str(e.reason)
+        )
+        raise StorageAccessError(
+            f"Could not resolve NEMAR pointer {dataset_id}/{relpath} from "
+            f"GitHub raw: {detail}",
+            dataset_id=dataset_id,
+            backend="nemar",
+            logical_uri=f"{base}/{relpath}",
+            cache_path=str(dest),
+        ) from e
+
+    if annex_key:
+        return f"{base}/objects/{annex_key}"
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dest.exists():
+        dest.write_bytes(payload)
+    return None
+
+
 class EEGDashRaw(RawDataset):
     """A single EEG recording dataset.
 
@@ -277,41 +425,37 @@ class EEGDashRaw(RawDataset):
 
         self.record = record
 
-        # Derive local cache paths from record fields (portable - no absolute paths stored)
+        # Self-heal records constructed directly (bypassing
+        # ``EEGDashDataset._normalize_records``).
+        correct_storage_inplace(self.record)
+
         storage = self.record.get("storage", {})
         dataset_id = self.record["dataset"]
         bids_relpath = self.record["bids_relpath"]
-        dep_keys = storage.get("dep_keys", [])
+        dep_keys = storage.get("dep_keys") or []
 
-        # Robust root resolution: check if a folder with the dataset_id exists,
-        # or if there's a unique folder that "matches" the dataset (e.g. ds0001mini)
         self.bids_root = self.cache_dir / dataset_id
-
         self.filecache = self.bids_root / bids_relpath
         self._dep_paths = [self.bids_root / p for p in dep_keys]
 
-        # Build remote URIs based on storage backend
         backend = storage.get("backend")
         base = storage.get("base", "").rstrip("/")
         raw_key = storage.get("raw_key", "")
-        dep_keys = storage.get("dep_keys") or []
+
+        # Default: no remote URIs. The two backends below override.
+        self._raw_uri: str | None = None
+        self._dep_uris: list[str] = []
+        self._storage_backend = backend
 
         if backend in ("s3", "https") and base and raw_key:
             self._raw_uri = f"{base}/{raw_key}"
             self._dep_uris = [f"{base}/{k}" for k in dep_keys]
         elif backend == "local" and base:
-            # Local backend: data already exists at storage.base
             local_base = Path(base)
             self.bids_root = local_base
             self.filecache = local_base / raw_key if raw_key else self.filecache
-            self._dep_paths = (
-                [local_base / k for k in dep_keys] if dep_keys else self._dep_paths
-            )
-            self._raw_uri = None
-            self._dep_uris = []
-        else:
-            self._raw_uri = None
-            self._dep_uris = []
+            if dep_keys:
+                self._dep_paths = [local_base / k for k in dep_keys]
 
         if not self.bids_root.exists() and self._raw_uri:
             self.bids_root.mkdir(parents=True, exist_ok=True)
@@ -377,6 +521,25 @@ class EEGDashRaw(RawDataset):
         return uri.rsplit("/", 1)[0] + "/" + bids_filename
 
     def _download_required_files(self) -> None:
+        # NEMAR records carry a logical ``s3://nemar/<id>/<bids_relpath>``
+        # base, but actual fetching has to go through the SHA-keyed
+        # object name under ``s3://nemar/<id>/objects/<KEY>``. Resolve
+        # the keys lazily (and only when the file isn't already cached)
+        # so that we don't hit GitHub raw for files that are already on
+        # disk.
+        if (
+            self._raw_uri is None
+            and self._storage_backend == "nemar"
+            and not self.filecache.exists()
+        ):
+            dep_keys = (self.record.get("storage") or {}).get("dep_keys") or []
+            self._raw_uri, self._dep_uris = _resolve_nemar_uris(
+                self.record,
+                raw_dest=self.filecache,
+                dep_keys=list(dep_keys),
+                dep_dests=list(self._dep_paths),
+            )
+
         if self._raw_uri is not None:
             filesystem = downloader.get_s3_filesystem()
 

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -31,8 +31,8 @@ from .. import downloader
 from ..const import MODALITY_ALIASES
 from ..logging import logger
 from ..schemas import validate_record
-from .bids_dataset import _COMPANION_FILES
 from ._source_inference import correct_storage_inplace
+from .bids_dataset import _COMPANION_FILES
 from .exceptions import DataIntegrityError, StorageAccessError
 from .io import (
     _ANNEX_KEY_RE,
@@ -234,7 +234,9 @@ def _make_tolerant_get_sample_info(orig_fn):
 # stores by content hash). The BIDS-path → SHA-key mapping lives in the
 # dataset's git-annex pointer file, fetched here from GitHub raw.
 
-_NEMAR_RAW_URL = "https://raw.githubusercontent.com/NEMARDatasets/{dataset_id}/HEAD/{relpath}"
+_NEMAR_RAW_URL = (
+    "https://raw.githubusercontent.com/NEMARDatasets/{dataset_id}/HEAD/{relpath}"
+)
 _NEMAR_POINTER_TIMEOUT = 30  # seconds — pointer files are tiny
 _NEMAR_USER_AGENT = "eegdash-runtime/nemar-resolver"
 

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -27,6 +27,7 @@ from ..local_bids import discover_local_bids_records
 from ..logging import logger
 from ..paths import get_default_cache_dir
 from ..schemas import validate_record
+from ._source_inference import correct_storage_inplace
 from .base import EEGDashRaw
 from .bids_dataset import EEGBIDSDataset
 from .registry import register_openneuro_datasets
@@ -457,8 +458,11 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         This method performs several normalizations:
         1. Filters out records with invalid extensions (e.g., .json, .tsv sidecar files)
-        2. Updates storage backend/base if s3_bucket is specified
-        3. Deduplicates records if _dedupe_records is enabled
+        2. Self-heals records whose ``storage.base`` is misrouted for the
+           dataset_id pattern (residual fallout from the pre-PR-#327 NEMAR
+           ingestion bug — ``nm*`` records pointing at ``s3://openneuro.org``).
+        3. Updates storage backend/base if s3_bucket is specified
+        4. Deduplicates records if _dedupe_records is enabled
         """
         # Filter out records that are not valid EEG data files
         # (e.g., filter out .json, .tsv sidecar files that may be in the database)
@@ -471,6 +475,24 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             filtered_records.append(record)
 
         records = filtered_records
+
+        # Self-heal misrouted storage.base before any user override applies.
+        # The pre-PR-#327 NEMAR mislabel has since been patched in the DB, so
+        # this is now a defensive net for stale caches / third-party records.
+        seen_corrections: set[tuple[str, str, str]] = set()
+        for record in records:
+            corrected, old_base = correct_storage_inplace(record)
+            if corrected:
+                key = (record.get("dataset", ""), old_base, record["storage"]["base"])
+                if key not in seen_corrections:
+                    seen_corrections.add(key)
+                    logger.info(
+                        "Auto-corrected misrouted storage.base for dataset %s: "
+                        "%s -> %s",
+                        record.get("dataset"),
+                        old_base,
+                        record["storage"]["base"],
+                    )
 
         if self.s3_bucket:
             for record in records:

--- a/eegdash/dataset/exceptions.py
+++ b/eegdash/dataset/exceptions.py
@@ -301,4 +301,29 @@ class DataIntegrityError(EEGDashError):
         return error
 
 
-__all__ = ["EEGDashError", "DataIntegrityError"]
+class StorageAccessError(EEGDashError):
+    """Raised when a record's storage backend cannot be reached.
+
+    Attributes
+    ----------
+    dataset_id, backend, logical_uri, cache_path : str | None
+        Optional context attached to the error for downstream handlers.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        dataset_id: str | None = None,
+        backend: str | None = None,
+        logical_uri: str | None = None,
+        cache_path: str | None = None,
+    ):
+        self.dataset_id = dataset_id
+        self.backend = backend
+        self.logical_uri = logical_uri
+        self.cache_path = cache_path
+        super().__init__(message)
+
+
+__all__ = ["EEGDashError", "DataIntegrityError", "StorageAccessError"]

--- a/eegdash/dataset/exceptions.py
+++ b/eegdash/dataset/exceptions.py
@@ -308,6 +308,7 @@ class StorageAccessError(EEGDashError):
     ----------
     dataset_id, backend, logical_uri, cache_path : str | None
         Optional context attached to the error for downstream handlers.
+
     """
 
     def __init__(

--- a/eegdash/features/datasets.py
+++ b/eegdash/features/datasets.py
@@ -952,9 +952,12 @@ class FeaturesConcatDataset(BaseConcatDataset):
         _, mean, var = _pooled_var(counts, means, variances, ddof, ddof_in=0)
         std = np.sqrt(var + eps)
         for ds in self.datasets:
-            ds.features.loc[:, self._numeric_columns()] = (
-                ds.features.loc[:, self._numeric_columns()] - mean
-            ) / std
+            cols = self._numeric_columns()
+            # Whole-column replacement, not ``.loc[:, cols] =``: pandas 2.2+
+            # refuses to silently downcast a float result into an int64
+            # column and raises TypeError; replacing the columns wholesale
+            # adopts the float dtype of the right-hand side.
+            ds.features[cols] = (ds.features[cols] - mean) / std
 
     @staticmethod
     def _enforce_inplace_operations(func_name: str, kwargs: dict):

--- a/eegdash/schemas.py
+++ b/eegdash/schemas.py
@@ -749,8 +749,10 @@ class Storage(TypedDict):
 
     Attributes
     ----------
-    backend : {'s3', 'https', 'local'}
-        Storage backend protocol.
+    backend : {'s3', 'https', 'local', 'nemar'}
+        Storage backend protocol. ``"nemar"`` is a non-fetchable marker
+        for NEMAR-hosted datasets — see ``StorageAccessError`` for the
+        out-of-band access paths (git-annex / nemar CLI / NEMAR API).
     base : str
         Base URI (e.g., "s3://openneuro.org/ds000001").
     raw_key : str
@@ -760,7 +762,7 @@ class Storage(TypedDict):
 
     """
 
-    backend: Literal["s3", "https", "local"]
+    backend: Literal["s3", "https", "local", "nemar"]
     base: str
     raw_key: str
     dep_keys: list[str]
@@ -974,13 +976,14 @@ def create_record(
     dep_keys: list[str] | None = None,
     datatype: str = "eeg",
     suffix: str = "eeg",
-    storage_backend: Literal["s3", "https", "local"] = "s3",
+    storage_backend: Literal["s3", "https", "local", "nemar"] = "s3",
     recording_modality: list[str] | None = None,
     ch_names: list[str] | None = None,
     sampling_frequency: float | None = None,
     nchans: int | None = None,
     ntimes: int | None = None,
     digested_at: str | None = None,
+    annex_keys: dict[str, str] | None = None,
 ) -> Record:
     """Create an EEGDash record.
 
@@ -1050,6 +1053,16 @@ def create_record(
     entities_mne: Entities = dict(entities)  # type: ignore[assignment]
     entities_mne["run"] = _sanitize_run_for_mne(run)
 
+    storage_block: dict[str, Any] = {
+        "backend": storage_backend,
+        "base": storage_base.rstrip("/"),
+        "raw_key": bids_relpath,
+        "dep_keys": dep_keys,
+    }
+    # Sparse map (relpath → SHA-key) — annex-managed files only.
+    if annex_keys:
+        storage_block["annex_keys"] = dict(annex_keys)
+
     return Record(
         dataset=dataset,
         data_name=f"{dataset}_{PurePosixPath(bids_relpath).name}",
@@ -1061,12 +1074,7 @@ def create_record(
         recording_modality=recording_modality or [datatype],
         entities=entities,
         entities_mne=entities_mne,
-        storage=Storage(
-            backend=storage_backend,
-            base=storage_base.rstrip("/"),
-            raw_key=bids_relpath,
-            dep_keys=dep_keys,
-        ),
+        storage=storage_block,  # type: ignore[arg-type]
         ch_names=ch_names,
         sampling_frequency=sampling_frequency,
         nchans=nchans,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ docs = [
   "numpydoc",
   "lightgbm",
   "plotly",
+  "seaborn",
 ]
 
 digestion = [

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -41,7 +41,7 @@ from _constants import (
     MODALITY_DETECTION_TARGETS,
     NEURO_MODALITIES,
 )
-from _file_utils import get_annex_file_size
+from _file_utils import get_annex_file_key, get_annex_file_size
 from _fingerprint import fingerprint_from_files, fingerprint_from_manifest
 from _mef3_parser import parse_mef3_metadata
 from _montage import extract_layout
@@ -58,11 +58,14 @@ from eegdash.schemas import Storage, create_dataset, create_record
 os.environ.setdefault("NUMBA_CACHE_DIR", str(Path(".cache") / "numba"))
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS  # noqa: E402
 
-# Storage configuration per source
-# Each source has a backend type and base URL pattern
+# Storage configuration per source. Keep aligned with
+# ``eegdash/dataset/_source_inference.py::STORAGE_CONFIGS``. NEMAR uses a
+# dedicated ``"nemar"`` backend because direct fetches against
+# ``s3://nemar/<id>/<bidspath>`` don't work (filenames are SHA-resolved by
+# git-annex); the runtime resolves BIDS paths to SHA keys at fetch time.
 STORAGE_CONFIGS = {
     "openneuro": {"backend": "s3", "base": "s3://openneuro.org"},
-    "nemar": {"backend": "s3", "base": "s3://nemar"},  # NEMAR uses S3 too
+    "nemar": {"backend": "nemar", "base": "s3://nemar"},
     "gin": {"backend": "https", "base": "https://gin.g-node.org"},
     "figshare": {"backend": "https", "base": "https://figshare.com/ndownloader/files"},
     "zenodo": {"backend": "https", "base": "https://zenodo.org/records"},
@@ -1234,6 +1237,19 @@ def extract_record(
                 bids_relpath,
             )
 
+    # Stored at digest time so the runtime can skip the GitHub-raw
+    # round-trip when fetching SHA-keyed objects from the NEMAR bucket.
+    annex_keys: dict[str, str] = {}
+    if source == "nemar":
+        bids_root_path = bids_dataset.bidsdir  # already a Path
+        raw_annex_key = get_annex_file_key(Path(bids_file))
+        if raw_annex_key:
+            annex_keys[bids_relpath] = raw_annex_key
+        for dep in dep_keys:
+            dep_annex_key = get_annex_file_key(bids_root_path / dep)
+            if dep_annex_key:
+                annex_keys[dep] = dep_annex_key
+
     # Create record using the schema
     record = create_record(
         dataset=dataset_id,
@@ -1254,6 +1270,7 @@ def extract_record(
         nchans=nchans,
         ntimes=ntimes,
         digested_at=digested_at,
+        annex_keys=annex_keys or None,
     )
 
     # Restore participant_tsv metadata if available

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -153,22 +153,44 @@ def _source_from_dataset_id(dataset_id: str) -> str:
     return "unknown"
 
 
+def _reconcile_source(
+    manifest_src: str | None, dataset_id: str, *, context: str
+) -> str:
+    """Resolve the authoritative source for a dataset.
+
+    When the manifest carries a source but the dataset_id pattern implies
+    a different one (the bug behind the NEMAR mislabel — manifests said
+    ``openneuro`` for ``nm*`` ids), trust the pattern and warn loudly.
+    Without this guardrail the bad value flows straight into Mongo and we
+    get records pointing at the wrong S3 bucket.
+    """
+    pattern_src = _source_from_dataset_id(dataset_id)
+    if manifest_src and pattern_src not in (None, "unknown") and manifest_src != pattern_src:
+        print(
+            f"WARNING [{context}]: {dataset_id} manifest source={manifest_src!r} "
+            f"disagrees with id-pattern source={pattern_src!r}; using pattern.",
+            file=sys.stderr,
+        )
+        return pattern_src
+    if manifest_src:
+        return manifest_src
+    return pattern_src
+
+
 def detect_source(dataset_dir: Path) -> str:
     """Detect source from manifest.json or dataset structure."""
     dataset_id = dataset_dir.name
     manifest_path = dataset_dir / "manifest.json"
+    manifest_src: str | None = None
     if manifest_path.exists():
         try:
             with open(manifest_path) as f:
                 manifest = json.load(f)
-            src = manifest.get("source")
-            if src:
-                return src
+            manifest_src = manifest.get("source")
         except Exception:
-            pass
+            manifest_src = None
 
-    # Fallback: check dataset_id pattern
-    return _source_from_dataset_id(dataset_id)
+    return _reconcile_source(manifest_src, dataset_id, context="detect_source")
 
 
 def _parse_edf_with_mne(edf_path: Path) -> dict[str, Any] | None:
@@ -1681,7 +1703,9 @@ def digest_from_manifest(
             "error": f"Failed to load manifest: {e}",
         }
 
-    source = manifest.get("source") or _source_from_dataset_id(dataset_id)
+    source = _reconcile_source(
+        manifest.get("source"), dataset_id, context="digest_from_manifest"
+    )
     digested_at = datetime.now(timezone.utc).isoformat()
 
     # Get file list from manifest
@@ -1725,6 +1749,21 @@ def digest_from_manifest(
         else:
             # Default: use base/dataset_id pattern
             storage_base = f"{base}/{dataset_id}"
+    else:
+        # Sanity-check explicit storage_base against the resolved source.
+        # 2_clone.py used to write ``s3://openneuro.org/<id>`` for any
+        # git-cloned dataset, including NEMAR — that value reached MongoDB
+        # as ``storage.base`` and we'd 404 on download. Reject the mismatch
+        # here so the bad value never gets written again.
+        expected_prefix = get_storage_config(source).get("base", "")
+        if expected_prefix and not str(storage_base).startswith(expected_prefix):
+            print(
+                f"WARNING [digest]: {dataset_id} manifest storage_base="
+                f"{storage_base!r} does not start with {expected_prefix!r} "
+                f"for source={source!r}; rebuilding from source config.",
+                file=sys.stderr,
+            )
+            storage_base = f"{expected_prefix}/{dataset_id}"
 
     # Collect BIDS entities from file paths (both direct files and ZIP contents)
     subjects = set()

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -168,7 +168,11 @@ def _reconcile_source(
     get records pointing at the wrong S3 bucket.
     """
     pattern_src = _source_from_dataset_id(dataset_id)
-    if manifest_src and pattern_src not in (None, "unknown") and manifest_src != pattern_src:
+    if (
+        manifest_src
+        and pattern_src not in (None, "unknown")
+        and manifest_src != pattern_src
+    ):
         print(
             f"WARNING [{context}]: {dataset_id} manifest source={manifest_src!r} "
             f"disagrees with id-pattern source={pattern_src!r}; using pattern.",

--- a/scripts/ingestions/_file_utils.py
+++ b/scripts/ingestions/_file_utils.py
@@ -560,6 +560,13 @@ def list_datarn_files(source_url: str) -> list[dict]:
 
 
 _ANNEX_SIZE_RE = re.compile(r"-s(\d+)--")
+# Anchored to the start of the basename. The trailing ``\.`` is enough to
+# reject garbage like ``garbage-not-a-key.set`` because the regex demands
+# the SHA-key shape *before* the extension dot.
+_ANNEX_KEY_BASENAME_RE = re.compile(
+    r"^(?:SHA256E|MD5E)-s\d+--[0-9a-f]+\.", flags=re.IGNORECASE
+)
+_ANNEX_POINTER_MAX_SIZE = 256
 
 
 def parse_annex_size(text: str) -> int | None:
@@ -572,38 +579,58 @@ def parse_annex_size(text: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
-def get_annex_file_size(path: Path) -> int:
-    """Get file size, resolving git-annex pointers and symlinks.
+def _read_annex_pointer_text(path: Path) -> str | None:
+    """Return the symlink target / smudged-pointer content for *path*.
 
-    After a shallow clone with ``GIT_LFS_SKIP_SMUDGE=1``, git-annex data
-    files are small text pointers whose content encodes the real size in
-    the annex key (e.g. ``/annex/objects/MD5E-s128356352--…``).
-
-    Returns the real data size for annex-managed files, the stat size for
-    regular files, or 0 for broken symlinks without annex keys.
+    For both symlinks and small regular files (≤256B). Returns ``None``
+    for missing paths, large files, OS errors, and non-decodable content.
     """
     if path.is_symlink():
         try:
-            annex_size = parse_annex_size(str(path.readlink()))
-            if annex_size is not None:
-                return annex_size
-        except (OSError, ValueError):
-            pass
-        return 0
-
+            return str(path.readlink())
+        except OSError:
+            return None
     if path.is_file():
-        stat_size = path.stat().st_size
-        if stat_size < 256:
-            try:
-                content = path.read_text(encoding="utf-8", errors="ignore").strip()
-                if "/annex/" in content:
-                    annex_size = parse_annex_size(content)
-                    if annex_size is not None:
-                        return annex_size
-            except (OSError, UnicodeDecodeError):
-                pass
-        return stat_size
+        try:
+            if path.stat().st_size > _ANNEX_POINTER_MAX_SIZE:
+                return None
+            return path.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeDecodeError):
+            return None
+    return None
 
+
+def get_annex_file_key(path: Path) -> str | None:
+    """Return the git-annex SHA key for *path*, or ``None``.
+
+    Git-annex tracks binaries as either a symlink ending in
+    ``.git/annex/objects/<X>/<Y>/<KEY>/<KEY>`` or a smudged pointer
+    file whose content is a line like ``/annex/objects/<KEY>``. In both
+    cases the SHA key is the final path segment. Returns ``None`` for
+    regular git-tracked sidecars and real binaries.
+    """
+    text = _read_annex_pointer_text(path)
+    if text is None or "/annex/objects/" not in text:
+        return None
+    candidate = text.strip().rsplit("/", 1)[-1]
+    return candidate if _ANNEX_KEY_BASENAME_RE.match(candidate) else None
+
+
+def get_annex_file_size(path: Path) -> int:
+    """Get file size, resolving git-annex pointers and symlinks.
+
+    Returns the real data size for annex-managed files, the stat size
+    for regular files, or 0 for broken symlinks without annex keys.
+    """
+    text = _read_annex_pointer_text(path)
+    if text is not None and "/annex/" in text:
+        annex_size = parse_annex_size(text)
+        if annex_size is not None:
+            return annex_size
+    if path.is_symlink():
+        return 0
+    if path.is_file():
+        return path.stat().st_size
     return 0
 
 

--- a/scripts/ingestions/_parser_utils.py
+++ b/scripts/ingestions/_parser_utils.py
@@ -99,10 +99,17 @@ def build_s3_url(dataset_id: str, relative_path: str, source: str = "openneuro")
     """
     encoded_path = quote(relative_path, safe="/")
     if source == "openneuro":
+        # OpenNeuro's git-annex remote uses ``exporttree=yes``, so files on
+        # S3 are addressed by their BIDS path directly.
         return f"https://s3.amazonaws.com/openneuro.org/{dataset_id}/{encoded_path}"
     if source == "nemar":
-        # NEMAR mirrors datasets under s3://nemar/<id>/ with the same path
-        # scheme as OpenNeuro's bucket.
+        # NOTE: NEMAR's public README documents this same BIDS-path layout
+        # (``aws s3 cp s3://nemar/<id>/path/to/file --no-sign-request``),
+        # but in practice the bucket only serves files at
+        # ``s3://nemar/<id>/objects/<git-annex-key>`` — anonymous GETs on
+        # BIDS paths return 403, and ListObjectsV2 is denied. ``relative_path``
+        # here must already be the ``objects/<annex-key>`` form; callers
+        # cannot pass a BIDS path. See _resolve_nemar_annex_key (TODO).
         return f"https://s3.amazonaws.com/nemar/{dataset_id}/{encoded_path}"
     raise ValueError(f"Unsupported source for S3 URL: {source}")
 

--- a/scripts/ingestions/patch_nemar_records_storage.py
+++ b/scripts/ingestions/patch_nemar_records_storage.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Patch NEMAR records whose ``storage.base`` still points at OpenNeuro.
+
+Companion to ``patch_nemar_source.py``. That script fixes the
+``Dataset.source`` field for nm-prefixed datasets that were mislabeled by
+the pre-PR-#327 ``detect_source()`` bug. Records, however, also encode a
+``storage.base`` (e.g. ``s3://openneuro.org/nm000237``) — and they were
+left untouched by the dataset-document patch.
+
+This script flips ``storage.base`` from ``s3://openneuro.org/<id>`` to
+``s3://nemar/<id>`` (the value the digest pipeline writes today, see
+``STORAGE_CONFIGS`` in ``3_digest.py``) for every record under each
+nm-prefixed dataset. Without this fix, ``EEGDashRaw._raw_uri`` resolves to
+the OpenNeuro mirror and downloads 404 with::
+
+    DataIntegrityError: Primary data file not found on S3:
+    s3://openneuro.org/nm000237/sub-13/.../sub-13_..._eeg.bdf
+
+Usage
+-----
+    # Dry-run (default)
+    python scripts/ingestions/patch_nemar_records_storage.py
+
+    # Apply against prod
+    EEGDASH_API_TOKEN=... python scripts/ingestions/patch_nemar_records_storage.py --apply
+
+    # Restrict to a specific list of dataset IDs
+    python scripts/ingestions/patch_nemar_records_storage.py --ids nm000237 --apply
+
+    # Target a non-prod DB
+    python scripts/ingestions/patch_nemar_records_storage.py --database eegdash_staging --apply
+
+Environment variables
+---------------------
+    EEGDASH_API_URL    API base URL (default: https://data.eegdash.org)
+    EEGDASH_API_TOKEN  Admin token; required when ``--apply`` is set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+from eegdash.http_api_client import get_client
+
+NM_PATTERN = re.compile(r"^nm\d+$")
+WRONG_BASE_PREFIX = "s3://openneuro.org/"
+RIGHT_BASE_PREFIX = "s3://nemar/"
+
+
+def discover_nm_dataset_ids(client, page_size: int = 1000) -> list[str]:
+    """Return every nm-prefixed dataset_id known to the API."""
+    url = f"{client.api_url}/api/{client.database}/datasets"
+    ids: list[str] = []
+    skip = 0
+    while True:
+        resp = client._session.get(
+            url, params={"limit": page_size, "skip": skip}, timeout=60
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        if not data:
+            break
+        ids.extend(
+            d["dataset_id"]
+            for d in data
+            if NM_PATTERN.match(str(d.get("dataset_id", "")))
+        )
+        if len(data) < page_size:
+            break
+        skip += page_size
+    return ids
+
+
+def patch_dataset_records(client, dataset_id: str, apply: bool) -> tuple[int, int]:
+    """Flip ``storage.base`` for one dataset's records.
+
+    Returns ``(matched, modified)``. In dry-run mode ``modified`` is the
+    count of records that *would* change.
+    """
+    wrong_base = f"{WRONG_BASE_PREFIX}{dataset_id}"
+    right_base = f"{RIGHT_BASE_PREFIX}{dataset_id}"
+
+    query = {"dataset": dataset_id, "storage.base": wrong_base}
+
+    if not apply:
+        matched = client.count_documents(query)
+        return matched, matched
+
+    return client.update_many(
+        query,
+        {"storage.base": right_base, "storage.backend": "s3"},
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--database", default="eegdash")
+    parser.add_argument("--api-url", default=None)
+    parser.add_argument(
+        "--ids",
+        nargs="+",
+        default=None,
+        help="Explicit list of nm* dataset IDs (default: auto-discover all nm*)",
+    )
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    if args.apply and not os.getenv("EEGDASH_API_TOKEN"):
+        print(
+            "error: --apply requires EEGDASH_API_TOKEN in the environment",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = get_client(api_url=args.api_url, database=args.database)
+    print(f"Database: {args.database}")
+    print(f"API URL:  {client.api_url}")
+    print(f"Mode:     {'APPLY' if args.apply else 'DRY-RUN'}\n")
+
+    if args.ids:
+        ids = [i for i in args.ids if NM_PATTERN.match(i)]
+        skipped = [i for i in args.ids if not NM_PATTERN.match(i)]
+        for s in skipped:
+            print(f"skip (not nm-prefixed): {s}")
+    else:
+        print("Discovering nm* datasets...")
+        ids = discover_nm_dataset_ids(client)
+        print(f"  {len(ids)} nm* datasets found\n")
+
+    total_matched = 0
+    total_modified = 0
+    affected: list[tuple[str, int, int]] = []
+
+    for dsid in ids:
+        try:
+            matched, modified = patch_dataset_records(client, dsid, apply=args.apply)
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR {dsid}: {e}", file=sys.stderr)
+            continue
+
+        if matched:
+            affected.append((dsid, matched, modified))
+            total_matched += matched
+            total_modified += modified
+            verb = "would update" if not args.apply else "updated"
+            print(f"{dsid}: {verb} {modified}/{matched} records")
+
+    print("\n" + "=" * 50)
+    print("Summary")
+    print("=" * 50)
+    print(f"Datasets affected: {len(affected)}")
+    print(f"Records matched:   {total_matched}")
+    print(f"Records modified:  {total_modified}")
+
+    if not args.apply and total_matched:
+        print("\nRe-run with --apply (and EEGDASH_API_TOKEN) to commit changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingestions/patch_nemar_records_storage.py
+++ b/scripts/ingestions/patch_nemar_records_storage.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python3
-"""Patch NEMAR records whose ``storage.base`` still points at OpenNeuro.
+"""Patch NEMAR records whose ``storage`` is misrouted or stale.
 
 Companion to ``patch_nemar_source.py``. That script fixes the
 ``Dataset.source`` field for nm-prefixed datasets that were mislabeled by
 the pre-PR-#327 ``detect_source()`` bug. Records, however, also encode a
-``storage.base`` (e.g. ``s3://openneuro.org/nm000237``) — and they were
-left untouched by the dataset-document patch.
+``storage.base`` (e.g. ``s3://openneuro.org/nm000237``) and a
+``storage.backend`` — and the prior fixes left both fields stale for some
+cohorts of records.
 
-This script flips ``storage.base`` from ``s3://openneuro.org/<id>`` to
-``s3://nemar/<id>`` (the value the digest pipeline writes today, see
-``STORAGE_CONFIGS`` in ``3_digest.py``) for every record under each
-nm-prefixed dataset. Without this fix, ``EEGDashRaw._raw_uri`` resolves to
-the OpenNeuro mirror and downloads 404 with::
+This script applies two independent corrections:
 
-    DataIntegrityError: Primary data file not found on S3:
-    s3://openneuro.org/nm000237/sub-13/.../sub-13_..._eeg.bdf
+1. **Base** — flip ``storage.base`` from ``s3://openneuro.org/<id>`` to
+   ``s3://nemar/<id>`` for any record that still points at OpenNeuro
+   despite belonging to an ``nm*`` dataset. Without this, the runtime
+   would resolve ``_raw_uri`` to the OpenNeuro mirror and 404.
+2. **Backend** — flip ``storage.backend`` from ``"s3"`` to ``"nemar"`` for
+   any NEMAR record. The runtime now uses ``"nemar"`` as a non-fetchable
+   marker so it can fail loud with actionable guidance (git-annex / nemar
+   CLI / NEMAR API) instead of opaquely failing on a closed S3 bucket.
+   Records carrying ``backend="s3"`` would attempt anonymous S3 fetches
+   that always fail because NEMAR's ``s3:ListBucket`` /
+   ``s3:GetObject`` are closed by design.
 
 Usage
 -----
@@ -48,6 +54,8 @@ from eegdash.http_api_client import get_client
 NM_PATTERN = re.compile(r"^nm\d+$")
 WRONG_BASE_PREFIX = "s3://openneuro.org/"
 RIGHT_BASE_PREFIX = "s3://nemar/"
+WRONG_BACKEND = "s3"
+RIGHT_BACKEND = "nemar"
 
 
 def discover_nm_dataset_ids(client, page_size: int = 1000) -> list[str]:
@@ -75,24 +83,45 @@ def discover_nm_dataset_ids(client, page_size: int = 1000) -> list[str]:
 
 
 def patch_dataset_records(client, dataset_id: str, apply: bool) -> tuple[int, int]:
-    """Flip ``storage.base`` for one dataset's records.
+    """Apply both the base and backend corrections to one dataset's records.
+
+    Two cohorts are healed:
+
+    * **base + backend** — records where ``storage.base`` still points at
+      ``s3://openneuro.org/<id>``. Both ``base`` and ``backend`` get
+      rewritten to the canonical NEMAR values.
+    * **backend only** — records that already have the canonical
+      ``s3://nemar/<id>`` base but stale ``storage.backend = "s3"``. Only
+      ``backend`` is flipped to ``"nemar"``.
 
     Returns ``(matched, modified)``. In dry-run mode ``modified`` is the
-    count of records that *would* change.
+    count of records that *would* change across both phases.
     """
     wrong_base = f"{WRONG_BASE_PREFIX}{dataset_id}"
     right_base = f"{RIGHT_BASE_PREFIX}{dataset_id}"
 
-    query = {"dataset": dataset_id, "storage.base": wrong_base}
+    base_query = {"dataset": dataset_id, "storage.base": wrong_base}
+    backend_query = {
+        "dataset": dataset_id,
+        "storage.base": right_base,
+        "storage.backend": WRONG_BACKEND,
+    }
 
     if not apply:
-        matched = client.count_documents(query)
-        return matched, matched
+        base_matched = client.count_documents(base_query)
+        backend_matched = client.count_documents(backend_query)
+        total = base_matched + backend_matched
+        return total, total
 
-    return client.update_many(
-        query,
-        {"storage.base": right_base, "storage.backend": "s3"},
+    base_matched, base_modified = client.update_many(
+        base_query,
+        {"storage.base": right_base, "storage.backend": RIGHT_BACKEND},
     )
+    backend_matched, backend_modified = client.update_many(
+        backend_query,
+        {"storage.backend": RIGHT_BACKEND},
+    )
+    return base_matched + backend_matched, base_modified + backend_modified
 
 
 def main() -> int:

--- a/tests/unit_tests/dataset/test_source_inference.py
+++ b/tests/unit_tests/dataset/test_source_inference.py
@@ -1,0 +1,88 @@
+"""Tests for the runtime source / storage inference helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from eegdash.dataset._source_inference import (
+    correct_storage_inplace,
+    expected_storage_base,
+    infer_source_from_dataset_id,
+)
+
+
+@pytest.mark.parametrize(
+    "dataset_id, expected",
+    [
+        ("nm000237", "nemar"),
+        ("nm000001", "nemar"),
+        ("ds005505", "openneuro"),
+        ("ds002718", "openneuro"),
+        ("EEG2025r1mini", "nemar"),
+        ("EEGManyLabs_MMN", "gin"),
+        ("totally-custom-id", None),
+        ("", None),
+    ],
+)
+def test_infer_source_from_dataset_id(dataset_id, expected):
+    assert infer_source_from_dataset_id(dataset_id) == expected
+
+
+def test_expected_storage_base_only_resolves_pattern_sources():
+    assert expected_storage_base("nm000237") == "s3://nemar/nm000237"
+    assert expected_storage_base("ds005505") == "s3://openneuro.org/ds005505"
+    # GIN and unknown patterns require extra metadata, so we don't fabricate one.
+    assert expected_storage_base("EEGManyLabs_MMN") is None
+    assert expected_storage_base("totally-custom-id") is None
+
+
+def test_correct_storage_reroutes_misrouted_nemar_record():
+    rec = {
+        "dataset": "nm000237",
+        "storage": {
+            "backend": "s3",
+            "base": "s3://openneuro.org/nm000237",
+            "raw_key": "sub-13/ses-3/eeg/sub-13_ses-3_task-imagery_run-5_eeg.bdf",
+        },
+    }
+    corrected, old = correct_storage_inplace(rec)
+    assert corrected is True
+    assert old == "s3://openneuro.org/nm000237"
+    assert rec["storage"]["base"] == "s3://nemar/nm000237"
+    assert rec["storage"]["backend"] == "s3"
+    # Idempotent: a second call leaves the record untouched.
+    assert correct_storage_inplace(rec) == (False, None)
+
+
+def test_correct_storage_leaves_correct_records_alone():
+    rec = {
+        "dataset": "ds005505",
+        "storage": {"backend": "s3", "base": "s3://openneuro.org/ds005505"},
+    }
+    assert correct_storage_inplace(rec) == (False, None)
+
+
+def test_correct_storage_does_not_touch_unknown_patterns():
+    # We only auto-correct when the dataset_id pattern unambiguously
+    # implies a source — never touch arbitrary IDs.
+    rec = {
+        "dataset": "totally-custom-id",
+        "storage": {"base": "s3://openneuro.org/totally-custom-id"},
+    }
+    assert correct_storage_inplace(rec) == (False, None)
+
+
+def test_correct_storage_skips_user_supplied_buckets():
+    # A user-supplied mirror (not in STORAGE_CONFIGS) must not be silently
+    # rewritten — only known foreign buckets are auto-rerouted.
+    rec = {
+        "dataset": "nm000237",
+        "storage": {"base": "s3://my-private-mirror/nm000237", "backend": "s3"},
+    }
+    assert correct_storage_inplace(rec) == (False, None)
+
+
+def test_correct_storage_handles_missing_storage():
+    # No storage block at all -> no-op (no base to compare against).
+    rec = {"dataset": "nm000237"}
+    assert correct_storage_inplace(rec) == (False, None)

--- a/tests/unit_tests/dataset/test_source_inference.py
+++ b/tests/unit_tests/dataset/test_source_inference.py
@@ -49,8 +49,32 @@ def test_correct_storage_reroutes_misrouted_nemar_record():
     assert corrected is True
     assert old == "s3://openneuro.org/nm000237"
     assert rec["storage"]["base"] == "s3://nemar/nm000237"
-    assert rec["storage"]["backend"] == "s3"
+    # NEMAR records use the dedicated ``"nemar"`` backend tag because
+    # direct S3 fetches against ``s3://nemar/<id>/<bidspath>`` don't work
+    # (filenames are SHA-resolved); the runtime resolver converts BIDS
+    # paths to SHA-keyed objects via the dataset's git-annex pointers.
+    assert rec["storage"]["backend"] == "nemar"
     # Idempotent: a second call leaves the record untouched.
+    assert correct_storage_inplace(rec) == (False, None)
+
+
+def test_correct_storage_fixes_stale_backend_on_canonical_nemar_base():
+    # Records ingested between PR #327 and the nemar-backend split sit in
+    # the DB with the right base but the wrong backend tag. Self-heal
+    # should still fire so the runtime takes the NEMAR resolution path.
+    rec = {
+        "dataset": "nm000237",
+        "storage": {
+            "backend": "s3",
+            "base": "s3://nemar/nm000237",
+            "raw_key": "sub-13/ses-3/eeg/sub-13_ses-3_task-imagery_run-5_eeg.bdf",
+        },
+    }
+    corrected, old = correct_storage_inplace(rec)
+    assert corrected is True
+    assert old is None  # base wasn't rewritten, only backend
+    assert rec["storage"]["base"] == "s3://nemar/nm000237"
+    assert rec["storage"]["backend"] == "nemar"
     assert correct_storage_inplace(rec) == (False, None)
 
 

--- a/tests/unit_tests/test_annex_key_utils.py
+++ b/tests/unit_tests/test_annex_key_utils.py
@@ -21,9 +21,7 @@ def get_annex_file_key():
     return fn
 
 
-_REAL_KEY = (
-    "SHA256E-s121363992--47368a490fb602d7ed40698bcf062fa9ff938b8dd03d5ce25d30a64d11c5dace.set"
-)
+_REAL_KEY = "SHA256E-s121363992--47368a490fb602d7ed40698bcf062fa9ff938b8dd03d5ce25d30a64d11c5dace.set"
 
 
 def test_extracts_key_from_smudged_pointer(tmp_path, get_annex_file_key):

--- a/tests/unit_tests/test_annex_key_utils.py
+++ b/tests/unit_tests/test_annex_key_utils.py
@@ -1,0 +1,71 @@
+"""Tests for the git-annex SHA-key extractor used during NEMAR digestion."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_INGESTIONS_DIR = str(Path(__file__).resolve().parents[2] / "scripts" / "ingestions")
+
+
+@pytest.fixture()
+def get_annex_file_key():
+    """Import ``get_annex_file_key`` from ``scripts/ingestions/_file_utils.py``."""
+    if _INGESTIONS_DIR not in sys.path:
+        sys.path.insert(0, _INGESTIONS_DIR)
+    from _file_utils import get_annex_file_key as fn  # type: ignore
+
+    return fn
+
+
+_REAL_KEY = (
+    "SHA256E-s121363992--47368a490fb602d7ed40698bcf062fa9ff938b8dd03d5ce25d30a64d11c5dace.set"
+)
+
+
+def test_extracts_key_from_smudged_pointer(tmp_path, get_annex_file_key):
+    p = tmp_path / "sub-01_eeg.set"
+    p.write_text(f"/annex/objects/{_REAL_KEY}\n")
+    assert get_annex_file_key(p) == _REAL_KEY
+
+
+def test_extracts_key_from_symlink_target(tmp_path, get_annex_file_key):
+    target_dir = tmp_path / ".git" / "annex" / "objects" / "Vf" / "4X" / _REAL_KEY
+    target_dir.mkdir(parents=True)
+    target_file = target_dir / _REAL_KEY
+    target_file.write_bytes(b"")  # not used, just so the path exists
+
+    pointer = tmp_path / "sub-01_eeg.set"
+    rel_target = os.path.relpath(target_file, pointer.parent)
+    os.symlink(rel_target, pointer)
+
+    assert get_annex_file_key(pointer) == _REAL_KEY
+
+
+def test_returns_none_for_directly_tracked_sidecar(tmp_path, get_annex_file_key):
+    sidecar = tmp_path / "dataset_description.json"
+    sidecar.write_text('{"Name": "Example"}\n')
+    assert get_annex_file_key(sidecar) is None
+
+
+def test_returns_none_for_real_binary_file(tmp_path, get_annex_file_key):
+    binary = tmp_path / "something.bdf"
+    # Larger than the 256B sniff window — must be skipped.
+    binary.write_bytes(b"\x00" * 4096)
+    assert get_annex_file_key(binary) is None
+
+
+def test_returns_none_for_missing_path(tmp_path, get_annex_file_key):
+    assert get_annex_file_key(tmp_path / "does-not-exist") is None
+
+
+def test_rejects_basename_that_is_not_a_full_key(tmp_path, get_annex_file_key):
+    # A pointer that mentions /annex/objects/ but whose basename does not
+    # match the strict SHA-key shape must be rejected — we never want to
+    # forward garbage to S3.
+    p = tmp_path / "broken.set"
+    p.write_text("/annex/objects/garbage-not-a-key.set\n")
+    assert get_annex_file_key(p) is None


### PR DESCRIPTION
## Summary

PR #327 fixed NEMAR source detection going forward, but ~35k records
ingested earlier still carried `storage.base=s3://openneuro.org/<nm-id>`
in Mongo. End-users hit `DataIntegrityError: Primary data file not found
on S3: s3://openneuro.org/nm000237/sub-13/.../sub-13_ses-3_task-imagery_run-5_eeg.bdf`
because `EEGDashRaw` reads `storage.base` verbatim. The records have
since been patched live, but nothing prevented a recurrence.

This adds defense in depth at three layers:

- **Shared inference helper** — `eegdash/dataset/_source_inference.py`
  centralises pattern→source/storage rules that were inlined in
  `3_digest.py`, plus a `correct_storage_inplace(record)` corrector
  that only fires on (a) dataset_ids whose pattern unambiguously
  determines the source, and (b) `storage.base` values matching a
  *known* foreign bucket. User-supplied mirrors are never silently
  rewritten.

- **Runtime self-heal** — `EEGDashDataset._normalize_records` calls
  the corrector on every record from the API. `nm*` records
  mistakenly pointing at OpenNeuro get rerouted in memory, with a
  single info-level log per `(dataset, old, new)`. User `s3_bucket`
  overrides still apply afterwards.

- **Digest guardrails** — `3_digest.py` gains `_reconcile_source`:
  when the manifest source disagrees with the id pattern, the pattern
  wins and a warning prints. `digest_from_manifest` also rejects an
  explicit `manifest["storage_base"]` whose prefix doesn't match the
  resolved source's bucket and rebuilds from `STORAGE_CONFIGS` —
  closing the loophole where `2_clone.py` hardcoded
  `s3://openneuro.org/<id>` for any git-cloned dataset.

Adds `scripts/ingestions/patch_nemar_records_storage.py` — the missing
companion to `patch_nemar_source.py`. The latter explicitly skips
records (\"records have no \`source\` field of their own\") but
records *do* carry `storage.base`, which is exactly what was wrong.

## Already executed (separate from this PR)

- `patch_nemar_records_storage.py --apply` rewrote 34,882 records
  across 139 nm* datasets to `s3://nemar/<id>` (verified zero
  remaining via second discovery pass).
- `patch_nemar_source.py` was already a no-op (dataset documents
  clean).

## Test plan

- [x] `pytest tests/unit_tests/dataset/test_source_inference.py` — 14
      cases covering pattern inference, idempotent self-heal,
      no-op-on-correct/unknown/user-supplied-bucket
- [x] `pytest tests/unit_tests/dataset/test_dataset.py
      tests/unit_tests/dataset/test_base.py` — 174 existing tests
      remain green
- [ ] Live: `NM000237(cache_dir=..., subject="13").datasets[0].raw`
      should now resolve to `s3://nemar/nm000237/...` from the DB
      with no client-side correction needed