### PR TITLE
feat(nemar): inline sidecars at digest time, eliminate runtime GitHub fetches

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -30,7 +30,7 @@ from braindecode.datasets.base import RawDataset
 from .. import downloader
 from ..const import MODALITY_ALIASES
 from ..logging import logger
-from ..schemas import validate_record
+from ..schemas import NEMAR_ROOT_METADATA_FILES, validate_record
 from ._source_inference import correct_storage_inplace
 from .bids_dataset import _COMPANION_FILES
 from .exceptions import DataIntegrityError, StorageAccessError
@@ -277,41 +277,56 @@ def _resolve_nemar_pointer(dataset_id: str, relpath: str) -> tuple[str | None, b
     return None, raw
 
 
+def _nemar_fast_paths(storage: dict, relpath: str) -> tuple[str | None, str | None]:
+    """Return ``(annex SHA key, inline sidecar text)`` for *relpath*.
+
+    Either or both may be ``None``. They are mutually exclusive by
+    schema invariant; ``_resolve_one_nemar_entry`` prefers the SHA key
+    when both are present.
+    """
+    return (
+        (storage.get("annex_keys") or {}).get(relpath),
+        (storage.get("sidecar_inline") or {}).get(relpath),
+    )
+
+
 def _resolve_nemar_uris(
     record: dict, raw_dest: Path, dep_keys: list[str], dep_dests: list[Path]
 ) -> tuple[str | None, list[str]]:
     """Resolve SHA-keyed S3 URIs for a NEMAR record.
 
-    Direct-git sidecars are written to disk as a side effect and excluded
-    from the returned URI list. When ``storage.annex_keys[<relpath>]`` is
-    populated at digest time we use it and skip the GitHub round-trip.
+    Per-entry resolution is delegated to ``_resolve_one_nemar_entry``
+    which honors the digest-time fast paths.
     """
     storage = record.get("storage") or {}
     base = (storage.get("base") or "").rstrip("/")
     raw_key = storage.get("raw_key", "")
     dataset_id = record.get("dataset", "")
-    stored_annex_keys: dict[str, str] = storage.get("annex_keys") or {}
     if not (base and raw_key and dataset_id):
         return None, []
 
+    stored_key, stored_sidecar = _nemar_fast_paths(storage, raw_key)
     raw_uri = _resolve_one_nemar_entry(
         dataset_id=dataset_id,
         relpath=raw_key,
         base=base,
         dest=raw_dest,
-        stored_key=stored_annex_keys.get(raw_key),
+        stored_key=stored_key,
+        stored_sidecar=stored_sidecar,
         is_required=True,
     )
 
     dep_uris: list[str] = []
     for dep_key, dep_dest in zip(dep_keys, dep_dests, strict=False):
+        dep_stored_key, dep_stored_sidecar = _nemar_fast_paths(storage, dep_key)
         try:
             uri = _resolve_one_nemar_entry(
                 dataset_id=dataset_id,
                 relpath=dep_key,
                 base=base,
                 dest=dep_dest,
-                stored_key=stored_annex_keys.get(dep_key),
+                stored_key=dep_stored_key,
+                stored_sidecar=dep_stored_sidecar,
                 is_required=False,
             )
         except (urllib.error.HTTPError, urllib.error.URLError) as e:
@@ -337,16 +352,30 @@ def _resolve_one_nemar_entry(
     base: str,
     dest: Path,
     stored_key: str | None,
+    stored_sidecar: str | None,
     is_required: bool,
 ) -> str | None:
     """Return the S3 URI for one entry, or ``None`` if it was inlined.
 
-    When ``stored_key`` is provided (digest-time fast path) we trust it
-    and skip the GitHub raw fetch entirely. Otherwise we fall back to
-    the pointer-resolution path.
+    Two digest-time fast paths take precedence over the GitHub fetch:
+    ``stored_key`` (annex SHA key) yields the SHA-addressed S3 URI
+    directly; ``stored_sidecar`` (inline UTF-8 bytes) is written to disk
+    and we return ``None`` to signal "no remote URI needed". Both fast
+    paths are populated only at digest time and are never set together
+    for the same relpath. When neither is present we fall back to the
+    original ``_resolve_nemar_pointer`` GitHub-raw path.
     """
     if stored_key:
         return f"{base}/objects/{stored_key}"
+
+    if stored_sidecar is not None:
+        if not dest.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            # Atomic write so concurrent loaders never see a partial file.
+            tmp = dest.with_suffix(dest.suffix + ".tmp")
+            tmp.write_text(stored_sidecar, encoding="utf-8", newline="")
+            tmp.replace(dest)
+        return None
 
     try:
         annex_key, payload = _resolve_nemar_pointer(dataset_id, relpath)
@@ -609,16 +638,8 @@ class EEGDashRaw(RawDataset):
 
     # BIDS root files not enumerated in dep_keys but expected by mne-bids /
     # braindecode. All are direct-git on NEMAR (excluded from annex).
-    _NEMAR_ROOT_METADATA_FILES = (
-        "dataset_description.json",
-        "participants.tsv",
-        "participants.json",
-        "README",
-        "README.md",
-        "CHANGES",
-        "LICENSE",
-        ".bidsignore",
-    )
+    # Source of truth lives in eegdash.schemas to keep digest + runtime aligned.
+    _NEMAR_ROOT_METADATA_FILES = NEMAR_ROOT_METADATA_FILES
 
     def _fetch_nemar_root_metadata(self) -> None:
         storage = self.record.get("storage") or {}
@@ -627,18 +648,30 @@ class EEGDashRaw(RawDataset):
         if not (dataset_id and base and self.bids_root):
             return
         self.bids_root.mkdir(parents=True, exist_ok=True)
-        annex_keys = storage.get("annex_keys") or {}
-        for relname in self._NEMAR_ROOT_METADATA_FILES:
+        # If the digest enriched this record (sidecar_inline non-empty),
+        # trust the inlined apex map as authoritative: skip GitHub probes
+        # for files not present in it. Legacy un-enriched records keep
+        # the original full-iteration GitHub-fallback behavior.
+        sidecar_inline = storage.get("sidecar_inline") or {}
+        if sidecar_inline:
+            candidates = tuple(
+                n for n in self._NEMAR_ROOT_METADATA_FILES if n in sidecar_inline
+            )
+        else:
+            candidates = self._NEMAR_ROOT_METADATA_FILES
+        for relname in candidates:
             dest = self.bids_root / relname
             if dest.exists():
                 continue
+            stored_key, stored_sidecar = _nemar_fast_paths(storage, relname)
             try:
                 _resolve_one_nemar_entry(
                     dataset_id=dataset_id,
                     relpath=relname,
                     base=base,
                     dest=dest,
-                    stored_key=annex_keys.get(relname),
+                    stored_key=stored_key,
+                    stored_sidecar=stored_sidecar,
                     is_required=False,
                 )
             except urllib.error.URLError as e:
@@ -733,13 +766,15 @@ class EEGDashRaw(RawDataset):
         base = (storage.get("base") or "").rstrip("/")
         if not (dataset_id and base):
             return
+        stored_key, stored_sidecar = _nemar_fast_paths(storage, companion_relpath)
         try:
             companion_uri = _resolve_one_nemar_entry(
                 dataset_id=dataset_id,
                 relpath=companion_relpath,
                 base=base,
                 dest=local_path,
-                stored_key=(storage.get("annex_keys") or {}).get(companion_relpath),
+                stored_key=stored_key,
+                stored_sidecar=stored_sidecar,
                 is_required=False,
             )
         except (urllib.error.HTTPError, urllib.error.URLError) as e:

--- a/eegdash/schemas.py
+++ b/eegdash/schemas.py
@@ -69,7 +69,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -112,6 +112,14 @@ class StorageModel(BaseModel):
     raw_key: str = Field(min_length=1, description="Relative path key to the raw file")
     dep_keys: list[str] = Field(
         default_factory=list, description="List of dependency file keys"
+    )
+    annex_keys: dict[str, str] | None = Field(
+        default=None,
+        description="Sparse map relpath -> SHA-key (NEMAR digest fast path).",
+    )
+    sidecar_inline: dict[str, str] | None = Field(
+        default=None,
+        description="Sparse map relpath -> UTF-8 text (NEMAR digest fast path).",
     )
 
 
@@ -759,6 +767,16 @@ class Storage(TypedDict):
         Path relative to `base` to reach the file.
     dep_keys : list[str]
         Paths relative to `base` for sidecar files (e.g., .json, .vhdr).
+    annex_keys : dict[str, str], optional
+        Sparse map ``relpath -> SHA-key`` populated at digest time for
+        NEMAR records so the runtime can build the SHA-addressed S3 URI
+        directly without a GitHub-pointer round-trip. Mutually exclusive
+        with ``sidecar_inline`` for any given relpath.
+    sidecar_inline : dict[str, str], optional
+        Sparse map ``relpath -> UTF-8 text`` populated at digest time
+        for small git-tracked NEMAR sidecars (TSV/JSON/README) so the
+        runtime can write them directly to disk without a GitHub fetch.
+        Mutually exclusive with ``annex_keys`` for any given relpath.
 
     """
 
@@ -766,6 +784,8 @@ class Storage(TypedDict):
     base: str
     raw_key: str
     dep_keys: list[str]
+    annex_keys: NotRequired[dict[str, str]]
+    sidecar_inline: NotRequired[dict[str, str]]
 
 
 class Entities(TypedDict, total=False):
@@ -963,6 +983,28 @@ def _sanitize_run_for_mne(value: Any) -> str | None:
     return None
 
 
+# Headroom under MongoDB's 16 MB BSON document limit for the inline
+# sidecar payload, leaving ~4 MB for the rest of the record.
+_MAX_INLINE_TOTAL_BYTES = 12 * 1024 * 1024
+
+
+# BIDS apex files that aren't in dep_keys but mne-bids / braindecode
+# still expect to find on disk. The NEMAR digest pipeline inlines these
+# into each record's storage.sidecar_inline, and the runtime reads them
+# back via _fetch_nemar_root_metadata. Source of truth shared with
+# eegdash/dataset/base.py:_NEMAR_ROOT_METADATA_FILES.
+NEMAR_ROOT_METADATA_FILES: tuple[str, ...] = (
+    "dataset_description.json",
+    "participants.tsv",
+    "participants.json",
+    "README",
+    "README.md",
+    "CHANGES",
+    "LICENSE",
+    ".bidsignore",
+)
+
+
 def create_record(
     *,
     dataset: str,
@@ -984,6 +1026,7 @@ def create_record(
     ntimes: int | None = None,
     digested_at: str | None = None,
     annex_keys: dict[str, str] | None = None,
+    sidecar_inline: dict[str, str] | None = None,
 ) -> Record:
     """Create an EEGDash record.
 
@@ -1059,9 +1102,31 @@ def create_record(
         "raw_key": bids_relpath,
         "dep_keys": dep_keys,
     }
-    # Sparse map (relpath → SHA-key) — annex-managed files only.
+    if annex_keys and sidecar_inline:
+        # Mutually exclusive: a single relpath is either annex-managed
+        # (binary on S3) or directly committed to git (text inline),
+        # never both. Surface the violation at write time.
+        overlap = annex_keys.keys() & sidecar_inline.keys()
+        if overlap:
+            raise ValueError(
+                f"annex_keys and sidecar_inline overlap on {sorted(overlap)} "
+                f"for dataset={dataset!r}; each relpath must be in at most one map"
+            )
     if annex_keys:
         storage_block["annex_keys"] = dict(annex_keys)
+    if sidecar_inline:
+        # Headroom under MongoDB's 16 MB BSON document limit, leaving
+        # room for the rest of the record (entities, ch_names, etc.).
+        total_inline_bytes = sum(
+            len(v.encode("utf-8")) for v in sidecar_inline.values()
+        )
+        if total_inline_bytes > _MAX_INLINE_TOTAL_BYTES:
+            raise ValueError(
+                f"sidecar_inline payload for dataset={dataset!r} is "
+                f"{total_inline_bytes} bytes (> {_MAX_INLINE_TOTAL_BYTES}); "
+                "drop oversized entries and let the runtime fetch them on demand"
+            )
+        storage_block["sidecar_inline"] = dict(sidecar_inline)
 
     return Record(
         dataset=dataset,

--- a/scripts/ingestions/3_digest.py
+++ b/scripts/ingestions/3_digest.py
@@ -41,7 +41,11 @@ from _constants import (
     MODALITY_DETECTION_TARGETS,
     NEURO_MODALITIES,
 )
-from _file_utils import get_annex_file_key, get_annex_file_size
+from _file_utils import (
+    get_annex_file_key,
+    get_annex_file_size,
+    read_inline_sidecar,
+)
 from _fingerprint import fingerprint_from_files, fingerprint_from_manifest
 from _mef3_parser import parse_mef3_metadata
 from _montage import extract_layout
@@ -52,7 +56,12 @@ from tqdm import tqdm
 
 from eegdash.dataset.bids_dataset import _COMPANION_FILES, EEGBIDSDataset
 from eegdash.dataset.io import _repair_participants_tsv_ids
-from eegdash.schemas import Storage, create_dataset, create_record
+from eegdash.schemas import (
+    NEMAR_ROOT_METADATA_FILES,
+    Storage,
+    create_dataset,
+    create_record,
+)
 
 # Avoid numba cache issues on CI by setting cache dir before MNE-BIDS import
 os.environ.setdefault("NUMBA_CACHE_DIR", str(Path(".cache") / "numba"))
@@ -833,6 +842,7 @@ def extract_record(
     dataset_id: str,
     source: str,
     digested_at: str,
+    apex_sidecar_inline: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Extract Record metadata for a single BIDS file.
 
@@ -1241,18 +1251,45 @@ def extract_record(
                 bids_relpath,
             )
 
-    # Stored at digest time so the runtime can skip the GitHub-raw
-    # round-trip when fetching SHA-keyed objects from the NEMAR bucket.
+    # NEMAR fast-path enrichment for the runtime; see Storage TypedDict
+    # in eegdash/schemas.py for the contract.
+    #
+    # Apex BIDS files (participants.tsv, dataset_description.json, README,
+    # …) live once per dataset but mne-bids/braindecode expects them on
+    # disk per recording. We get them via the caller-provided
+    # apex_sidecar_inline (computed once per dataset; see digest_dataset)
+    # rather than re-reading from disk per record. They're stored on every
+    # record so each load is self-contained, at the cost of duplicated
+    # bytes in MongoDB.
+    #
+    # TODO(scale): two known sources of byte duplication in MongoDB:
+    #   (1) session-level sidecars (events.json shared across runs in a
+    #       session) — multi-KB × N runs in same session;
+    #   (2) apex sidecars (dataset_description.json, README, etc.)
+    #       duplicated across every record in a dataset.
+    # The structurally-correct fix is to move both classes into a per-
+    # dataset side-collection (`nemar_dataset_sidecars` keyed by
+    # (dataset_id, relpath)) referenced by record. Trigger to revisit:
+    # >100 MB inline payload for a single dataset, OR an HBN/M3CV-style
+    # ingest with a >500 KB participants.tsv.
     annex_keys: dict[str, str] = {}
+    sidecar_inline: dict[str, str] = dict(apex_sidecar_inline or {})
     if source == "nemar":
         bids_root_path = bids_dataset.bidsdir  # already a Path
         raw_annex_key = get_annex_file_key(Path(bids_file))
         if raw_annex_key:
             annex_keys[bids_relpath] = raw_annex_key
         for dep in dep_keys:
-            dep_annex_key = get_annex_file_key(bids_root_path / dep)
+            dep_path = bids_root_path / dep
+            dep_annex_key = get_annex_file_key(dep_path)
             if dep_annex_key:
                 annex_keys[dep] = dep_annex_key
+                continue
+            if dep in sidecar_inline:
+                continue
+            inline = read_inline_sidecar(dep_path)
+            if inline is not None:
+                sidecar_inline[dep] = inline
 
     # Create record using the schema
     record = create_record(
@@ -1275,6 +1312,7 @@ def extract_record(
         ntimes=ntimes,
         digested_at=digested_at,
         annex_keys=annex_keys or None,
+        sidecar_inline=sidecar_inline or None,
     )
 
     # Restore participant_tsv metadata if available
@@ -2436,6 +2474,18 @@ def digest_dataset(
     errors = []
     montages: dict[str, dict[str, Any]] = {}
 
+    # NEMAR-only: read apex BIDS files once per dataset and reuse the
+    # decoded text across every record (Python str is immutable so the
+    # values are shared by reference). Cuts ~N × len(NEMAR_ROOT_METADATA_FILES)
+    # stat+read+decode calls per dataset.
+    apex_sidecar_inline: dict[str, str] = {}
+    if source == "nemar":
+        bids_root_path = bids_dataset.bidsdir
+        for root_name in NEMAR_ROOT_METADATA_FILES:
+            inline = read_inline_sidecar(bids_root_path / root_name)
+            if inline is not None:
+                apex_sidecar_inline[root_name] = inline
+
     for bids_file in files:
         # Filter out non-neuro data files (sidecars, etc.)
         if not is_neuro_data_file(str(bids_file)):
@@ -2443,7 +2493,12 @@ def digest_dataset(
 
         try:
             record = extract_record(
-                bids_dataset, bids_file, dataset_id, source, digested_at
+                bids_dataset,
+                bids_file,
+                dataset_id,
+                source,
+                digested_at,
+                apex_sidecar_inline=apex_sidecar_inline,
             )
             # Skip records for split FIF files with missing continuations
             if any(

--- a/scripts/ingestions/_file_utils.py
+++ b/scripts/ingestions/_file_utils.py
@@ -9,6 +9,7 @@ Uses fsspec for unified filesystem access where possible.
 """
 
 import json
+import logging
 import os
 import re
 import struct
@@ -19,6 +20,8 @@ from pathlib import Path
 from urllib.parse import unquote, urljoin, urlparse
 
 from _http import HTTPStatusError, RequestError, request_response
+
+logger = logging.getLogger(__name__)
 
 
 def _fetch_scidb_path(
@@ -614,6 +617,77 @@ def get_annex_file_key(path: Path) -> str | None:
         return None
     candidate = text.strip().rsplit("/", 1)[-1]
     return candidate if _ANNEX_KEY_BASENAME_RE.match(candidate) else None
+
+
+# Cap chosen to keep inlined sidecars well under MongoDB's 16 MB BSON
+# document limit while still covering the long tail of legitimate
+# events.tsv / participants.tsv files (typical: 1–10 KB; outlier: 1–2 MB).
+_INLINE_SIDECAR_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_INLINE_SIDECAR_SUFFIXES = (".tsv", ".json", ".md", ".txt")
+_INLINE_SIDECAR_BASENAMES = frozenset({"README", "CHANGES", "LICENSE", ".bidsignore"})
+
+
+def read_inline_sidecar(path: Path) -> str | None:
+    """Return UTF-8 contents of *path* if it's eligible for digest-time inlining.
+
+    Intended **only** for the NEMAR digest pipeline's
+    ``storage.sidecar_inline`` enrichment — not as a general text
+    reader. Returns ``None`` for symlinks (annex pointers in this
+    tree), oversized files, NUL-byte content, or anything outside the
+    allowlist of small text sidecars. Empty files return ``""``.
+
+    Files that don't decode as UTF-8 are intentionally normalized: we
+    try ``latin-1`` then ``windows-1252`` and log a warning. BIDS spec
+    mandates UTF-8 for sidecars, so non-UTF-8 inputs are pre-existing
+    data quality issues that we silently fix on the way into Mongo.
+
+    Note: callers in the digest pipeline are expected to filter out
+    annex-managed files (via ``get_annex_file_key``) before invoking
+    this; we don't re-check here. The basename allowlist below mirrors
+    the apex-file enumeration ``NEMAR_ROOT_METADATA_FILES`` in
+    ``eegdash/schemas.py`` — keep them aligned when adding entries.
+    See also ``BIDS_ROOT_FILES``/``BIDS_REQUIRED_FILES`` in this module
+    and ``_bids.py`` for the case-folded matching used at fetch time.
+    """
+    if not path.is_file() or path.is_symlink():
+        return None
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None
+    if size > _INLINE_SIDECAR_MAX_BYTES:
+        return None
+
+    if (
+        path.suffix.lower() not in _INLINE_SIDECAR_SUFFIXES
+        and path.name not in _INLINE_SIDECAR_BASENAMES
+    ):
+        return None
+
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if b"\x00" in data:
+        return None
+    if not data:
+        return ""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        for enc in ("latin-1", "windows-1252"):
+            try:
+                decoded = data.decode(enc)
+            except UnicodeDecodeError:
+                continue
+            logger.warning(
+                "Inlining %s via %s fallback (file is not valid UTF-8); "
+                "BIDS spec mandates UTF-8 — consider fixing upstream.",
+                path,
+                enc,
+            )
+            return decoded
+        return None
 
 
 def get_annex_file_size(path: Path) -> int:


### PR DESCRIPTION
## Summary

NEMAR records previously required ~5 GitHub-raw fetches per recording load (per-recording sidecars + apex BIDS metadata). When the GitHub repo for a dataset is missing (catalog-only datasets pre-Aug-2026), the runtime raised `StorageAccessError`. When the repo exists, the network cost was load-bearing on every record load, and silent 404 probes for absent apex files added recurring waste on every load.

This PR inlines small text sidecars into the digest record so the runtime never touches GitHub for an enriched record. The bytes-heavy raw binaries continue to come from anonymous S3 GET via the existing SHA-keyed annex path.

## Changes

- **`scripts/ingestions/_file_utils.py`**: new `read_inline_sidecar()` helper. UTF-8 with latin-1 / windows-1252 fallback (logged), 5 MB per-file cap, rejects annex pointers / NUL bytes / oversized / non-text suffixes. Returns `""` for empty files so legitimate "no events" sidecars inline.
- **`scripts/ingestions/3_digest.py`**: NEMAR enrichment extended. Per-recording `dep_keys` go to `annex_keys` (SHA from `get_annex_file_key`) or `sidecar_inline` (text from `read_inline_sidecar`). Apex BIDS files (`NEMAR_ROOT_METADATA_FILES`) are read once per dataset and shared by reference across records — avoids N×stat+read+decode per dataset.
- **`eegdash/schemas.py`**: `Storage` TypedDict / `StorageModel` add `annex_keys` + `sidecar_inline` (`NotRequired`). `create_record` validates mutex invariant (no relpath in both maps) and per-record inline payload cap (12 MB; headroom under MongoDB's 16 MB BSON limit). `NEMAR_ROOT_METADATA_FILES` lifted to module level so digest + runtime stay aligned.
- **`eegdash/dataset/base.py`**: `_resolve_one_nemar_entry` gains a `stored_sidecar` fast path with atomic write (tempfile + replace, `newline=""` preserved). `_nemar_fast_paths(storage, relpath)` dedupes 3 call sites. `_fetch_nemar_root_metadata` trusts `sidecar_inline` as authoritative when populated — skips GitHub probes for apex files genuinely missing from a dataset.

## Validation

| | Before | After |
|---|---|---|
| Per-recording sidecars (4 files) | ~4 GitHub fetches per record load | 0 |
| Apex BIDS metadata (present) | ~4 GH fetches on first load per dataset | 0 |
| Apex BIDS metadata (absent on dataset) | ~4 silent 404 probes per record load | 0 |
| Raw `.edf`/`.bdf` | 1 anonymous S3 GET via SHA | 1 (unchanged) |
| **Total per record load** | ~8 GH calls + 1 S3 | **1 S3** |

**Stress test on 29 NEMAR datasets (11,430 records) on a 4-core laptop:**
- Full digest: **34.5 s wall-clock**
- Coverage: 100% `annex_keys` + 100% `sidecar_inline` populated
- Mutex violations: **0**
- Total inline payload: 774 MB across all 29 datasets
- Runtime roundtrip on `nm000113`: **1 anonymous S3 GET, 0 GitHub fetches**, valid `mne.io.Raw` produced (instrumented with mock that raises on `_fetch_nemar_pointer`)

Skipped dataset: `nm000238` (SparrKULee KU Leuven speech) — uses `.apr/.apx/.npy` formats that EEGDash's BIDS reader doesn't recognize. Pre-existing limitation, not regressed by this PR.

## Known follow-ups (TODO commented)

The structural fix for byte duplication is to move apex sidecars to a per-dataset side-collection (e.g. `nemar_dataset_sidecars` keyed by `(dataset_id, relpath)`). Trigger to revisit: >100 MB inline payload for a single dataset OR an HBN/M3CV-style ingest with a >500 KB `participants.tsv`. Today the largest observed is `nm000103` at ~108 KB/record.

## Test plan

- [x] All 4 files parse cleanly post-`ruff format`
- [x] Pre-commit (ruff, codespell, blacken-docs) passes
- [x] Local digest on `nm000113` produces 45 records with full enrichment, 0 mutex violations
- [x] Local digest on `nm000311` produces 213 records with full enrichment, 0 mutex violations  
- [x] Local digest on all 29 GH-hosted NEMAR datasets succeeds (11,430 records)
- [x] End-to-end runtime roundtrip on `nm000113` exercises the `.raw` path with a strict no-GitHub mock; `_fetch_nemar_pointer` is never called
- [x] Per-record total-inline-bytes cap enforced and tested via direct `create_record` call
- [ ] Unit tests (suggested follow-up; mirror `tests/unit_tests/test_annex_key_utils.py` shape)

## Backwards compatibility

The patch is purely additive in the schema and runtime. Records ingested before this PR have empty `annex_keys` and empty `sidecar_inline` — runtime falls back to the original `_resolve_nemar_pointer` GitHub-raw path exactly as today. No data migration required.