### PR TITLE
chore(registry): quiet canonical-alias collision logs + sync uv.lock

### DIFF
--- a/eegdash/dataset/registry.py
+++ b/eegdash/dataset/registry.py
@@ -229,6 +229,7 @@ def register_openneuro_datasets(
     reserved_names: set[str] = set(namespace.keys())
 
     taken_aliases: set[str] = set()
+    collision_count = 0
 
     for dataset_id, row_series in rows:
         class_name = dataset_id.upper()
@@ -256,7 +257,12 @@ def register_openneuro_datasets(
                 or alias in taken_aliases
                 or alias in reserved_names
             ):
-                logger.warning(
+                # Canonical aliases routinely overlap across dataset variants
+                # (e.g. several BNCI2015 entries). Surface the detail at DEBUG
+                # and emit a single aggregate count at INFO so the import-time
+                # log stays quiet by default.
+                collision_count += 1
+                logger.debug(
                     "Skipping canonical_name %r for dataset %s: name already "
                     "registered or reserved in the target namespace.",
                     alias,
@@ -309,6 +315,15 @@ def register_openneuro_datasets(
             registered[alias] = cls
             if add_to_all and isinstance(ns_all, list) and alias not in ns_all:
                 ns_all.append(alias)
+
+    if collision_count:
+        logger.info(
+            "Skipped %d canonical_name alias%s already registered or reserved "
+            "(enable DEBUG logging on %s for per-dataset details).",
+            collision_count,
+            "" if collision_count == 1 else "es",
+            __name__,
+        )
 
     return registered
 

--- a/tests/unit_tests/dataset/test_registry.py
+++ b/tests/unit_tests/dataset/test_registry.py
@@ -564,7 +564,9 @@ def test_canonical_name_reserved_names_skipped(
 ):
     seed_obj = object()
     ns = {seed: seed_obj} if seed else {}
-    with caplog.at_level(logging.WARNING, logger="eegdash.dataset.registry"):
+    # Per-collision message lives at DEBUG (alias overlaps are routine);
+    # an aggregate INFO summary surfaces the count to operators.
+    with caplog.at_level(logging.DEBUG, logger="eegdash.dataset.registry"):
         _register(tmp_path, rows, namespace=ns)
 
     if winner_ds is None:
@@ -574,6 +576,9 @@ def test_canonical_name_reserved_names_skipped(
     assert any(
         "already registered" in r.message or "reserved" in r.message
         for r in caplog.records
+    )
+    assert any(
+        r.levelno == logging.INFO and "Skipped" in r.message for r in caplog.records
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -936,6 +936,7 @@ all = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-gallery" },
+    { name = "sphinx-markdown-builder" },
     { name = "sphinx-sitemap" },
     { name = "sphinxext-opengraph" },
     { name = "tenacity" },
@@ -967,6 +968,7 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-gallery" },
+    { name = "sphinx-markdown-builder" },
     { name = "sphinx-sitemap" },
     { name = "sphinxext-opengraph" },
 ]
@@ -1022,6 +1024,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'" },
     { name = "sphinx-design", marker = "extra == 'docs'" },
     { name = "sphinx-gallery", marker = "extra == 'docs'" },
+    { name = "sphinx-markdown-builder", marker = "extra == 'docs'" },
     { name = "sphinx-sitemap", marker = "extra == 'docs'" },
     { name = "sphinxext-opengraph", marker = "extra == 'docs'" },
     { name = "tenacity", marker = "extra == 'digestion'" },
@@ -3839,6 +3842,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- In `register_openneuro_datasets`, demote the per-collision `canonical_name` warnings to `DEBUG` and emit a single aggregate `INFO` line at the end with the total count. Canonical aliases routinely overlap across dataset variants (e.g. several `BNCI2015*` entries), so the old `WARNING`-per-collision spam was noisy on every import.
- Update `tests/unit_tests/dataset/test_registry.py::test_canonical_name_reserved_names_skipped` to capture at `DEBUG` and additionally assert the new aggregate `INFO` summary is emitted.
- Sync `uv.lock` to record `sphinx-markdown-builder`, which is already declared in `pyproject.toml` under the `docs` extra but was missing from the lockfile.

No behavior change in the registered datasets — only logging verbosity.

## Test plan

- [ ] `pytest tests/unit_tests/dataset/test_registry.py::test_canonical_name_reserved_names_skipped`
- [ ] Import `eegdash.dataset` at default log level (`WARNING`) and confirm no per-collision noise; switch logger `eegdash.dataset.registry` to `DEBUG` and confirm per-collision detail is still available.
- [ ] `uv sync --extra docs` resolves cleanly and pulls `sphinx-markdown-builder`.