### PR TITLE
fix(dataset): make EEGDashRaw repr work + clarify NEMAR private-blob errors

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -99,6 +99,42 @@ _SPLIT_FIF_MISSING_RE = re.compile(
 _SPLIT_ENTITY_RE = re.compile(r"_split-(?P<num>\d+)(?=_)")
 _SPLIT_PART_RE = re.compile(r"-(?P<num>\d+)(?=\.fif$)", re.IGNORECASE)
 
+# `mne.create_info` rejects unknown channel types (e.g. ``ieeg``, ``fnirs``,
+# ``meg``); BIDS ``datatype`` doesn't always overlap. The lazy
+# :meth:`EEGDashRaw._make_mne_info` falls back to ``misc`` for the rest.
+_MNE_CHANNEL_TYPES = frozenset(
+    {
+        "eeg",
+        "seeg",
+        "dbs",
+        "ecog",
+        "eog",
+        "emg",
+        "ecg",
+        "resp",
+        "bio",
+        "misc",
+        "stim",
+        "exci",
+        "syst",
+        "ias",
+        "gof",
+        "dipole",
+        "chpi",
+        "fnirs_cw_amplitude",
+        "fnirs_fd_ac_amplitude",
+        "fnirs_fd_phase",
+        "fnirs_od",
+        "hbo",
+        "hbr",
+        "csd",
+        "temperature",
+        "gsr",
+        "eyegaze",
+        "pupil",
+    }
+)
+
 
 def _clamp_negative_annotation_durations(raw: BaseRaw) -> None:
     """Clamp any negative annotation durations to zero on a loaded Raw.
@@ -623,17 +659,11 @@ class EEGDashRaw(RawDataset):
                         issues=[f"Missing S3 file: {self._raw_uri}"],
                     )
             except PermissionError as exc:
-                # NEMAR returns HTTP 403 (rendered as PermissionError by
-                # s3fs) for two reasons that look identical from the
-                # outside: ListBucket is denied for everyone, and
-                # GetObject is denied when the blob simply isn't on the
-                # public bucket yet. The first is fine here (we don't
-                # list — we GET a known key). The second is what users
-                # hit on private-repo NEMAR datasets where the binary
-                # hasn't been published on S3 yet (only the git-annex
-                # pointer lives on GitHub). Surface it as a clear
-                # DataIntegrityError instead of a raw AccessDenied so
-                # the cause is unambiguous.
+                # NEMAR S3 returns 403 on GetObject when the blob isn't on
+                # the public bucket yet — common for private-repo datasets
+                # whose git-annex pointer lives on GitHub but whose binary
+                # NEMAR hasn't mirrored. Re-raise with a message that names
+                # the cause instead of leaking the raw AccessDenied.
                 if self._storage_backend == "nemar":
                     raise DataIntegrityError(
                         message=(
@@ -641,8 +671,7 @@ class EEGDashRaw(RawDataset):
                             "to public S3 (only metadata + sidecars are available). "
                             "This is common for datasets whose GitHub repository is "
                             "still private; the data will become accessible once "
-                            "NEMAR mirrors the blob to "
-                            f"{self._raw_uri}."
+                            f"NEMAR mirrors the blob to {self._raw_uri}."
                         ),
                         record=self.record,
                         issues=[
@@ -1923,23 +1952,24 @@ class EEGDashRaw(RawDataset):
 
         Once :attr:`raw` has been materialized this returns ``raw.info``.
         Before that, we build a minimal :class:`mne.Info` from the record
-        metadata so that :meth:`braindecode.datasets.RawDataset._build_repr`
-        and any other consumer of ``info`` can run without forcing a download.
+        metadata so callers (including :meth:`braindecode.datasets.RawDataset._build_repr`)
+        don't have to force a download.
         """
         if self._raw is not None:
             return self._raw.info
         import mne
 
-        record = self.record
-        ch_names = list(record.get("channel_names") or [])
-        if not ch_names:
-            nchans = int(record.get("nchans") or 0)
-            ch_names = [f"ch{i}" for i in range(nchans)] or ["ch0"]
-        sfreq = float(record.get("sampling_frequency") or 1.0)
-        modality = (record.get("recording_modality") or ["misc"])[0]
-        ch_type = modality.lower() if modality else "misc"
-        ch_types = [ch_type] * len(ch_names)
-        return mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+        ch_names = list(self.record.get("channel_names") or []) or [
+            f"ch{i}" for i in range(int(self.record.get("nchans") or 1))
+        ]
+        ch_type = (self.record.get("datatype") or "misc").lower()
+        if ch_type not in _MNE_CHANNEL_TYPES:
+            ch_type = "misc"
+        return mne.create_info(
+            ch_names=ch_names,
+            sfreq=float(self.record.get("sampling_frequency") or 1.0),
+            ch_types=[ch_type] * len(ch_names),
+        )
 
     def _build_repr(self):
         """Render a :class:`braindecode._ReprBuilder` from record metadata.
@@ -1956,11 +1986,9 @@ class EEGDashRaw(RawDataset):
         record = self.record
         n_ch = int(record.get("nchans") or len(record.get("channel_names") or []) or 0)
         sfreq = float(record.get("sampling_frequency") or 0.0)
-        type_str = (record.get("recording_modality") or ["?"])[0].upper()
+        type_str = (record.get("datatype") or "?").upper()
         n_times = int(record.get("ntimes") or 0)
         duration = float(record.get("duration") or (n_times / sfreq if sfreq else 0.0))
-        if n_times == 0 and duration and sfreq:
-            n_times = int(duration * sfreq)
         b = _ReprBuilder(type(self).__name__)
         b.add_header(f"{n_ch} ch ({type_str})", "Channels", f"{n_ch} ({type_str})")
         b.add_header(f"{sfreq:.1f} Hz", "Sfreq", f"{sfreq:.1f} Hz")

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -622,6 +622,35 @@ class EEGDashRaw(RawDataset):
                         record=self.record,
                         issues=[f"Missing S3 file: {self._raw_uri}"],
                     )
+            except PermissionError as exc:
+                # NEMAR returns HTTP 403 (rendered as PermissionError by
+                # s3fs) for two reasons that look identical from the
+                # outside: ListBucket is denied for everyone, and
+                # GetObject is denied when the blob simply isn't on the
+                # public bucket yet. The first is fine here (we don't
+                # list — we GET a known key). The second is what users
+                # hit on private-repo NEMAR datasets where the binary
+                # hasn't been published on S3 yet (only the git-annex
+                # pointer lives on GitHub). Surface it as a clear
+                # DataIntegrityError instead of a raw AccessDenied so
+                # the cause is unambiguous.
+                if self._storage_backend == "nemar":
+                    raise DataIntegrityError(
+                        message=(
+                            "NEMAR has not yet published this recording's binary "
+                            "to public S3 (only metadata + sidecars are available). "
+                            "This is common for datasets whose GitHub repository is "
+                            "still private; the data will become accessible once "
+                            "NEMAR mirrors the blob to "
+                            f"{self._raw_uri}."
+                        ),
+                        record=self.record,
+                        issues=[
+                            f"S3 GetObject denied: {self._raw_uri}",
+                            f"Underlying error: {exc}",
+                        ],
+                    ) from exc
+                raise
 
             # Auto-discover and download companion files (.fdt, .eeg, .vmrk)
             # that may not have been included in dep_keys.

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -1889,6 +1889,63 @@ class EEGDashRaw(RawDataset):
             # Clean up lock file
             lock_path.unlink(missing_ok=True)
 
+    def _make_mne_info(self):
+        """Return :class:`mne.Info` for the recording without loading the data.
+
+        Once :attr:`raw` has been materialized this returns ``raw.info``.
+        Before that, we build a minimal :class:`mne.Info` from the record
+        metadata so that :meth:`braindecode.datasets.RawDataset._build_repr`
+        and any other consumer of ``info`` can run without forcing a download.
+        """
+        if self._raw is not None:
+            return self._raw.info
+        import mne
+
+        record = self.record
+        ch_names = list(record.get("channel_names") or [])
+        if not ch_names:
+            nchans = int(record.get("nchans") or 0)
+            ch_names = [f"ch{i}" for i in range(nchans)] or ["ch0"]
+        sfreq = float(record.get("sampling_frequency") or 1.0)
+        modality = (record.get("recording_modality") or ["misc"])[0]
+        ch_type = modality.lower() if modality else "misc"
+        ch_types = [ch_type] * len(ch_names)
+        return mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+
+    def _build_repr(self):
+        """Render a :class:`braindecode._ReprBuilder` from record metadata.
+
+        The parent ``RawDataset._build_repr`` reads ``self._zarr_data.shape[1]``
+        when ``self._raw`` is ``None``; that path is for zarr-backed datasets
+        only. EEGDashRaw is lazy on a remote object instead, so we read the
+        same headers (channels, sfreq, samples) directly from the record.
+        """
+        if self._raw is not None:
+            return super()._build_repr()
+        from braindecode.datasets.base import _ReprBuilder
+
+        record = self.record
+        n_ch = int(record.get("nchans") or len(record.get("channel_names") or []) or 0)
+        sfreq = float(record.get("sampling_frequency") or 0.0)
+        type_str = (record.get("recording_modality") or ["?"])[0].upper()
+        n_times = int(record.get("ntimes") or 0)
+        duration = float(record.get("duration") or (n_times / sfreq if sfreq else 0.0))
+        if n_times == 0 and duration and sfreq:
+            n_times = int(duration * sfreq)
+        b = _ReprBuilder(type(self).__name__)
+        b.add_header(f"{n_ch} ch ({type_str})", "Channels", f"{n_ch} ({type_str})")
+        b.add_header(f"{sfreq:.1f} Hz", "Sfreq", f"{sfreq:.1f} Hz")
+        b.add_header(
+            f"{n_times} samples ({duration:.1f} s)",
+            "Samples",
+            f"{n_times} ({duration:.1f} s)",
+        )
+        if self.description is not None:
+            desc_items = ", ".join(f"{k}={v}" for k, v in self.description.items())
+            b.add_row("description", desc_items)
+        b.add_footnote("Data not loaded yet — info derived from record metadata.")
+        return b
+
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""
         if self._skipped:


### PR DESCRIPTION
## Summary

Two related runtime UX fixes for `EEGDashRaw` that the user kept hitting when loading NEMAR datasets:

### 1. `repr(eegdash_raw)` no longer crashes before `.raw` is loaded

```
AttributeError: 'EEGDashRaw' object has no attribute '_info_dict'
```

`braindecode.datasets.RawDataset._build_repr` falls back to
`self._make_mne_info()` (which expects `_info_dict` from the zarr-backed
path) and `self._zarr_data.shape[1]` for `n_times` when `self._raw is None`.
`EEGDashRaw` is lazy on a remote object and populates neither, so the
repr crashed before the user even asked for the data.

This adds the two pieces braindecode is looking for, so its existing
`_ReprBuilder` machinery just works:

- `_make_mne_info` returns a minimal `mne.Info` built from the record
  (channel names/types and sfreq) when `_raw` is unset, and returns
  `_raw.info` otherwise. Anything that wanted `info` before triggering
  a download now keeps working.
- `_build_repr` reuses braindecode's `_ReprBuilder` but pulls `n_ch`,
  `sfreq`, `n_times`, and `duration` from the record instead of the
  parent's zarr-only `else` branch.

Result, before any data is fetched:

```
<EEGDashRaw | 26 ch (EEG) | 500.0 Hz | 187999 samples (376.0 s)>
  description: subject=13, session=4, run=3, task=imagery, ...
  (Data not loaded yet — info derived from record metadata.)
```

### 2. `PermissionError: Access Denied` on private NEMAR datasets is now a clear `DataIntegrityError`

Anonymous `GetObject` on `s3://nemar/<id>/objects/<key>` returns HTTP 403
when the blob hasn't been published yet — typical for datasets whose
GitHub repository is still private (MongoDB has the metadata + inline
sidecars from the digest, but NEMAR hasn't mirrored the actual
recording binary). Previously this surfaced as a raw aiobotocore
`PermissionError: Access Denied` and there was no way to tell whether
it was a missing blob, a missing IAM grant, or a transient outage.

We now catch `PermissionError` on the NEMAR backend specifically and
re-raise as `DataIntegrityError` with a message that names the cause and
the exact key NEMAR still needs to publish:

```
DataIntegrityError: NEMAR has not yet published this recording's
binary to public S3 (only metadata + sidecars are available). This is
common for datasets whose GitHub repository is still private; the data
will become accessible once NEMAR mirrors the blob to
s3://nemar/nm000237/objects/SHA256E-s14682448--32c09fb6e5...bdf.
```

Public NEMAR datasets (where `GetObject` succeeds) are unaffected — the
new handler only fires on 403.

## Test plan

- [x] `repr(NM000113().datasets[0])` works without `.raw` access (lazy
  headers come from MongoDB record metadata)
- [x] After `.raw` is materialized, `repr(...)` falls through to
  `super()._build_repr()` and shows the loaded MNE info
- [x] `_make_mne_info()` on a lazy `EEGDashRaw` returns a usable
  `mne.Info` (correct `sfreq`, `ch_names`, `ch_types`)
- [x] Sparse records (no `nchans` / `sampling_frequency`) degrade
  gracefully to `0 ch / 0.0 Hz / 0 samples` instead of crashing
- [x] `NM000115().datasets[0].raw` (public NEMAR) loads end-to-end
- [x] `NM000237().datasets[0].raw` (private NEMAR, blob not yet on
  public S3) raises `DataIntegrityError` with the new explanatory
  message instead of a raw `PermissionError`
- [x] `ruff lint`, `ruff format`, `codespell`, `blacken-docs`,
  nested-function-check pre-commit hooks pass