### PR TITLE
fix(nemar): make anonymous S3 + GitHub access work end-to-end

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -610,8 +610,14 @@ class EEGDashRaw(RawDataset):
     # BIDS root files not enumerated in dep_keys but expected by mne-bids /
     # braindecode. All are direct-git on NEMAR (excluded from annex).
     _NEMAR_ROOT_METADATA_FILES = (
-        "dataset_description.json", "participants.tsv", "participants.json",
-        "README", "README.md", "CHANGES", "LICENSE", ".bidsignore",
+        "dataset_description.json",
+        "participants.tsv",
+        "participants.json",
+        "README",
+        "README.md",
+        "CHANGES",
+        "LICENSE",
+        ".bidsignore",
     )
 
     def _fetch_nemar_root_metadata(self) -> None:
@@ -628,8 +634,11 @@ class EEGDashRaw(RawDataset):
                 continue
             try:
                 _resolve_one_nemar_entry(
-                    dataset_id=dataset_id, relpath=relname, base=base,
-                    dest=dest, stored_key=annex_keys.get(relname),
+                    dataset_id=dataset_id,
+                    relpath=relname,
+                    base=base,
+                    dest=dest,
+                    stored_key=annex_keys.get(relname),
                     is_required=False,
                 )
             except urllib.error.URLError as e:
@@ -637,7 +646,9 @@ class EEGDashRaw(RawDataset):
                 if not (isinstance(e, urllib.error.HTTPError) and e.code == 404):
                     logger.warning(
                         "Could not fetch NEMAR root metadata %s for %s: %s",
-                        relname, dataset_id, e,
+                        relname,
+                        dataset_id,
+                        e,
                     )
 
     def _download_companion_files(self, filesystem) -> None:

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -597,6 +597,8 @@ class EEGDashRaw(RawDataset):
             # Auto-discover and download companion files (.fdt, .eeg, .vmrk)
             # that may not have been included in dep_keys.
             self._download_companion_files(filesystem)
+            if self._storage_backend == "nemar":
+                self._fetch_nemar_root_metadata()
 
         # CTF MEG .ds directories require internal files (.meg4, .res4, etc.)
         if self.filecache and self.filecache.suffix == ".ds":
@@ -604,6 +606,39 @@ class EEGDashRaw(RawDataset):
 
         # Always set filenames (important for local datasets)
         self.filenames = [self.filecache]
+
+    # BIDS root files not enumerated in dep_keys but expected by mne-bids /
+    # braindecode. All are direct-git on NEMAR (excluded from annex).
+    _NEMAR_ROOT_METADATA_FILES = (
+        "dataset_description.json", "participants.tsv", "participants.json",
+        "README", "README.md", "CHANGES", "LICENSE", ".bidsignore",
+    )
+
+    def _fetch_nemar_root_metadata(self) -> None:
+        storage = self.record.get("storage") or {}
+        dataset_id = self.record.get("dataset", "")
+        base = (storage.get("base") or "").rstrip("/")
+        if not (dataset_id and base and self.bids_root):
+            return
+        self.bids_root.mkdir(parents=True, exist_ok=True)
+        annex_keys = storage.get("annex_keys") or {}
+        for relname in self._NEMAR_ROOT_METADATA_FILES:
+            dest = self.bids_root / relname
+            if dest.exists():
+                continue
+            try:
+                _resolve_one_nemar_entry(
+                    dataset_id=dataset_id, relpath=relname, base=base,
+                    dest=dest, stored_key=annex_keys.get(relname),
+                    is_required=False,
+                )
+            except urllib.error.URLError as e:
+                # 404 = file simply absent; everything else is worth a warning.
+                if not (isinstance(e, urllib.error.HTTPError) and e.code == 404):
+                    logger.warning(
+                        "Could not fetch NEMAR root metadata %s for %s: %s",
+                        relname, dataset_id, e,
+                    )
 
     def _download_companion_files(self, filesystem) -> None:
         """Download companion files for formats that require them.
@@ -613,26 +648,41 @@ class EEGDashRaw(RawDataset):
         ``.vmrk``).  When the ingestion pipeline does not list these in
         ``dep_keys``, they are never fetched.  This method inspects
         ``_COMPANION_FILES`` and attempts to download any missing
-        companions from S3.
+        companions, routed appropriately per backend.
         """
         suffix = self.filecache.suffix.lower()
         companions = _COMPANION_FILES.get(suffix)
         if not companions:
             return
 
-        # Use BIDS-named base URI when the raw URI has a git-annex key,
-        # so companion URIs also resolve to real S3 objects.
-        base_uri = self._raw_uri
-        if _ANNEX_KEY_RE.match(PurePosixPath(self._raw_uri).name):
-            bids_filename = PurePosixPath(self.record["bids_relpath"]).name
-            base_uri = self._raw_uri.rsplit("/", 1)[0] + "/" + bids_filename
+        storage = self.record.get("storage") or {}
+        dep_keys = set(storage.get("dep_keys") or [])
+        raw_relpath = storage.get("raw_key") or self.record.get("bids_relpath") or ""
 
         for ext in companions:
             local_path = self.filecache.with_suffix(ext)
             if local_path.exists():
                 continue
 
-            # Derive S3 URI by replacing the primary file's extension
+            # Skip companions already declared at digest time — they were
+            # resolved through the backend's dep_keys path (success or
+            # legitimate 404). Re-fetching them here either duplicates work
+            # or re-issues the same failing request.
+            companion_relpath = (
+                raw_relpath.rsplit(".", 1)[0] + ext if raw_relpath else ""
+            )
+            if companion_relpath and companion_relpath in dep_keys:
+                continue
+
+            if self._storage_backend == "nemar":
+                self._fetch_nemar_companion(local_path, companion_relpath, filesystem)
+                continue
+
+            # Other backends (OpenNeuro etc.) store under BIDS-named keys.
+            base_uri = self._raw_uri
+            if _ANNEX_KEY_RE.match(PurePosixPath(self._raw_uri).name):
+                bids_filename = PurePosixPath(self.record["bids_relpath"]).name
+                base_uri = self._raw_uri.rsplit("/", 1)[0] + "/" + bids_filename
             companion_uri = base_uri.rsplit(".", 1)[0] + ext
 
             try:
@@ -651,6 +701,48 @@ class EEGDashRaw(RawDataset):
                         base_uri,
                     )
                 continue
+
+    def _fetch_nemar_companion(
+        self, local_path: Path, companion_relpath: str, filesystem
+    ) -> None:
+        """Resolve a NEMAR companion file via the GitHub-annex pointer path.
+
+        The git-annex pointer at ``raw.githubusercontent.com/.../<relpath>``
+        is authoritative for whether the file exists and where its bytes
+        live: a directly-tracked file (typically <100 KB metadata) returns
+        its content inline, an annexed file returns a SHA-keyed pointer
+        that resolves to ``s3://nemar/<id>/objects/<KEY>``. A 404 from
+        GitHub is the genuine "missing" answer (S3 by itself can't tell
+        us, since anonymous ListBucket is denied).
+        """
+        if not companion_relpath:
+            return
+        storage = self.record.get("storage") or {}
+        dataset_id = self.record.get("dataset", "")
+        base = (storage.get("base") or "").rstrip("/")
+        if not (dataset_id and base):
+            return
+        try:
+            companion_uri = _resolve_one_nemar_entry(
+                dataset_id=dataset_id,
+                relpath=companion_relpath,
+                base=base,
+                dest=local_path,
+                stored_key=(storage.get("annex_keys") or {}).get(companion_relpath),
+                is_required=False,
+            )
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            logger.warning(
+                "Companion %s not available on NEMAR for %s: %s",
+                companion_relpath,
+                dataset_id,
+                e,
+            )
+            return
+        if companion_uri:
+            downloader.download_s3_file(
+                companion_uri, local_path, filesystem=filesystem
+            )
 
     def _download_embedded_fdt(self, filesystem) -> None:
         """Download a non-BIDS-named ``.fdt`` referenced inside a ``.set`` header.
@@ -686,7 +778,9 @@ class EEGDashRaw(RawDataset):
         try:
             downloader.download_s3_file(fdt_uri, local_path, filesystem=filesystem)
             logger.info("Downloaded embedded .fdt companion: %s", datfile)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
+            # NEMAR returns 403 (PermissionError) for missing keys when
+            # anonymous ListBucket is denied — see _download_companion_files.
             logger.warning(
                 "Embedded .fdt %s not found on S3 for %s",
                 datfile,

--- a/eegdash/downloader.py
+++ b/eegdash/downloader.py
@@ -226,7 +226,9 @@ def _filesystem_get(
         The local path to the downloaded file.
 
     """
-    filename = Path(s3path).name
+    # Show the BIDS-named local destination, not the SHA-keyed S3 object,
+    # so the progress bar matches what the user expects on disk.
+    filename = Path(filepath).name
     description = f"Downloading {filename}"
 
     # Check if we should use Rich
@@ -260,7 +262,14 @@ def _filesystem_get(
         )
 
     try:
-        filesystem.get(s3path, str(filepath), callback=callback, recursive=True)
+        # NEMAR denies anonymous ListBucket but allows GetObject. Both
+        # ``filesystem.get`` and ``filesystem.get(..., recursive=True)`` call
+        # ``_isdir`` / ``_lsdir`` (ListObjectsV2) before issuing GetObject and
+        # 403 on those buckets. ``get_file`` is the single-object primitive
+        # (HEAD + GET only), and all callers here pass single object URIs —
+        # the CTF directory case in base.py pre-expands via ``filesystem.ls``
+        # into per-file pairs.
+        filesystem.get_file(s3path, str(filepath), callback=callback)
     finally:
         # Ensure callback is closed properly (important for Rich to clean up display)
         if hasattr(callback, "close"):

--- a/tests/unit_tests/hbn/test_windows.py
+++ b/tests/unit_tests/hbn/test_windows.py
@@ -153,7 +153,7 @@ def test_hbn_annotate_trials_gaps(tmp_path):
             ) as _mock_unlink:  # Mock unlink to avoid deleting our test file (optional)
                 with pytest.raises(OSError, match="Incomplete download"):
                     download_s3_file("s3://bucket/key", p)
-                assert mock_fs.get.called
+                assert mock_fs.get_file.called
 
     pass
 

--- a/tests/unit_tests/test_downloader.py
+++ b/tests/unit_tests/test_downloader.py
@@ -272,7 +272,7 @@ def test_download_file_incomplete(tmp_path):
     def mock_get(rpath, lpath, **kwargs):
         Path(lpath).write_text("short")  # Write less than expected
 
-    mock_fs.get = mock_get
+    mock_fs.get_file = mock_get
 
     with pytest.raises(OSError, match="Incomplete download"):
         download_s3_file("s3://bucket/key", local_path, filesystem=mock_fs)
@@ -366,7 +366,7 @@ def test_downloader_download_s3_file_exists_match(tmp_path):
 
     res = downloader.download_s3_file("s3://b/test.txt", f, filesystem=mock_fs)
     assert res == f
-    mock_fs.get.assert_not_called()
+    mock_fs.get_file.assert_not_called()
 
 
 def test_downloader_download_s3_file_incomplete(tmp_path):
@@ -383,11 +383,11 @@ def test_downloader_download_s3_file_incomplete(tmp_path):
     mock_fs = MagicMock()
     mock_fs.info.return_value = {"size": 100}
 
-    # Mock get to recreate file but with wrong size
+    # Mock get_file to recreate file but with wrong size
     def mock_get(s3, local, **kwargs):
         Path(local).write_text("b" * 50)  # only 50 bytes, expected 100
 
-    mock_fs.get.side_effect = mock_get
+    mock_fs.get_file.side_effect = mock_get
 
     with pytest.raises(OSError, match="Incomplete download"):
         downloader.download_s3_file("s3://b/f", f, filesystem=mock_fs)
@@ -409,11 +409,11 @@ def test_downloader_batch_skip_existing(tmp_path):
     # f1 size 1 (matches "a"), f2 size 10 (needs DL)
     mock_fs.info.side_effect = [{"size": 1}, {"size": 10}]
 
-    # For f2, assume 'get' writes the file
+    # For f2, assume 'get_file' writes the file
     def mock_get(s3, local, **kwargs):
         Path(local).write_text("b" * 10)
 
-    mock_fs.get.side_effect = mock_get
+    mock_fs.get_file.side_effect = mock_get
 
     files = [("s3://b/f1", f1), ("s3://b/f2", f2)]
     downloaded = downloader.download_files(
@@ -456,8 +456,8 @@ def test_download_files_skip_existing_check_explicit(tmp_path):
         downloader.download_files(
             [("s3://b/f", dest)], filesystem=mock_fs, skip_existing=True
         )
-        # Should NOT call get
-        mock_fs.get.assert_not_called()
+        # Should NOT call get_file
+        mock_fs.get_file.assert_not_called()
 
 
 def test_rich_callback_methods():
@@ -495,7 +495,7 @@ def test_filesystem_get_with_rich_console(tmp_path):
             mock_rich.return_value.close = MagicMock()
             downloader._filesystem_get(mock_fs, "s3://b/f", dest, size=100)
             mock_rich.assert_called_once()
-            mock_fs.get.assert_called_once()
+            mock_fs.get_file.assert_called_once()
 
 
 def test_filesystem_get_rich_exception_fallback(tmp_path):


### PR DESCRIPTION
## Summary

eegdash 0.7.0's NEMAR pipeline never actually downloads data anonymously: `s3fs.get(..., recursive=True)` triggers `ListObjectsV2` to probe `_isdir` before issuing the GET, and NEMAR's bucket denies anonymous `ListBucket`. `GetObject` on the SHA-keyed object IS public (verified with `aws s3 cp --no-sign-request s3://nemar/nm000131/objects/SHA256E-...`), so the fix is to stop probing and just GET.

Three additional NEMAR-specific gaps fixed in the same pass:

1. The companion-file fallback constructs BIDS-named S3 URIs (`s3://nemar/<id>/objects/sub-..._eeg.fdt`); those keys haven't existed since the v0.6.3 SHA-key migration, so every NEMAR `.set` failed with `PermissionError`.
2. Anonymous GET on a missing NEMAR key returns 403, not 404 — the legacy fallback only caught `FileNotFoundError`.
3. Root-level BIDS metadata (`dataset_description.json`, `participants.tsv`, `participants.json`, `README.md`, `.bidsignore`, …) is never enumerated in `dep_keys` and so was never downloaded, leaving the cache without a spec-compliant BIDS root.

## Changes

- **`eegdash/downloader.py`**
  - `_filesystem_get` now calls `filesystem.get_file(...)` (single-object HEAD + GET) instead of `filesystem.get(..., recursive=True)`.
  - Progress-bar label is derived from the local destination path so users see `sub-..._eeg.set`, not `SHA256E-s121363992--47368a4...set`.

- **`eegdash/dataset/base.py`**
  - `_download_companion_files`: skip companions already present in `dep_keys` (resolved at digest time, success or genuine 404). For NEMAR, route remaining companions through `_resolve_one_nemar_entry` (GitHub-pointer-first); other backends keep the existing BIDS-named-S3 path.
  - `_download_embedded_fdt`: also catch `PermissionError` (NEMAR's "missing key" answer).
  - New `_fetch_nemar_root_metadata` populates the BIDS root from the GitHub mirror once per recording (no-op if already cached). Pulls `dataset_description.json`, `participants.{tsv,json}`, `README*`, `CHANGES`, `LICENSE`, `.bidsignore`.

## Test plan

- [x] `NM000131` sub-4 with `Parallel(n_jobs=-1)(delayed(lambda d: d.raw)(d) for d in ds.datasets)` — both runs load (31 ch, 1000 Hz, ~16 min each).
- [x] BIDS root populated after load: `dataset_description.json` (Wang2021 SSVEP, BIDSVersion 1.9.0), `participants.tsv`, `participants.json`, `README.md`.
- [x] No regression on `DS002718` sub-002 (OpenNeuro): 74 ch, 250 Hz loads end-to-end.
- [x] Progress bar shows `sub-4_ses-0_task-ssvep_run-1_eeg.set`, file written to that BIDS path on disk.
- [ ] CI green