### PR TITLE
Fix test warning cleanup and helper imports

### DIFF
--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -2383,7 +2383,9 @@ def _repair_eeglab_fdt(set_path: Path) -> bool:
 
     # --- patch header fields ---
     srate = float(eeg.get("srate", 1.0)) or 1.0
-    repaired = dict(eeg)
+    repaired = {
+        key: value for key, value in dict(eeg).items() if not str(key).startswith("__")
+    }
 
     # Always fix the datfile/data reference to point at the BIDS-named .fdt
     repaired["datfile"] = bids_fdt_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,32 +1,13 @@
+import sys
 from pathlib import Path
 
 import pytest
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from eegdash.paths import get_default_cache_dir
-
-
-def is_bids_dataset_available() -> tuple[bool, str]:
-    """Check if the BIDS test dataset is available and valid.
-
-    Returns a tuple of (is_available, reason).
-    """
-    cache_dir = Path(get_default_cache_dir())
-    path = cache_dir / "ds005509-bdf-mini"
-
-    if not path.exists():
-        return False, f"BIDS dataset not found at {path}"
-
-    # Check for basic BIDS structure (dataset_description.json)
-    if not (path / "dataset_description.json").exists():
-        return False, "Not a valid BIDS dataset (missing dataset_description.json)"
-
-    # Check for at least one data file
-    bdf_files = list(path.rglob("*.bdf"))
-    edf_files = list(path.rglob("*.edf"))
-    if not bdf_files and not edf_files:
-        return False, "No BDF/EDF data files found in dataset"
-
-    return True, ""
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_speed_regression.py
+++ b/tests/e2e/test_speed_regression.py
@@ -14,15 +14,11 @@ Note: This module uses the shared `bids_mini_dataset_path` and `cache_dir` fixtu
 from conftest.py to ensure consistent caching and avoid redundant downloads.
 """
 
-import sys
 import time
-from pathlib import Path
 
 import pytest
 
-# Add parent directory to path for conftest import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from conftest import is_bids_dataset_available
+from tests_support.bids_helpers import is_bids_dataset_available
 
 # Module-level skip if dataset not available
 _available, _reason = is_bids_dataset_available()

--- a/tests/integration/test_benchmarks.py
+++ b/tests/integration/test_benchmarks.py
@@ -14,15 +14,11 @@ Note: This module uses the shared `bids_mini_dataset_path` and `cache_dir` fixtu
 from conftest.py to ensure consistent caching and avoid redundant downloads.
 """
 
-import sys
 import time
-from pathlib import Path
 
 import pytest
 
-# Add parent directory to path for conftest import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from conftest import is_bids_dataset_available
+from tests_support.bids_helpers import is_bids_dataset_available
 
 # Module-level skip if dataset not available
 _available, _reason = is_bids_dataset_available()

--- a/tests/integration/test_model_correctness.py
+++ b/tests/integration/test_model_correctness.py
@@ -29,11 +29,13 @@ def normalize_data(x):
     return x
 
 
+def _slice_dataset_to_numpy(dataset):
+    return np.stack([np.asarray(item) for item in dataset])
+
+
 def test_complete_train(windows_ds):
     """Test the complete training process with the EEG dataset."""
-    label_eye_open_closed = np.array(
-        SliceDataset(windows_ds, idx=1)
-    ).T  # Extract labels (eyes open/closed)
+    label_eye_open_closed = np.asarray(list(SliceDataset(windows_ds, idx=1))).T
 
     # train-test split
     train_idx, valid_idx = train_test_split(
@@ -45,12 +47,10 @@ def test_complete_train(windows_ds):
 
     # Convert the data to tensors
     X_train = SliceDataset(windows_ds, idx=0, indices=train_idx)
-    # Convert list of arrays to torch
-    X_train = torch.FloatTensor(np.array(X_train))
+    X_train = torch.from_numpy(_slice_dataset_to_numpy(X_train)).float()
 
     X_valid = SliceDataset(windows_ds, idx=0, indices=valid_idx)
-    # Convert list of arrays to torch
-    X_valid = torch.FloatTensor(np.array(X_valid))
+    X_valid = torch.from_numpy(_slice_dataset_to_numpy(X_valid)).float()
     # Convert targets to tensor
     y_train = torch.LongTensor(label_eye_open_closed[train_idx])
     y_valid = torch.LongTensor(label_eye_open_closed[valid_idx])

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -1,10 +1,12 @@
 import json
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 from scipy.io import loadmat, savemat
+from scipy.io.matlab import MatWriteWarning
 
 from eegdash.dataset.io import (
     _convert_time_with_numeric_dash,
@@ -30,6 +32,12 @@ from eegdash.dataset.io import (
     _repair_vhdr_missing_markerfile,
     _repair_vhdr_pointers,
 )
+
+
+def _savemat_without_matwritewarning(path: Path, data: dict) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MatWriteWarning)
+        savemat(str(path), data, do_compression=False)
 
 
 def test_convert_time_with_numeric_dash_dd_mm_yyyy():
@@ -836,7 +844,6 @@ def test_repair_events_tsv_mixed_nan_types(tmp_path):
 def _create_minimal_set_fdt(tmp_path, n_channels=3, n_samples=100, sfreq=256.0):
     """Helper: create a minimal .set + .fdt pair for testing."""
     import numpy as np
-    import scipy.io
 
     set_path = tmp_path / "test.set"
     fdt_path = tmp_path / "test.fdt"
@@ -854,7 +861,7 @@ def _create_minimal_set_fdt(tmp_path, n_channels=3, n_samples=100, sfreq=256.0):
         "data": np.array(["test.fdt"]),
     }
 
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
     return set_path, fdt_path, data
 
 
@@ -898,7 +905,6 @@ def test_load_raw_eeglab_fallback_with_bids_channels(tmp_path):
 def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
     """Raises ValueError when no .fdt and no embedded data."""
     import numpy as np
-    import scipy.io
 
     from eegdash.dataset.io import _load_raw_eeglab_fallback
 
@@ -911,7 +917,7 @@ def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
         "datfile": np.array([""]),
         "data": np.array(["test.fdt"]),
     }
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
 
     with pytest.raises(ValueError, match="No data source"):
         _load_raw_eeglab_fallback(set_path)
@@ -920,7 +926,6 @@ def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
 def test_load_raw_eeglab_fallback_size_mismatch_raises(tmp_path):
     """Raises ValueError when .fdt size doesn't match metadata."""
     import numpy as np
-    import scipy.io
 
     from eegdash.dataset.io import _load_raw_eeglab_fallback
 
@@ -937,7 +942,7 @@ def test_load_raw_eeglab_fallback_size_mismatch_raises(tmp_path):
         "datfile": np.array(["test.fdt"]),
         "data": np.array(["test.fdt"]),
     }
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
 
     with pytest.raises(ValueError, match="FDT size mismatch"):
         _load_raw_eeglab_fallback(set_path)
@@ -1107,7 +1112,7 @@ def test_repair_eeglab_fdt_truncated_fdt_repairs(tmp_path):
         "xmax": (pnts_orig - 1) / 250.0,
         "data": "test.fdt",
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
 
     result = _repair_eeglab_fdt(set_path)
     assert result is True
@@ -1141,7 +1146,7 @@ def test_eeglab_load_first_eeg_returns_eeg_when_valid_set(tmp_path):
 
     set_path = tmp_path / "valid.set"
     eeg = {"nbchan": 2, "pnts": 10, "srate": 250.0, "data": "valid.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     out = _eeglab_load_first_eeg(set_path)
     assert out is not None
     assert int(out["nbchan"]) == 2 and int(out["pnts"]) == 10
@@ -1158,7 +1163,7 @@ def test_repair_eeglab_fdt_no_fdt_file_returns_false(tmp_path):
 
     set_path = tmp_path / "nofdt.set"
     eeg = {"nbchan": 2, "pnts": 10, "srate": 250.0, "data": "nofdt.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1171,7 +1176,7 @@ def test_repair_eeglab_fdt_not_truncated_returns_false(tmp_path):
     nbchan, pnts = 2, 10
     fdt_path.write_bytes(b"\x00" * (nbchan * pnts * 4))
     eeg = {"nbchan": nbchan, "pnts": pnts, "srate": 250.0, "data": "full.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1183,7 +1188,7 @@ def test_repair_eeglab_fdt_fdt_too_small_returns_false(tmp_path):
     fdt_path = tmp_path / "tiny.fdt"
     fdt_path.write_bytes(b"\x00" * 4)  # 4 bytes, 2 channels -> 0 samples
     eeg = {"nbchan": 2, "pnts": 100, "srate": 250.0, "data": "tiny.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1208,7 +1213,7 @@ def test_load_raw_eeglab_alleeg_success(tmp_path):
         "data": "raw.fdt",
         "chanlocs": [{"labels": "Fp1"}, {"labels": "Fp2"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan
@@ -1231,7 +1236,7 @@ def test_load_raw_eeglab_alleeg_truncated_fdt_pads(tmp_path):
         "data": "trunc.fdt",
         "chanlocs": [{"labels": "A"}, {"labels": "B"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan
@@ -1252,7 +1257,7 @@ def test_load_raw_eeglab_alleeg_inline_data(tmp_path):
         "data": data,
         "chanlocs": [{"labels": "Fp1"}, {"labels": "Fp2"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan

--- a/tests/unit_tests/features/feature_bank/test_spectral.py
+++ b/tests/unit_tests/features/feature_bank/test_spectral.py
@@ -75,7 +75,7 @@ def test_spectral_more():
     # lines 27-34: skip_outlier_noise
     # Use longer signal for better frequency resolution to satisfy frequency bands
     # f0 = 2 * fs / n. For fs=100, n=200 -> f0=1.0. Delta starts at 1.0
-    data = np.random.randn(2, 4, 300)
+    data = np.random.randn(2, 4, 512)
     metadata = {"info": {"sfreq": 100.0}}
     f, p = spectral_preprocessor(data, _metadata=metadata, fs=100.0)
 

--- a/tests_support/__init__.py
+++ b/tests_support/__init__.py
@@ -1,0 +1,1 @@
+"""Test-only support helpers."""

--- a/tests_support/bids_helpers.py
+++ b/tests_support/bids_helpers.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from eegdash.paths import get_default_cache_dir
+
+
+def is_bids_dataset_available() -> tuple[bool, str]:
+    """Check if the shared mini BIDS dataset is available and valid."""
+    cache_dir = Path(get_default_cache_dir())
+    path = cache_dir / "ds005509-bdf-mini"
+
+    if not path.exists():
+        return False, f"BIDS dataset not found at {path}"
+
+    if not (path / "dataset_description.json").exists():
+        return False, "Not a valid BIDS dataset (missing dataset_description.json)"
+
+    bdf_files = list(path.rglob("*.bdf"))
+    edf_files = list(path.rglob("*.edf"))
+    if not bdf_files and not edf_files:
+        return False, "No BDF/EDF data files found in dataset"
+
+    return True, ""


### PR DESCRIPTION
## Summary
- move the shared BIDS dataset availability helper into an importable test support module
- remove the NumPy conversion deprecation in model correctness tests and avoid the Welch warning in spectral coverage
- silence EEGLAB fixture `MatWriteWarning` noise and strip reserved MAT metadata keys during repair

## Testing
- `pytest -q tests/integration/test_model_correctness.py tests/unit_tests/features/feature_bank/test_spectral.py tests/unit_tests/dataset/test_io.py`
- `pytest -p no:sugar -q --ignore=tests/unit_tests/features/feature_bank/test_csp.py`

## Notes
- The full isolated-suite run segfaulted in `tests/unit_tests/features/feature_bank/test_csp.py`, which is unrelated to this change; the branch validates cleanly with that file excluded.