### PR TITLE
test: expand coverage + relocate doi helpers to scripts/citations

### DIFF
--- a/eegdash/features/feature_bank/pick.py
+++ b/eegdash/features/feature_bank/pick.py
@@ -18,6 +18,7 @@ parameter.
 from typing import Iterable, Tuple
 
 import mne
+import numpy as np
 
 from ..base_utils import BivariateIterator, channel_names_to_indices
 from ..decorators import (
@@ -133,7 +134,7 @@ def pick_channel_pairs_preprocessor(
     `numpy.ndarray`.
 
     """
-    assert index or c_index or x_index or y_index
+    assert any(v is not None for v in (index, c_index, x_index, y_index))
     if index is None:
         index = []
     elif isinstance(index, int):
@@ -168,7 +169,8 @@ def pick_channel_pairs_preprocessor(
     for i in index:
         y[i] = x[i].take(pick_idx, axis=axis)
     for i in c_index:
-        y[i] = x[i].take(list(set(x_it[pick_idx] + y_it[pick_idx])), axis=c_axis)
+        ch_idx = np.unique(np.concatenate((x_it[pick_idx], y_it[pick_idx]))).tolist()
+        y[i] = x[i].take(ch_idx, axis=c_axis)
     for i in x_index:
         y[i] = x[i].take(list(set(x_it[pick_idx])), axis=c_axis)
     for i in y_index:

--- a/scripts/citations/__init__.py
+++ b/scripts/citations/__init__.py
@@ -1,0 +1,1 @@
+"""Citation and DOI utilities for EEGDash datasets."""

--- a/scripts/citations/doi_utils.py
+++ b/scripts/citations/doi_utils.py
@@ -1,0 +1,246 @@
+"""DOI validation and resolution utilities.
+
+Provides helpers for validating DOI format, resolving DOIs via the
+doi.org content-negotiation API, caching results, and comparing
+author lists. Inspired by MOABB's ``test_doi_validation.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import socket
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DOI_REGEX = re.compile(r"^10\.\d{4,}/\S+$")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_CACHE_PATH = _REPO_ROOT / "tests" / "doi_cache.json"
+
+# Delay between consecutive doi.org requests (seconds) to respect rate limits.
+RESOLVE_DELAY: float = 0.15
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+
+def normalize_doi(raw: str | None) -> str | None:
+    """Strip URL prefixes and whitespace from a DOI string.
+
+    Handles forms like ``"doi:10.1234/x"``, ``"https://doi.org/10.1234/x"``,
+    or bare ``"10.1234/x"``.
+
+    Returns *None* when the input is falsy or cannot be cleaned.
+    """
+    if not raw:
+        return None
+    doi = str(raw).strip()
+    # Remove common prefixes
+    for prefix in (
+        "https://doi.org/",
+        "http://doi.org/",
+        "https://dx.doi.org/",
+        "http://dx.doi.org/",
+        "doi:",
+    ):
+        if doi.lower().startswith(prefix):
+            doi = doi[len(prefix) :]
+            break
+    doi = doi.strip()
+    return doi if doi else None
+
+
+def is_valid_doi(doi: str | None) -> bool:
+    """Return *True* if *doi* matches the canonical DOI pattern ``10.XXXX/...``."""
+    if doi is None:
+        return False
+    return bool(DOI_REGEX.match(normalize_doi(doi) or ""))
+
+
+# ---------------------------------------------------------------------------
+# Resolution via doi.org
+# ---------------------------------------------------------------------------
+
+
+def resolve_doi(
+    doi: str,
+    *,
+    timeout: float = 15,
+) -> dict[str, Any] | None:
+    """Resolve a single DOI via doi.org content-negotiation (CSL-JSON).
+
+    Parameters
+    ----------
+    doi : str
+        A normalised DOI (e.g. ``"10.1234/foo"``).
+    timeout : float
+        HTTP timeout in seconds.
+
+    Returns
+    -------
+    dict or None
+        The CSL-JSON metadata dict, or *None* on failure.
+
+    """
+    clean = normalize_doi(doi)
+    if not clean:
+        return None
+
+    url = f"https://doi.org/{clean}"
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/vnd.citationstyles.csl+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+        socket.timeout,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+    ) as exc:
+        logger.warning(
+            "Failed to resolve DOI %s (%s): %s", clean, type(exc).__name__, exc
+        )
+        return None
+
+
+def resolve_doi_cached(
+    doi: str,
+    cache: dict[str, dict[str, Any]],
+    *,
+    timeout: float = 15,
+    delay: float = RESOLVE_DELAY,
+) -> dict[str, Any] | None:
+    """Resolve a DOI, checking *cache* first.
+
+    On a cache miss the result is fetched from doi.org and inserted into
+    *cache* (in-place) so callers can persist it afterwards.
+    """
+    clean = normalize_doi(doi)
+    if not clean:
+        return None
+
+    if clean in cache:
+        return cache[clean]
+
+    time.sleep(delay)
+    result = resolve_doi(clean, timeout=timeout)
+    if result is not None:
+        # Store a compact subset to keep the cache small.
+        cache[clean] = _compact_metadata(result)
+    return cache.get(clean)
+
+
+def _compact_metadata(csl: dict[str, Any]) -> dict[str, Any]:
+    """Keep only the fields we need for validation."""
+    authors = []
+    for a in csl.get("author", []):
+        name = {}
+        if "family" in a:
+            name["family"] = a["family"]
+        if "given" in a:
+            name["given"] = a["given"]
+        if name:
+            authors.append(name)
+
+    issued = csl.get("issued", {})
+    date_parts = issued.get("date-parts", [[]])
+    year = date_parts[0][0] if date_parts and date_parts[0] else None
+
+    return {
+        "title": csl.get("title", ""),
+        "authors": authors,
+        "year": year,
+        "type": csl.get("type", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O
+# ---------------------------------------------------------------------------
+
+
+def load_cache(path: Path | str | None = None) -> dict[str, dict[str, Any]]:
+    """Load the persistent DOI cache from *path* (JSON)."""
+    path = Path(path) if path else _DEFAULT_CACHE_PATH
+    if path.exists():
+        with open(path) as fh:
+            return json.load(fh)
+    return {}
+
+
+def save_cache(
+    cache: dict[str, dict[str, Any]],
+    path: Path | str | None = None,
+) -> None:
+    """Persist *cache* to *path* as pretty-printed JSON."""
+    path = Path(path) if path else _DEFAULT_CACHE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(cache, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Author helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_surnames(authors: list[dict[str, str]]) -> list[str]:
+    """Return lowercased family names from a CSL-JSON author list."""
+    out: list[str] = []
+    for a in authors:
+        family = a.get("family", "").strip()
+        if family:
+            out.append(family.lower())
+    return out
+
+
+def surnames_overlap(
+    authors_a: list[dict[str, str]],
+    authors_b: list[dict[str, str]],
+) -> set[str]:
+    """Return the set of shared family names between two author lists."""
+    return set(extract_surnames(authors_a)) & set(extract_surnames(authors_b))
+
+
+# ---------------------------------------------------------------------------
+# Bulk helpers for dataset CSV
+# ---------------------------------------------------------------------------
+
+
+def load_dataset_dois(csv_path: Path | str | None = None) -> list[tuple[str, str]]:
+    """Load ``(dataset_id, doi)`` pairs from ``dataset_summary.csv``.
+
+    Returns only rows where the DOI column is non-empty.
+    """
+    import csv
+
+    if csv_path is None:
+        csv_path = _REPO_ROOT / "eegdash" / "dataset" / "dataset_summary.csv"
+    csv_path = Path(csv_path)
+    pairs: list[tuple[str, str]] = []
+    with open(csv_path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            raw = row.get("doi", "").strip()
+            if raw:
+                did = row.get("dataset", "").strip()
+                pairs.append((did, raw))
+    return pairs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,30 +5,6 @@ import pytest
 from eegdash.paths import get_default_cache_dir
 
 
-def is_bids_dataset_available() -> tuple[bool, str]:
-    """Check if the BIDS test dataset is available and valid.
-
-    Returns a tuple of (is_available, reason).
-    """
-    cache_dir = Path(get_default_cache_dir())
-    path = cache_dir / "ds005509-bdf-mini"
-
-    if not path.exists():
-        return False, f"BIDS dataset not found at {path}"
-
-    # Check for basic BIDS structure (dataset_description.json)
-    if not (path / "dataset_description.json").exists():
-        return False, "Not a valid BIDS dataset (missing dataset_description.json)"
-
-    # Check for at least one data file
-    bdf_files = list(path.rglob("*.bdf"))
-    edf_files = list(path.rglob("*.edf"))
-    if not bdf_files and not edf_files:
-        return False, "No BDF/EDF data files found in dataset"
-
-    return True, ""
-
-
 @pytest.fixture(scope="session")
 def cache_dir():
     """Provide a shared cache directory for tests that need to cache datasets.

--- a/tests/e2e/test_speed_regression.py
+++ b/tests/e2e/test_speed_regression.py
@@ -14,15 +14,11 @@ Note: This module uses the shared `bids_mini_dataset_path` and `cache_dir` fixtu
 from conftest.py to ensure consistent caching and avoid redundant downloads.
 """
 
-import sys
 import time
-from pathlib import Path
 
 import pytest
 
-# Add parent directory to path for conftest import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from conftest import is_bids_dataset_available
+from tests_support.bids_helpers import is_bids_dataset_available
 
 # Module-level skip if dataset not available
 _available, _reason = is_bids_dataset_available()

--- a/tests/e2e/test_workflow_user_journeys.py
+++ b/tests/e2e/test_workflow_user_journeys.py
@@ -1,0 +1,225 @@
+"""E2E workflow tests for user-visible BIDS catalog journeys."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eegdash.dataset.bids_dataset import EEGBIDSDataset
+
+
+def _write_channels_tsv(path: Path, channels: list[tuple[str, str]]) -> None:
+    lines = ["name\ttype"] + [f"{name}\t{kind}" for name, kind in channels]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _create_synthetic_bids_dataset(tmp_path: Path, scenario: dict) -> Path:
+    dataset_root = tmp_path / scenario["dataset_name"]
+    dataset_root.mkdir()
+
+    (dataset_root / "dataset_description.json").write_text(
+        json.dumps(
+            {
+                "Name": "Synthetic workflow dataset",
+                "BIDSVersion": "1.8.0",
+                "DatasetType": "raw",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    participants_lines = ["participant_id\tgroup"]
+    participants_lines.extend(f"{pid}\tcontrol" for pid in scenario["participants"])
+    (dataset_root / "participants.tsv").write_text(
+        "\n".join(participants_lines) + "\n",
+        encoding="utf-8",
+    )
+
+    for rec in scenario["recordings"]:
+        eeg_dir = dataset_root / f"sub-{rec['subject']}"
+        if rec.get("session") is not None:
+            eeg_dir = eeg_dir / f"ses-{rec['session']}"
+        eeg_dir = eeg_dir / "eeg"
+        eeg_dir.mkdir(parents=True, exist_ok=True)
+
+        stem_parts = [f"sub-{rec['subject']}"]
+        if rec.get("session") is not None:
+            stem_parts.append(f"ses-{rec['session']}")
+        stem_parts.append(f"task-{rec['task']}")
+        stem_parts.append(f"run-{rec['run']}")
+        stem_parts.append("eeg")
+        stem = "_".join(stem_parts)
+
+        (eeg_dir / f"{stem}.edf").write_text("", encoding="utf-8")
+        (eeg_dir / f"{stem}.json").write_text(
+            json.dumps(
+                {
+                    "SamplingFrequency": rec["sfreq"],
+                    "RecordingDuration": rec["duration"],
+                    "EEGChannelCount": sum(
+                        1 for _, kind in rec["channels"] if kind == "EEG"
+                    ),
+                    "EOGChannelCount": sum(
+                        1 for _, kind in rec["channels"] if kind == "EOG"
+                    ),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        if scenario["channels_layout"] == "shared-per-session":
+            channels_path = eeg_dir / "channels.tsv"
+        else:
+            channels_path = eeg_dir / f"{stem.replace('_eeg', '')}_channels.tsv"
+        _write_channels_tsv(channels_path, rec["channels"])
+
+    return dataset_root
+
+
+WORKFLOW_SCENARIOS = [
+    pytest.param(
+        {
+            "dataset_name": "ds-workflow-shared",
+            "channels_layout": "shared-per-session",
+            "participants": ["sub-01", "sub-02"],
+            "recordings": [
+                {
+                    "subject": "01",
+                    "session": "01",
+                    "task": "rest",
+                    "run": "01",
+                    "sfreq": 128.0,
+                    "duration": 10.0,
+                    "channels": [("C3", "EEG"), ("C4", "EEG"), ("EOG1", "EOG")],
+                },
+                {
+                    "subject": "01",
+                    "session": "01",
+                    "task": "rest",
+                    "run": "02",
+                    "sfreq": 128.0,
+                    "duration": 12.0,
+                    "channels": [("C3", "EEG"), ("C4", "EEG"), ("EOG1", "EOG")],
+                },
+                {
+                    "subject": "02",
+                    "session": "01",
+                    "task": "rest",
+                    "run": "01",
+                    "sfreq": 256.0,
+                    "duration": 8.0,
+                    "channels": [("F3", "EEG"), ("F4", "EEG"), ("EOG2", "EOG")],
+                },
+            ],
+            "expected": {
+                "recordings": 3,
+                "subjects": {"01", "02"},
+                "tasks": {"rest"},
+                "orphans": set(),
+            },
+        },
+        id="shared-channels-resting-workflow",
+    ),
+    pytest.param(
+        {
+            "dataset_name": "ds-workflow-perfile",
+            "channels_layout": "per-recording",
+            "participants": ["sub-01", "sub-02", "sub-99"],
+            "recordings": [
+                {
+                    "subject": "01",
+                    "session": None,
+                    "task": "rest",
+                    "run": "01",
+                    "sfreq": 200.0,
+                    "duration": 6.0,
+                    "channels": [("Cz", "EEG"), ("Pz", "EEG")],
+                },
+                {
+                    "subject": "02",
+                    "session": None,
+                    "task": "motor",
+                    "run": "01",
+                    "sfreq": 200.0,
+                    "duration": 6.0,
+                    "channels": [("C3", "EEG"), ("C4", "EEG"), ("EMG1", "EOG")],
+                },
+                {
+                    "subject": "02",
+                    "session": None,
+                    "task": "motor",
+                    "run": "02",
+                    "sfreq": 200.0,
+                    "duration": 4.0,
+                    "channels": [("C3", "EEG"), ("C4", "EEG"), ("Oz", "EEG")],
+                },
+            ],
+            "expected": {
+                "recordings": 3,
+                "subjects": {"01", "02"},
+                "tasks": {"rest", "motor"},
+                "orphans": {"sub-99"},
+            },
+        },
+        id="per-recording-channels-with-orphan-participant",
+    ),
+]
+
+
+@pytest.mark.parametrize("scenario", WORKFLOW_SCENARIOS)
+@pytest.mark.parametrize(
+    "modalities", [None, ["eeg"]], ids=["all-ephy-default", "eeg-only"]
+)
+def test_user_can_build_bids_catalog_and_participant_qc_report(
+    tmp_path: Path, scenario: dict, modalities: list[str] | None
+) -> None:
+    """Validate an end-to-end catalog+QC workflow over realistic BIDS variants."""
+    dataset_root = _create_synthetic_bids_dataset(tmp_path, scenario)
+    dataset = EEGBIDSDataset(
+        data_dir=str(dataset_root),
+        dataset=dataset_root.name,
+        allow_symlinks=False,
+        modalities=modalities,
+    )
+
+    files = sorted(dataset.get_files())
+    assert len(files) == scenario["expected"]["recordings"]
+    assert dataset.check_eeg_dataset()
+
+    catalog = []
+    for file_path in files:
+        labels = dataset.channel_labels(file_path)
+        num_times = dataset.num_times(file_path)
+        rel_path = dataset.get_relative_bidspath(file_path)
+        catalog.append(
+            {
+                "subject": dataset.get_bids_file_attribute("subject", file_path),
+                "task": dataset.get_bids_file_attribute("task", file_path),
+                "run": dataset.get_bids_file_attribute("run", file_path),
+                "n_channels": len(labels),
+                "num_times": num_times,
+                "relative_path": rel_path,
+            }
+        )
+
+    summary = {
+        "recordings": len(catalog),
+        "subjects": {entry["subject"] for entry in catalog},
+        "tasks": {entry["task"] for entry in catalog},
+    }
+    assert summary["recordings"] == scenario["expected"]["recordings"]
+    assert summary["subjects"] == scenario["expected"]["subjects"]
+    assert summary["tasks"] == scenario["expected"]["tasks"]
+    assert all(entry["n_channels"] > 0 for entry in catalog)
+    assert all(entry["num_times"] > 0 for entry in catalog)
+    assert all(
+        entry["relative_path"].startswith(f"{dataset_root.name}/") for entry in catalog
+    )
+
+    participants = dataset.get_all_participants_tsv()
+    assert set(participants) == set(scenario["participants"])
+
+    orphan_participants = dataset.get_orphan_participants()
+    assert set(orphan_participants) == scenario["expected"]["orphans"]

--- a/tests/functional/test_api_contracts.py
+++ b/tests/functional/test_api_contracts.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from eegdash.api import EEGDash
+
+
+def _make_eegdash(monkeypatch: pytest.MonkeyPatch) -> tuple[EEGDash, MagicMock]:
+    client = MagicMock()
+    monkeypatch.setattr("eegdash.api.get_client", lambda *_args, **_kwargs: client)
+    return EEGDash(), client
+
+
+@pytest.mark.parametrize(
+    ("query", "kwargs", "expected_query", "expected_find_kwargs"),
+    [
+        (
+            None,
+            {"dataset": "ds001"},
+            {"dataset": "ds001"},
+            {},
+        ),
+        (
+            None,
+            {"dataset": "ds001", "subject": [" 01 ", None, "02", "", "01"], "limit": 3},
+            {"dataset": "ds001", "subject": {"$in": ["01", "02"]}},
+            {"limit": 3},
+        ),
+        (
+            {"dataset": "ds001"},
+            {"task": "RestingState", "skip": 7},
+            {"$and": [{"dataset": "ds001"}, {"task": "RestingState"}]},
+            {"skip": 7},
+        ),
+    ],
+)
+def test_find_contract_normalizes_and_merges_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    query: dict | None,
+    kwargs: dict,
+    expected_query: dict,
+    expected_find_kwargs: dict,
+):
+    eeg, client = _make_eegdash(monkeypatch)
+    client.find.return_value = [{"id": "row-1"}]
+
+    if query is None:
+        result = eeg.find(**kwargs)
+    else:
+        result = eeg.find(query, **kwargs)
+
+    assert result == [{"id": "row-1"}]
+    client.find.assert_called_once_with(expected_query, **expected_find_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "call_kwargs"),
+    [
+        ("find", {}),
+        ("find_one", {}),
+        ("exists", {}),
+        ("update_field", {"update": {"task": "new-value"}}),
+    ],
+)
+def test_query_required_contract_raises_meaningful_error(
+    monkeypatch: pytest.MonkeyPatch, method_name: str, call_kwargs: dict
+):
+    eeg, client = _make_eegdash(monkeypatch)
+
+    with pytest.raises(ValueError, match="Query required"):
+        getattr(eeg, method_name)(**call_kwargs)
+
+    client.find.assert_not_called()
+    client.find_one.assert_not_called()
+    client.update_many.assert_not_called()
+
+
+def test_count_contract_ignores_pagination_kwargs(monkeypatch: pytest.MonkeyPatch):
+    eeg, client = _make_eegdash(monkeypatch)
+    client.count_documents.return_value = 12
+
+    count = eeg.count(dataset="ds001", limit=2, skip=99)
+
+    assert count == 12
+    client.count_documents.assert_called_once_with({"dataset": "ds001"})
+
+
+@pytest.mark.parametrize(
+    ("records", "expected_count", "client_method"),
+    [
+        ({"dataset": "ds001", "subject": "01"}, 1, "insert_one"),
+        ([{"dataset": "ds001"}, {"dataset": "ds001"}], 2, "insert_many"),
+    ],
+)
+def test_insert_contract_switches_single_vs_bulk(
+    monkeypatch: pytest.MonkeyPatch,
+    records: dict | list[dict],
+    expected_count: int,
+    client_method: str,
+):
+    eeg, client = _make_eegdash(monkeypatch)
+    client.insert_many.return_value = 2
+
+    inserted = eeg.insert(records)
+
+    assert inserted == expected_count
+    assert getattr(client, client_method).call_count == 1

--- a/tests/functional/test_dataset_constructor_contracts.py
+++ b/tests/functional/test_dataset_constructor_contracts.py
@@ -1,0 +1,103 @@
+import shutil
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from eegdash.dataset import EEGDashDataset
+from eegdash.schemas import create_record
+
+
+@pytest.fixture
+def functional_cache_dir(request: pytest.FixtureRequest) -> Path:
+    path = Path.cwd() / ".functional_test_cache" / request.node.name
+    path.mkdir(parents=True, exist_ok=True)
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _synthetic_record(
+    *,
+    dataset: str,
+    extension: str,
+    backend: Literal["s3", "https", "local", "nemar"] = "local",
+    base: str = "s3://source-bucket/dataset",
+) -> dict:
+    return create_record(
+        dataset=dataset,
+        storage_base=base,
+        storage_backend=backend,
+        bids_relpath=f"sub-01/eeg/sub-01_task-rest_eeg{extension}",
+        subject="01",
+        task="rest",
+        sampling_frequency=100.0,
+        ntimes=1000,
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "records", "expected_dataset", "expected_error"),
+    [
+        (
+            None,
+            [_synthetic_record(dataset="ds_from_record", extension=".edf")],
+            "ds_from_record",
+            None,
+        ),
+        (
+            {"dataset": "ds_from_query"},
+            [_synthetic_record(dataset="ds_from_record", extension=".edf")],
+            "ds_from_query",
+            None,
+        ),
+        (None, [], None, "You must provide a 'dataset' argument"),
+        (None, None, None, "You must provide a 'dataset' argument"),
+    ],
+)
+def test_dataset_constructor_dataset_source_contract(
+    functional_cache_dir: Path,
+    query: dict | None,
+    records: list[dict] | None,
+    expected_dataset: str | None,
+    expected_error: str | None,
+):
+    kwargs = {"cache_dir": functional_cache_dir, "query": query, "records": records}
+    if expected_error:
+        with pytest.raises(ValueError, match=expected_error):
+            EEGDashDataset(download=False, **kwargs)
+        return
+
+    ds = EEGDashDataset(download=False, **kwargs)
+    assert ds.query["dataset"] == expected_dataset
+
+
+@pytest.mark.parametrize("initial_backend", ["local", "https"])
+def test_dataset_constructor_filters_extensions_and_overrides_storage(
+    functional_cache_dir: Path, initial_backend: str
+):
+    records = [
+        _synthetic_record(
+            dataset="ds_filter",
+            extension=".edf",
+            backend=initial_backend,
+            base="s3://original-bucket/ds_filter",
+        ),
+        _synthetic_record(
+            dataset="ds_filter",
+            extension=".json",
+            backend=initial_backend,
+            base="s3://original-bucket/ds_filter",
+        ),
+    ]
+
+    ds = EEGDashDataset(
+        cache_dir=functional_cache_dir,
+        records=records,
+        download=False,
+        s3_bucket="s3://override-bucket/custom",
+    )
+
+    assert len(ds.records) == 1
+    assert ds.records[0]["extension"] == ".edf"
+    assert ds.records[0]["storage"]["backend"] == "s3"
+    assert ds.records[0]["storage"]["base"] == "s3://override-bucket/custom"

--- a/tests/integration/test_benchmarks.py
+++ b/tests/integration/test_benchmarks.py
@@ -14,15 +14,11 @@ Note: This module uses the shared `bids_mini_dataset_path` and `cache_dir` fixtu
 from conftest.py to ensure consistent caching and avoid redundant downloads.
 """
 
-import sys
 import time
-from pathlib import Path
 
 import pytest
 
-# Add parent directory to path for conftest import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from conftest import is_bids_dataset_available
+from tests_support.bids_helpers import is_bids_dataset_available
 
 # Module-level skip if dataset not available
 _available, _reason = is_bids_dataset_available()

--- a/tests/integration/test_dataset_interactions.py
+++ b/tests/integration/test_dataset_interactions.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import mne
+import pandas as pd
+import pytest
+
+import eegdash.dataset.dataset as dataset_mod
+from eegdash.dataset import EEGDashDataset
+from eegdash.dataset.exceptions import DataIntegrityError
+from eegdash.features.datasets import FeaturesConcatDataset, FeaturesDataset
+from eegdash.features.serialization import load_features_concat_dataset
+
+
+def _record(dataset: str, run: str, backend: str = "s3") -> dict:
+    bids_relpath = f"sub-01/ses-01/eeg/sub-01_ses-01_task-test_run-{run}_eeg.set"
+    storage_base = f"s3://openneuro.org/{dataset}"
+    storage_raw = bids_relpath
+    if backend == "local":
+        storage_base = f"/local/{dataset}"
+        storage_raw = bids_relpath
+
+    return {
+        "data_name": f"{dataset}_sub-01_ses-01_task-test_run-{run}_eeg.set",
+        "dataset": dataset,
+        "bidspath": f"{dataset}/{bids_relpath}",
+        "bids_relpath": bids_relpath,
+        "subject": "01",
+        "session": "01",
+        "task": "test",
+        "run": run,
+        "modality": "eeg",
+        "suffix": "eeg",
+        "datatype": "eeg",
+        "extension": ".set",
+        "sampling_frequency": 128.0,
+        "nchans": 2,
+        "ntimes": 16,
+        "entities": {
+            "subject": "01",
+            "session": "01",
+            "task": "test",
+            "run": run,
+        },
+        "entities_mne": {
+            "subject": "01",
+            "session": "01",
+            "task": "test",
+            "run": run,
+        },
+        "storage": {
+            "backend": backend,
+            "base": storage_base,
+            "raw_key": storage_raw,
+            "dep_keys": [
+                f"sub-01/ses-01/eeg/sub-01_ses-01_task-test_run-{run}_events.tsv"
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "cached_main,cached_dep,n_jobs,expected_downloaded",
+    [
+        ({0, 1}, {0, 1}, 1, set()),
+        ({0}, {0}, 1, {1}),
+        ({1}, set(), 2, {0, 1}),
+    ],
+    ids=["fully-cached", "one-missing-main", "missing-dependency"],
+)
+def test_download_all_respects_cache_state(
+    tmp_path: Path,
+    cached_main: set[int],
+    cached_dep: set[int],
+    n_jobs: int,
+    expected_downloaded: set[int],
+):
+    records = [_record("ds-cache", "01"), _record("ds-cache", "02")]
+    dataset = EEGDashDataset(cache_dir=tmp_path, dataset="ds-cache", records=records)
+
+    for idx, ds in enumerate(dataset.datasets):
+        all_paths = [ds.filecache, *ds._dep_paths]
+        for p in all_paths:
+            p.unlink(missing_ok=True)
+
+        if idx in cached_main:
+            ds.filecache.parent.mkdir(parents=True, exist_ok=True)
+            ds.filecache.write_text("cached-main")
+
+        if idx in cached_dep:
+            for dep_path in ds._dep_paths:
+                dep_path.parent.mkdir(parents=True, exist_ok=True)
+                dep_path.write_text("cached-dep")
+
+    with (
+        patch.object(
+            dataset_mod.EEGDashRaw, "_download_required_files", autospec=True
+        ) as download_mock,
+        patch.object(dataset, "_download_dataset_files") as globals_mock,
+    ):
+        dataset.download_all(n_jobs=n_jobs)
+
+    called_indices = {
+        i
+        for i, ds in enumerate(dataset.datasets)
+        if any(call.args[0] is ds for call in download_mock.call_args_list)
+    }
+    assert called_indices == expected_downloaded
+    globals_mock.assert_called_once()
+
+
+@pytest.mark.parametrize("on_error", ["warn", "skip"], ids=["warn", "skip"])
+def test_drop_bad_after_integrity_errors(tmp_path: Path, on_error: str):
+    records = [
+        _record("ds-errors", "01", backend="local"),
+        _record("ds-errors", "02", backend="local"),
+    ]
+    dataset = EEGDashDataset(
+        cache_dir=tmp_path,
+        dataset="ds-errors",
+        records=records,
+        on_error=on_error,
+    )
+
+    def _ensure_side_effect(self):
+        if self.record["run"] == "01":
+            self._raw = object()
+            return
+        raise DataIntegrityError(
+            message="synthetic integrity failure",
+            record=self.record,
+            issues=["synthetic"],
+        )
+
+    with patch.object(
+        dataset_mod.EEGDashRaw, "_ensure_raw", autospec=True
+    ) as ensure_mock:
+        ensure_mock.side_effect = _ensure_side_effect
+        raws = [ds.raw for ds in dataset.datasets]
+
+    assert raws[0] is not None
+    assert raws[1] is None
+
+    dropped = dataset.drop_bad()
+    assert len(dropped) == 1
+    assert dropped[0]["run"] == "02"
+    assert len(dataset.datasets) == 1
+    assert dataset.datasets[0].record["run"] == "01"
+
+
+@pytest.mark.parametrize(
+    "ids_to_load,with_raw_info,expected_subjects",
+    [
+        (None, False, {"sub-01", "sub-02"}),
+        ([1], True, {"sub-02"}),
+    ],
+    ids=["load-all-no-raw-info", "subset-with-raw-info"],
+)
+def test_features_roundtrip_metadata_and_kwargs(
+    tmp_path: Path,
+    ids_to_load: list[int] | None,
+    with_raw_info: bool,
+    expected_subjects: set[str],
+):
+    metadata = pd.DataFrame(
+        {
+            "i_window_in_trial": [0, 1],
+            "i_start_in_trial": [0, 8],
+            "i_stop_in_trial": [8, 16],
+            "target": [0, 1],
+        }
+    )
+
+    info = (
+        mne.create_info(["Cz", "Pz"], sfreq=128.0, ch_types="eeg")
+        if with_raw_info
+        else None
+    )
+
+    ds1 = FeaturesDataset(
+        features=pd.DataFrame({"feat_a": [1.0, 2.0], "feat_b": [3.0, 4.0]}),
+        metadata=metadata,
+        description={"subject": "sub-01", "session": "ses-A"},
+        raw_info=info,
+        raw_preproc_kwargs={"resample": 128},
+        features_kwargs={"feature_set": "basic"},
+    )
+    ds2 = FeaturesDataset(
+        features=pd.DataFrame({"feat_a": [5.0, 6.0], "feat_b": [7.0, 8.0]}),
+        metadata=metadata,
+        description={"subject": "sub-02", "session": "ses-B"},
+        raw_info=info,
+        window_kwargs={"window_size": 8},
+        window_preproc_kwargs={"clip": True},
+    )
+
+    concat = FeaturesConcatDataset([ds1, ds2])
+    save_dir = tmp_path / "features"
+    save_dir.mkdir(parents=True, exist_ok=True)
+    concat.save(str(save_dir))
+
+    loaded = load_features_concat_dataset(save_dir, ids_to_load=ids_to_load)
+    loaded_metadata = loaded.get_metadata()
+
+    assert set(loaded_metadata["subject"].unique()) == expected_subjects
+    assert set(loaded_metadata["session"].unique()) == {
+        "ses-A" if s == "sub-01" else "ses-B" for s in expected_subjects
+    }
+
+    loaded_subjects = {ds.description["subject"] for ds in loaded.datasets}
+    assert loaded_subjects == expected_subjects
+
+    if with_raw_info:
+        assert all(ds.raw_info is not None for ds in loaded.datasets)
+    else:
+        assert all(ds.raw_info is None for ds in loaded.datasets)
+
+    first = loaded.datasets[0]
+    assert isinstance(first.metadata, pd.DataFrame)
+    assert "target" in first.metadata.columns
+    assert first.features.shape[1] == 2

--- a/tests/integration/test_model_correctness.py
+++ b/tests/integration/test_model_correctness.py
@@ -29,11 +29,13 @@ def normalize_data(x):
     return x
 
 
+def _slice_dataset_to_numpy(dataset):
+    return np.stack([np.asarray(item) for item in dataset])
+
+
 def test_complete_train(windows_ds):
     """Test the complete training process with the EEG dataset."""
-    label_eye_open_closed = np.array(
-        SliceDataset(windows_ds, idx=1)
-    ).T  # Extract labels (eyes open/closed)
+    label_eye_open_closed = np.asarray(list(SliceDataset(windows_ds, idx=1))).T
 
     # train-test split
     train_idx, valid_idx = train_test_split(
@@ -45,12 +47,10 @@ def test_complete_train(windows_ds):
 
     # Convert the data to tensors
     X_train = SliceDataset(windows_ds, idx=0, indices=train_idx)
-    # Convert list of arrays to torch
-    X_train = torch.FloatTensor(np.array(X_train))
+    X_train = torch.from_numpy(_slice_dataset_to_numpy(X_train)).float()
 
     X_valid = SliceDataset(windows_ds, idx=0, indices=valid_idx)
-    # Convert list of arrays to torch
-    X_valid = torch.FloatTensor(np.array(X_valid))
+    X_valid = torch.from_numpy(_slice_dataset_to_numpy(X_valid)).float()
     # Convert targets to tensor
     y_train = torch.LongTensor(label_eye_open_closed[train_idx])
     y_valid = torch.LongTensor(label_eye_open_closed[valid_idx])

--- a/tests/unit_tests/dataset/test_base_parametrized_helpers.py
+++ b/tests/unit_tests/dataset/test_base_parametrized_helpers.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import sys
+import types
+import urllib.error
+from pathlib import Path
+
+import filelock
+import numpy as np
+import pytest
+
+if "braindecode" not in sys.modules:
+    braindecode = types.ModuleType("braindecode")
+    datasets_mod = types.ModuleType("braindecode.datasets")
+    datasets_base_mod = types.ModuleType("braindecode.datasets.base")
+
+    class _RawDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _BaseConcatDataset:
+        pass
+
+    datasets_mod.BaseConcatDataset = _BaseConcatDataset
+    datasets_base_mod.RawDataset = _RawDataset
+    braindecode.datasets = datasets_mod
+
+    sys.modules["braindecode"] = braindecode
+    sys.modules["braindecode.datasets"] = datasets_mod
+    sys.modules["braindecode.datasets.base"] = datasets_base_mod
+
+from eegdash.dataset.base import (
+    _SPLIT_ENTITY_RE,
+    _SPLIT_PART_RE,
+    _clamp_negative_annotation_durations,
+    _increment_name_match,
+    _iter_split_fif_candidates,
+    _make_tolerant_get_sample_info,
+    _nemar_fast_paths,
+    _noop_filelock,
+    _parse_split_fif_missing_path,
+    _resolve_nemar_pointer,
+    _resolve_nemar_uris,
+    _resolve_one_nemar_entry,
+)
+from eegdash.dataset.exceptions import StorageAccessError
+
+
+class _FakeAnnotations:
+    def __init__(self, durations):
+        self.duration = np.array(durations, dtype=float)
+
+    def __len__(self):
+        return len(self.duration)
+
+
+class _FakeRaw:
+    def __init__(self, durations):
+        self.annotations = None if durations is None else _FakeAnnotations(durations)
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "Split raw file detected but next file '/tmp/run-1_raw.fif' does not exist",
+            Path("/tmp/run-1_raw.fif"),
+        ),
+        (
+            'Split raw file detected but next file "sub-01_split-02_raw.fif" does not exist',
+            Path("sub-01_split-02_raw.fif"),
+        ),
+        ("some unrelated error", None),
+    ],
+    ids=["single-quoted", "double-quoted", "no-match"],
+)
+def test_parse_split_fif_missing_path(message, expected):
+    assert _parse_split_fif_missing_path(message) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "regex", "expected"),
+    [
+        ("sub_split-009_task_raw.fif", _SPLIT_ENTITY_RE, "sub_split-010_task_raw.fif"),
+        ("raw-001.fif", _SPLIT_PART_RE, "raw-002.fif"),
+    ],
+    ids=["entity-split", "part-split"],
+)
+def test_increment_name_match_preserves_padding(name, regex, expected):
+    match = regex.search(name)
+    assert match is not None
+    assert _increment_name_match(name, match) == expected
+
+
+@pytest.mark.parametrize(
+    ("current_key", "current_path", "expected_path", "expected_candidates"),
+    [
+        (
+            "s3/sub-01/raw-01.fif",
+            Path("/cache/raw-01.fif"),
+            Path("/x/raw-02.fif"),
+            [("s3/sub-01/raw-02.fif", Path("/cache/raw-02.fif"))],
+        ),
+        (
+            "ds/sub_split-001_task_raw.fif",
+            Path("/cache/sub_split-001_task_raw.fif"),
+            None,
+            [
+                (
+                    "ds/sub_split-002_task_raw.fif",
+                    Path("/cache/sub_split-002_task_raw.fif"),
+                ),
+                (
+                    "ds/sub_split-001_task_raw-1.fif",
+                    Path("/cache/sub_split-001_task_raw-1.fif"),
+                ),
+            ],
+        ),
+        (
+            "d/sub-01_task_raw.fif",
+            Path("/cache/sub-01_task_raw.fif"),
+            None,
+            [
+                (
+                    "d/sub-01_task_raw-1.fif",
+                    Path("/cache/sub-01_task_raw-1.fif"),
+                ),
+            ],
+        ),
+    ],
+    ids=["expected-path-dedup", "entity-increment", "fallback-dash-1"],
+)
+def test_iter_split_fif_candidates(
+    current_key, current_path, expected_path, expected_candidates
+):
+    assert (
+        _iter_split_fif_candidates(current_key, current_path, expected_path)
+        == expected_candidates
+    )
+
+
+@pytest.mark.parametrize(
+    ("st_size", "res4", "expected", "orig_called"),
+    [
+        (
+            8 + 4 * 10 * 2,
+            {"nsamp": 10, "nchan": 2},
+            {"origin": "orig"},
+            True,
+        ),
+        (
+            8 + 4 * 8 * 2,
+            {"nsamp": 5, "nchan": 2},
+            {
+                "n_samp": 8,
+                "n_samp_tot": 8,
+                "block_size": 8,
+                "res4_nsamp": 8,
+                "n_chan": 2,
+            },
+            False,
+        ),
+    ],
+    ids=["divisible-use-original", "truncated-fallback"],
+)
+def test_make_tolerant_get_sample_info(
+    monkeypatch, st_size, res4, expected, orig_called
+):
+    calls = []
+
+    def _orig(fname, _res4, _system_clock):
+        calls.append(fname)
+        return {"origin": "orig"}
+
+    monkeypatch.setattr("os.path.getsize", lambda _fname: st_size)
+    fn = _make_tolerant_get_sample_info(_orig)
+
+    out = fn("fake.meg4", res4, False)
+
+    assert out == expected
+    assert bool(calls) is orig_called
+
+
+@pytest.mark.parametrize(
+    ("storage", "relpath", "expected"),
+    [
+        (
+            {"annex_keys": {"raw.fif": "SHA1"}, "sidecar_inline": {}},
+            "raw.fif",
+            ("SHA1", None),
+        ),
+        (
+            {"annex_keys": {}, "sidecar_inline": {"events.tsv": "a\tb"}},
+            "events.tsv",
+            (None, "a\tb"),
+        ),
+        ({}, "missing", (None, None)),
+    ],
+)
+def test_nemar_fast_paths(storage, relpath, expected):
+    assert _nemar_fast_paths(storage, relpath) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw_bytes", "expected_annex"),
+    [
+        (
+            b"/annex/objects/MD5E-s10--abcdef1234567890abcdef12345678.fif",
+            "MD5E-s10--abcdef1234567890abcdef12345678.fif",
+        ),
+        (b'{"name": "sidecar"}', None),
+        (b"\xff\xfe\xfd", None),
+    ],
+    ids=["annex-pointer", "inline-json", "non-utf8"],
+)
+def test_resolve_nemar_pointer_variants(monkeypatch, raw_bytes, expected_annex):
+    _resolve_nemar_pointer.cache_clear()
+    monkeypatch.setattr(
+        "eegdash.dataset.base._fetch_nemar_pointer", lambda *_a: raw_bytes
+    )
+
+    annex_key, payload = _resolve_nemar_pointer("dsX", "sub/file")
+
+    assert annex_key == expected_annex
+    assert payload == raw_bytes
+
+
+@pytest.mark.parametrize(
+    (
+        "stored_key",
+        "stored_sidecar",
+        "resolver_result",
+        "expected_uri",
+        "expected_text",
+    ),
+    [
+        ("SHA999", None, None, "s3://nemar/ds/objects/SHA999", None),
+        (None, "col\tval\n1\t2\n", None, None, "col\tval\n1\t2\n"),
+        (None, None, ("SHA001", b"ignored"), "s3://nemar/ds/objects/SHA001", None),
+        (None, None, (None, b"abc"), None, "abc"),
+    ],
+    ids=["fast-annex", "fast-sidecar", "resolved-annex", "resolved-inline-bytes"],
+)
+def test_resolve_one_nemar_entry_success_paths(
+    monkeypatch,
+    tmp_path,
+    stored_key,
+    stored_sidecar,
+    resolver_result,
+    expected_uri,
+    expected_text,
+):
+    dest = tmp_path / "sub" / "sample.tsv"
+
+    def _resolver(_dataset_id, _relpath):
+        if resolver_result is None:
+            raise AssertionError("resolver should not be called")
+        return resolver_result
+
+    monkeypatch.setattr("eegdash.dataset.base._resolve_nemar_pointer", _resolver)
+
+    uri = _resolve_one_nemar_entry(
+        dataset_id="ds",
+        relpath="sub/sample.tsv",
+        base="s3://nemar/ds",
+        dest=dest,
+        stored_key=stored_key,
+        stored_sidecar=stored_sidecar,
+        is_required=True,
+    )
+
+    assert uri == expected_uri
+    if expected_text is None:
+        assert not dest.exists()
+    else:
+        assert dest.read_text(encoding="utf-8") == expected_text
+
+
+@pytest.mark.parametrize("is_required", [True, False], ids=["required", "optional"])
+def test_resolve_one_nemar_entry_url_errors(monkeypatch, tmp_path, is_required):
+    dest = tmp_path / "x" / "sample.tsv"
+    err = urllib.error.URLError("offline")
+
+    monkeypatch.setattr(
+        "eegdash.dataset.base._resolve_nemar_pointer",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(err),
+    )
+
+    if is_required:
+        with pytest.raises(StorageAccessError, match="Could not resolve NEMAR pointer"):
+            _resolve_one_nemar_entry(
+                dataset_id="ds",
+                relpath="sub/sample.tsv",
+                base="s3://nemar/ds",
+                dest=dest,
+                stored_key=None,
+                stored_sidecar=None,
+                is_required=True,
+            )
+    else:
+        with pytest.raises(urllib.error.URLError, match="offline"):
+            _resolve_one_nemar_entry(
+                dataset_id="ds",
+                relpath="sub/sample.tsv",
+                base="s3://nemar/ds",
+                dest=dest,
+                stored_key=None,
+                stored_sidecar=None,
+                is_required=False,
+            )
+
+
+def test_resolve_nemar_uris_with_optional_sidecar_failure(monkeypatch, tmp_path):
+    record = {
+        "dataset": "dsA",
+        "storage": {
+            "base": "s3://nemar/dsA",
+            "raw_key": "sub/raw.fif",
+            "annex_keys": {"sub/raw.fif": "SHA-RAW", "sub/good.tsv": "SHA-GOOD"},
+        },
+    }
+
+    def _resolver(*, dataset_id, relpath, **kwargs):
+        if relpath == "sub/bad.tsv":
+            raise urllib.error.URLError("sidecar missing")
+        if relpath == "sub/good.tsv":
+            return "s3://nemar/dsA/objects/SHA-GOOD"
+        return "s3://nemar/dsA/objects/SHA-RAW"
+
+    monkeypatch.setattr("eegdash.dataset.base._resolve_one_nemar_entry", _resolver)
+
+    raw_uri, dep_uris = _resolve_nemar_uris(
+        record=record,
+        raw_dest=tmp_path / "raw.fif",
+        dep_keys=["sub/bad.tsv", "sub/good.tsv"],
+        dep_dests=[tmp_path / "bad.tsv", tmp_path / "good.tsv"],
+    )
+
+    assert raw_uri == "s3://nemar/dsA/objects/SHA-RAW"
+    assert dep_uris == ["s3://nemar/dsA/objects/SHA-GOOD"]
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {},
+        {"dataset": "ds", "storage": {"base": "s3://x", "raw_key": ""}},
+        {"dataset": "", "storage": {"base": "s3://x", "raw_key": "a"}},
+    ],
+)
+def test_resolve_nemar_uris_missing_required_fields(record, tmp_path):
+    raw_uri, dep_uris = _resolve_nemar_uris(record, tmp_path / "raw.fif", [], [])
+    assert raw_uri is None
+    assert dep_uris == []
+
+
+@pytest.mark.parametrize(
+    "durations",
+    [None, [], [0.1, 2.0], [0.1, -1.5, 0.0]],
+    ids=["no-annotations", "empty", "already-valid", "contains-negative"],
+)
+def test_clamp_negative_annotation_durations(durations):
+    raw = _FakeRaw(durations)
+
+    _clamp_negative_annotation_durations(raw)
+
+    if durations is None:
+        assert raw.annotations is None
+    elif len(durations) == 0:
+        assert raw.annotations.duration.size == 0
+    else:
+        assert np.all(raw.annotations.duration >= 0)
+
+
+@pytest.mark.parametrize("raise_inside", [False, True], ids=["normal", "exceptional"])
+def test_noop_filelock_restores_original(raise_inside):
+    original = filelock.FileLock
+
+    if raise_inside:
+        with pytest.raises(RuntimeError, match="boom"):
+            with _noop_filelock():
+                assert filelock.FileLock.__name__ == "_dummy_filelock"
+                raise RuntimeError("boom")
+    else:
+        with _noop_filelock():
+            assert filelock.FileLock.__name__ == "_dummy_filelock"
+
+    assert filelock.FileLock is original

--- a/tests/unit_tests/dataset/test_dataset_extended.py
+++ b/tests/unit_tests/dataset/test_dataset_extended.py
@@ -225,3 +225,195 @@ def test_eegchallenge_mini_subject_validation(toy_bids_dataset):
                     subject="99",
                     mini=True,
                 )
+
+
+@pytest.mark.parametrize(
+    ("query", "records", "kwargs", "expected_dataset"),
+    [
+        (
+            {"dataset": "ds_query"},
+            [
+                {
+                    "dataset": "ds_query",
+                    "bidspath": "ds_query/a.set",
+                    "bids_relpath": "a.set",
+                }
+            ],
+            {"task": "RestingState"},
+            "ds_query",
+        ),
+        (
+            None,
+            [
+                {
+                    "dataset": "ds_kwargs",
+                    "bidspath": "ds_kwargs/a.set",
+                    "bids_relpath": "a.set",
+                }
+            ],
+            {"dataset": "ds_kwargs", "subject": "01"},
+            "ds_kwargs",
+        ),
+        (
+            {},
+            [
+                {
+                    "dataset": "ds_inferred",
+                    "bidspath": "ds_inferred/a.set",
+                    "bids_relpath": "a.set",
+                }
+            ],
+            {},
+            "ds_inferred",
+        ),
+    ],
+)
+def test_eegdashdataset_constructor_dataset_resolution(
+    tmp_path, query, records, kwargs, expected_dataset
+):
+    with patch("eegdash.dataset.dataset.EEGDashRaw"):
+        ds = EEGDashDataset(
+            cache_dir=tmp_path,
+            query=query,
+            records=records,
+            download=True,
+            **kwargs,
+        )
+    assert ds.query["dataset"] == expected_dataset
+
+
+@pytest.mark.parametrize(
+    "query,records,kwargs",
+    [
+        (None, [], {}),
+        ({}, [{"bidspath": "no-dataset/a.set", "bids_relpath": "a.set"}], {}),
+    ],
+)
+def test_eegdashdataset_constructor_missing_dataset_raises(
+    tmp_path, query, records, kwargs
+):
+    with pytest.raises(ValueError, match="You must provide a 'dataset' argument"):
+        EEGDashDataset(
+            cache_dir=tmp_path,
+            query=query,
+            records=records,
+            download=True,
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("cache_input", ["", None])
+def test_eegdashdataset_constructor_uses_default_cache_dir(tmp_path, cache_input):
+    records = [
+        {"dataset": "ds_cache", "bidspath": "ds_cache/a.set", "bids_relpath": "a.set"}
+    ]
+    with (
+        patch(
+            "eegdash.dataset.dataset.get_default_cache_dir", return_value=str(tmp_path)
+        ),
+        patch("eegdash.dataset.dataset.logger") as mock_logger,
+        patch("eegdash.dataset.dataset.EEGDashRaw"),
+    ):
+        _ = EEGDashDataset(
+            cache_dir=cache_input,
+            records=records,
+            download=True,
+        )
+    assert mock_logger.warning.call_count >= 1
+
+
+def test_eegdashdataset_constructor_creates_missing_cache_dir(tmp_path):
+    missing_cache = tmp_path / "new-cache-dir"
+    records = [
+        {"dataset": "ds_cache", "bidspath": "ds_cache/a.set", "bids_relpath": "a.set"}
+    ]
+    with patch("eegdash.dataset.dataset.EEGDashRaw"):
+        _ = EEGDashDataset(cache_dir=missing_cache, records=records, download=True)
+    assert missing_cache.exists()
+
+
+@pytest.mark.parametrize("on_error", ["raise", "warn", "skip"])
+def test_eegdashdataset_constructor_passes_on_error_to_raw(tmp_path, on_error):
+    records = [
+        {
+            "dataset": "ds_on_error",
+            "bidspath": "ds_on_error/a.set",
+            "bids_relpath": "a.set",
+        }
+    ]
+    with patch("eegdash.dataset.dataset.EEGDashRaw") as mock_raw:
+        _ = EEGDashDataset(
+            cache_dir=tmp_path,
+            records=records,
+            download=True,
+            on_error=on_error,
+        )
+    assert mock_raw.call_args.kwargs["on_error"] == on_error
+
+
+@pytest.mark.parametrize(
+    ("database", "auth_token", "expected_kwargs"),
+    [
+        (None, None, {}),
+        ("eegdash_staging", None, {"database": "eegdash_staging"}),
+        (None, "token-123", {"auth_token": "token-123"}),
+        (
+            "eegdash_staging",
+            "token-123",
+            {"database": "eegdash_staging", "auth_token": "token-123"},
+        ),
+    ],
+)
+def test_eegdashdataset_constructor_builds_eegdash_client_kwargs(
+    tmp_path, database, auth_token, expected_kwargs
+):
+    with (
+        patch("eegdash.api.EEGDash") as mock_eegdash,
+        patch(
+            "eegdash.dataset.dataset.EEGDashDataset._find_datasets",
+            return_value=[MagicMock()],
+        ),
+        patch(
+            "eegdash.dataset.dataset.downloader.get_s3_filesystem",
+            return_value=MagicMock(),
+        ),
+    ):
+        _ = EEGDashDataset(
+            cache_dir=tmp_path,
+            dataset="ds_remote",
+            database=database,
+            auth_token=auth_token,
+            download=True,
+        )
+
+    mock_eegdash.assert_called_once_with(**expected_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("s3_bucket", "expected_backend"),
+    [(None, "https"), ("s3://mirror-bucket", "s3")],
+)
+def test_eegdashdataset_constructor_source_override_with_s3_bucket(
+    tmp_path, s3_bucket, expected_backend
+):
+    records = [
+        {
+            "dataset": "ds_source",
+            "bidspath": "ds_source/a.set",
+            "bids_relpath": "a.set",
+            "storage": {"backend": "https", "base": "https://original.example"},
+        }
+    ]
+    with patch("eegdash.dataset.dataset.EEGDashRaw"):
+        ds = EEGDashDataset(
+            cache_dir=tmp_path,
+            records=records,
+            download=True,
+            s3_bucket=s3_bucket,
+        )
+
+    if s3_bucket:
+        assert ds.records[0]["storage"]["base"] == s3_bucket
+    else:
+        assert ds.records[0]["storage"]["base"] == "https://original.example"
+    assert ds.records[0]["storage"]["backend"] == expected_backend

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -1,10 +1,13 @@
 import json
+import warnings
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 from scipy.io import loadmat, savemat
+from scipy.io.matlab import MatWriteWarning
 
 from eegdash.dataset.io import (
     _convert_time_with_numeric_dash,
@@ -20,16 +23,25 @@ from eegdash.dataset.io import (
     _generate_vmrk_stub,
     _load_raw_eeglab_alleeg,
     _load_raw_from_eeglab_epochs,
+    _parse_set_metadata,
+    _read_bids_channels_tsv,
     _repair_channels_tsv,
     _repair_channels_tsv_duplicates,
     _repair_eeglab_fdt,
     _repair_events_tsv_nan_samples,
+    _repair_scans_tsv_timestamps,
     _repair_tsv_decimal_separators,
     _repair_tsv_encoding,
     _repair_tsv_na_whitespace,
     _repair_vhdr_missing_markerfile,
     _repair_vhdr_pointers,
 )
+
+
+def _savemat_without_matwritewarning(path: Path, data: dict) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MatWriteWarning)
+        savemat(str(path), data, do_compression=False)
 
 
 def test_convert_time_with_numeric_dash_dd_mm_yyyy():
@@ -300,6 +312,95 @@ def test_find_best_matching_file_no_candidates(tmp_path):
     """Test returns None when no files with extension exist."""
     result = _find_best_matching_file(tmp_path, "missing.eeg", ".eeg")
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "chanlocs,expected_names",
+    [
+        (
+            [SimpleNamespace(labels="Fp1"), SimpleNamespace(labels="Fp2")],
+            ["Fp1", "Fp2"],
+        ),
+        (SimpleNamespace(labels="Cz"), ["Cz"]),
+    ],
+    ids=["iterable_chanlocs", "single_chanloc"],
+)
+def test_parse_set_metadata_chanloc_variants(tmp_path, chanlocs, expected_names):
+    """Extract channel names from iterable and scalar chanloc variants."""
+    eeg = SimpleNamespace(
+        srate=np.array([256.0]),
+        nbchan=np.array([len(expected_names)]),
+        pnts=np.array([4]),
+        chanlocs=chanlocs,
+        data=np.ones((len(expected_names), 4), dtype=np.float64),
+    )
+    with patch("scipy.io.loadmat", return_value={"EEG": eeg}):
+        meta = _parse_set_metadata(tmp_path / "dummy.set")
+
+    assert meta["srate"] == 256.0
+    assert meta["nbchan"] == len(expected_names)
+    assert meta["pnts"] == 4
+    assert meta["ch_names"] == expected_names
+    assert meta["data"].dtype == np.float32
+
+
+@pytest.mark.parametrize("missing_field", ["srate", "nbchan", "pnts"])
+def test_parse_set_metadata_missing_required_fields(tmp_path, missing_field):
+    """Missing required EEG fields raise ValueError with a clear message."""
+    eeg = SimpleNamespace(
+        srate=np.array([256.0]),
+        nbchan=np.array([2]),
+        pnts=np.array([10]),
+        chanlocs=None,
+    )
+    setattr(eeg, missing_field, None)
+
+    with patch("scipy.io.loadmat", return_value={"EEG": eeg}):
+        with pytest.raises(
+            ValueError, match=f"Missing required field '{missing_field}'"
+        ):
+            _parse_set_metadata(tmp_path / "dummy.set")
+
+
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        ("Fz\tEEG\tuV\nEOG1\tEOG\tuV\n", (["Fz", "EOG1"], ["eeg", "eog"])),
+        ("A1\tXYZ\tuV\nA2\t\t\n", (["A1", "A2"], ["eeg", "eeg"])),
+        (" \tEEG\tuV\n", None),
+    ],
+    ids=["known_types", "unknown_or_empty_type_fallback", "blank_names_dropped"],
+)
+def test_read_bids_channels_tsv_parametrized(tmp_path, rows, expected):
+    """BIDS channel parsing maps types and drops empty-name rows."""
+    channels_tsv = tmp_path / "sub-01_task-rest_channels.tsv"
+    channels_tsv.write_text("name\ttype\tunits\n" + rows)
+
+    assert _read_bids_channels_tsv(tmp_path) == expected
+
+
+@pytest.mark.parametrize(
+    "acq_time,expected_time,expected_repaired",
+    [
+        ("2024-01-02 03:04:05", "2024-01-02T03:04:05.000000", True),
+        ("2024-01-02T03:04:99", "n/a", True),
+        ("2024-01-02T03:04:05.000000", "2024-01-02T03:04:05.000000", False),
+    ],
+    ids=["normalize_space_separator", "invalid_timestamp_to_na", "already_normalized"],
+)
+def test_repair_scans_tsv_timestamps_parametrized(
+    tmp_path, acq_time, expected_time, expected_repaired
+):
+    """Repair scans.tsv acq_time normalization and invalid-value handling."""
+    data_dir = tmp_path / "sub-01" / "eeg"
+    data_dir.mkdir(parents=True)
+    scans_tsv = data_dir.parent / "sub-01_scans.tsv"
+    scans_tsv.write_text(f"filename\tacq_time\nsub-01/eeg/test.eeg\t{acq_time}\n")
+
+    repaired = _repair_scans_tsv_timestamps(data_dir)
+
+    assert repaired is expected_repaired
+    assert scans_tsv.read_text().splitlines()[1].split("\t")[1] == expected_time
 
 
 def test_repair_vhdr_fuzzy_match_typo(tmp_path):
@@ -836,7 +937,6 @@ def test_repair_events_tsv_mixed_nan_types(tmp_path):
 def _create_minimal_set_fdt(tmp_path, n_channels=3, n_samples=100, sfreq=256.0):
     """Helper: create a minimal .set + .fdt pair for testing."""
     import numpy as np
-    import scipy.io
 
     set_path = tmp_path / "test.set"
     fdt_path = tmp_path / "test.fdt"
@@ -854,7 +954,7 @@ def _create_minimal_set_fdt(tmp_path, n_channels=3, n_samples=100, sfreq=256.0):
         "data": np.array(["test.fdt"]),
     }
 
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
     return set_path, fdt_path, data
 
 
@@ -898,7 +998,6 @@ def test_load_raw_eeglab_fallback_with_bids_channels(tmp_path):
 def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
     """Raises ValueError when no .fdt and no embedded data."""
     import numpy as np
-    import scipy.io
 
     from eegdash.dataset.io import _load_raw_eeglab_fallback
 
@@ -911,7 +1010,7 @@ def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
         "datfile": np.array([""]),
         "data": np.array(["test.fdt"]),
     }
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
 
     with pytest.raises(ValueError, match="No data source"):
         _load_raw_eeglab_fallback(set_path)
@@ -920,7 +1019,6 @@ def test_load_raw_eeglab_fallback_no_data_raises(tmp_path):
 def test_load_raw_eeglab_fallback_size_mismatch_raises(tmp_path):
     """Raises ValueError when .fdt size doesn't match metadata."""
     import numpy as np
-    import scipy.io
 
     from eegdash.dataset.io import _load_raw_eeglab_fallback
 
@@ -937,10 +1035,46 @@ def test_load_raw_eeglab_fallback_size_mismatch_raises(tmp_path):
         "datfile": np.array(["test.fdt"]),
         "data": np.array(["test.fdt"]),
     }
-    scipy.io.savemat(str(set_path), {"EEG": eeg})
+    _savemat_without_matwritewarning(set_path, {"EEG": eeg})
 
     with pytest.raises(ValueError, match="FDT size mismatch"):
         _load_raw_eeglab_fallback(set_path)
+
+
+@pytest.mark.parametrize(
+    "embedded_data,expected_shape,raises",
+    [
+        (np.arange(6, dtype=np.float32).reshape(2, 3), (2, 3), False),
+        (np.arange(6, dtype=np.float32), (2, 3), False),
+        (np.arange(5, dtype=np.float32), None, True),
+    ],
+    ids=["already_2d", "reshape_1d", "shape_mismatch_raises"],
+)
+def test_load_raw_eeglab_fallback_embedded_data_paths(
+    tmp_path, embedded_data, expected_shape, raises
+):
+    """Embedded .set data path handles reshape and mismatch cases."""
+    from eegdash.dataset.io import _load_raw_eeglab_fallback
+
+    set_path = tmp_path / "embedded.set"
+    set_path.write_text("placeholder")
+
+    meta = {
+        "nbchan": 2,
+        "pnts": 3,
+        "srate": 128.0,
+        "ch_names": ["Fz", "Cz"],
+        "data": embedded_data,
+    }
+
+    with patch("eegdash.dataset.io._parse_set_metadata", return_value=meta):
+        if raises:
+            with pytest.raises(ValueError, match="Embedded data shape"):
+                _load_raw_eeglab_fallback(set_path)
+        else:
+            raw = _load_raw_eeglab_fallback(set_path)
+            assert raw.get_data().shape == expected_shape
+            assert raw.ch_names == ["Fz", "Cz"]
 
 
 # ---------- _repair_channels_tsv ----------
@@ -1107,7 +1241,7 @@ def test_repair_eeglab_fdt_truncated_fdt_repairs(tmp_path):
         "xmax": (pnts_orig - 1) / 250.0,
         "data": "test.fdt",
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
 
     result = _repair_eeglab_fdt(set_path)
     assert result is True
@@ -1141,7 +1275,7 @@ def test_eeglab_load_first_eeg_returns_eeg_when_valid_set(tmp_path):
 
     set_path = tmp_path / "valid.set"
     eeg = {"nbchan": 2, "pnts": 10, "srate": 250.0, "data": "valid.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     out = _eeglab_load_first_eeg(set_path)
     assert out is not None
     assert int(out["nbchan"]) == 2 and int(out["pnts"]) == 10
@@ -1158,7 +1292,7 @@ def test_repair_eeglab_fdt_no_fdt_file_returns_false(tmp_path):
 
     set_path = tmp_path / "nofdt.set"
     eeg = {"nbchan": 2, "pnts": 10, "srate": 250.0, "data": "nofdt.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1171,7 +1305,7 @@ def test_repair_eeglab_fdt_not_truncated_returns_false(tmp_path):
     nbchan, pnts = 2, 10
     fdt_path.write_bytes(b"\x00" * (nbchan * pnts * 4))
     eeg = {"nbchan": nbchan, "pnts": pnts, "srate": 250.0, "data": "full.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1183,7 +1317,7 @@ def test_repair_eeglab_fdt_fdt_too_small_returns_false(tmp_path):
     fdt_path = tmp_path / "tiny.fdt"
     fdt_path.write_bytes(b"\x00" * 4)  # 4 bytes, 2 channels -> 0 samples
     eeg = {"nbchan": 2, "pnts": 100, "srate": 250.0, "data": "tiny.fdt"}
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     assert _repair_eeglab_fdt(set_path) is False
 
 
@@ -1208,7 +1342,7 @@ def test_load_raw_eeglab_alleeg_success(tmp_path):
         "data": "raw.fdt",
         "chanlocs": [{"labels": "Fp1"}, {"labels": "Fp2"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan
@@ -1231,7 +1365,7 @@ def test_load_raw_eeglab_alleeg_truncated_fdt_pads(tmp_path):
         "data": "trunc.fdt",
         "chanlocs": [{"labels": "A"}, {"labels": "B"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan
@@ -1252,7 +1386,7 @@ def test_load_raw_eeglab_alleeg_inline_data(tmp_path):
         "data": data,
         "chanlocs": [{"labels": "Fp1"}, {"labels": "Fp2"}],
     }
-    savemat(str(set_path), eeg, do_compression=False)
+    _savemat_without_matwritewarning(set_path, eeg)
     raw = _load_raw_eeglab_alleeg(set_path)
     assert raw is not None
     assert raw.info["nchan"] == nbchan

--- a/tests/unit_tests/dataset/test_registry.py
+++ b/tests/unit_tests/dataset/test_registry.py
@@ -1,4 +1,7 @@
+import urllib.error
 from pathlib import Path
+
+import pytest
 
 
 class DummyBase:
@@ -343,6 +346,203 @@ def test_fetch_datasets_from_api_field_mappings():
         assert "MB" in row["size"]
         assert row["license"] == "CC0"
         assert row["doi"] == "doi:10.1234/test"
+
+
+def test_fetch_datasets_from_api_recovers_from_bad_cache_and_handles_write_failure(
+    tmp_path: Path,
+):
+    """If cache read/write fails, API fetch should still succeed."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from eegdash.dataset.registry import fetch_datasets_from_api
+
+    # Corrupt cache that triggers pd.read_csv exception
+    cache_file = tmp_path / "dataset_summary.csv"
+    cache_file.write_text("not,a,valid,csv\n", encoding="utf-8")
+
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "dataset_id": "ds_cache_fallback",
+                "demographics": {"subjects_count": 2},
+                "total_files": 3,
+                "tasks": ["rest"],
+            }
+        ],
+    }
+
+    with (
+        patch("eegdash.dataset.registry.get_default_cache_dir", return_value=tmp_path),
+        patch("pandas.read_csv", side_effect=ValueError("bad cache")),
+        patch("urllib.request.urlopen") as mock_urlopen,
+        patch("pandas.DataFrame.to_csv", side_effect=OSError("read-only cache")),
+    ):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(payload).encode("utf-8")
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        df = fetch_datasets_from_api("https://api.test.com", "db")
+
+    assert not df.empty
+    assert df.iloc[0]["dataset"] == "ds_cache_fallback"
+
+
+def test_fetch_chart_data_http_404_falls_back_to_summary():
+    """404 from chart endpoint should fall back to summary fetch."""
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from eegdash.dataset.registry import fetch_chart_data_from_api
+
+    fallback = pd.DataFrame([{"dataset": "ds_fallback"}])
+    with (
+        patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url="u", code=404, msg="not found", hdrs=None, fp=None
+            ),
+        ),
+        patch(
+            "eegdash.dataset.registry.fetch_datasets_from_api", return_value=fallback
+        ),
+    ):
+        df, aggregations = fetch_chart_data_from_api("https://api.test.com", "db")
+
+    assert len(df) == 1
+    assert df.iloc[0]["dataset"] == "ds_fallback"
+    assert aggregations == {}
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        urllib.error.HTTPError(url="u", code=500, msg="server", hdrs=None, fp=None),
+        RuntimeError("network down"),
+    ],
+    ids=["http-500", "generic-exception"],
+)
+def test_fetch_chart_data_errors_return_empty(side_effect):
+    from unittest.mock import patch
+
+    from eegdash.dataset.registry import fetch_chart_data_from_api
+
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        df, aggregations = fetch_chart_data_from_api("https://api.test.com", "db")
+    assert df.empty
+    assert aggregations == {}
+
+
+def test_fetch_chart_data_unsuccessful_payload_returns_empty():
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from eegdash.dataset.registry import fetch_chart_data_from_api
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"success": False}).encode("utf-8")
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        df, aggregations = fetch_chart_data_from_api("https://api.test.com", "db")
+
+    assert df.empty
+    assert aggregations == {}
+
+
+def test_fetch_chart_data_success_maps_rows_and_aggregations():
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from eegdash.dataset.registry import fetch_chart_data_from_api
+
+    payload = {
+        "success": True,
+        "datasets": [
+            # excluded
+            {"dataset_id": "ABUDUKADI"},
+            # included with fallback branches
+            {
+                "dataset_id": "ds_chart_1",
+                "name": "Chart Dataset",
+                "demographics": {"subjects_count": 5},
+                "total_files": 10,
+                "tasks": ["rest", "task"],
+                "sessions": ["s1"],
+                "recording_modality": "eeg",
+                "clinical": {"is_clinical": False},
+                "paradigm": {"modality": "visual", "cognitive_domain": "attention"},
+                "tags": {},
+                "timestamps": {"dataset_created_at": "2024-01-01"},
+                "size_bytes": 2048,
+                "source": "openneuro",
+                "license": "CC0",
+                "dataset_doi": "10.1234/abcd",
+                "nchans_counts": [32, 64],
+                "sfreq_counts": [128, 256],
+                "canonical_name": ["Smith2024"],
+                "name_source": "author_year",
+            },
+            # included with tags lists and missing source
+            {
+                "dataset_id": "ds_chart_2",
+                "computed_title": "Computed title",
+                "demographics": {},
+                "total_files": 1,
+                "tasks": [],
+                "sessions": [],
+                "recording_modality": ["meg", "eeg"],
+                "tags": {
+                    "pathology": ["epilepsy"],
+                    "modality": ["auditory", "visual"],
+                    "type": ["observation"],
+                },
+                "clinical": {"is_clinical": True, "purpose": "clinical trial"},
+                "paradigm": {},
+                "timestamps": {},
+                "size_human": "1.0 GB",
+            },
+        ],
+        "aggregations": {"n_datasets": 2},
+    }
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(payload).encode("utf-8")
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        df, aggregations = fetch_chart_data_from_api("https://api.test.com", "db")
+
+    # One excluded dataset must be filtered out
+    assert len(df) == 2
+    assert aggregations == {"n_datasets": 2}
+
+    row1 = df[df["dataset"] == "ds_chart_1"].iloc[0]
+    assert row1["record_modality"] == "eeg"
+    assert row1["recording_modality"] == "eeg"
+    assert row1["modality of exp"] == "visual"
+    assert row1["type of exp"] == "attention"
+    assert row1["Type Subject"] == "Healthy"
+    assert row1["source"] == "openneuro"
+    assert row1["author_year"] == "Smith2024"
+    assert row1["n_sessions"] == 1
+
+    row2 = df[df["dataset"] == "ds_chart_2"].iloc[0]
+    assert row2["record_modality"] == "meg, eeg"
+    assert row2["recording_modality"] == "meg, eeg"
+    assert row2["modality of exp"] == "auditory, visual"
+    assert row2["type of exp"] == "observation"
+    assert row2["Type Subject"] == "epilepsy"
+    assert row2["source"] == "unknown"
+    assert row2["dataset_title"] == "Computed title"
 
 
 def test_fetch_api_handles_missing_demographics():

--- a/tests/unit_tests/features/feature_bank/test_pick.py
+++ b/tests/unit_tests/features/feature_bank/test_pick.py
@@ -1,0 +1,104 @@
+import mne
+import numpy as np
+import pytest
+
+from eegdash.features.base_utils import BivariateIterator
+from eegdash.features.feature_bank.pick import (
+    pick_channel_pairs_preprocessor,
+    pick_channels_preprocessor,
+)
+
+
+def _metadata(ch_names=("C3", "C4", "Pz"), directed=False):
+    info = mne.create_info(
+        list(ch_names), sfreq=128.0, ch_types=["eeg"] * len(ch_names)
+    )
+    return {
+        "info": info,
+        "ch_pair_iterator": BivariateIterator(len(ch_names), directed=directed),
+    }
+
+
+@pytest.mark.parametrize(
+    "index,axis,expected_shape",
+    [
+        (-1, -2, (2, 2, 5)),
+        (0, 1, (2, 2, 5)),
+        ([0, -1], -2, (2, 2, 5)),
+    ],
+)
+def test_pick_channels_preprocessor_selects_requested_channels(
+    index, axis, expected_shape
+):
+    md = _metadata()
+    x0 = np.arange(2 * 3 * 5).reshape(2, 3, 5)
+    x1 = np.arange(2 * 3 * 5).reshape(2, 3, 5) + 1000
+
+    y0, y1, out_md = pick_channels_preprocessor(
+        x0, x1, channels=["C3", "Pz"], _metadata=md, index=index, axis=axis
+    )
+
+    if index in (0, [0, -1]):
+        assert y0.shape == expected_shape
+    if index in (-1, [0, -1]):
+        assert y1.shape == expected_shape
+    assert out_md["info"]["ch_names"] == ["C3", "Pz"]
+
+
+def test_pick_channels_preprocessor_raises_for_unknown_channel():
+    md = _metadata()
+    x = np.zeros((1, 3, 10))
+    with pytest.raises(ValueError, match="Channel O1 not found"):
+        pick_channels_preprocessor(x, channels=["O1"], _metadata=md)
+
+
+def test_pick_channel_pairs_preprocessor_requires_at_least_one_target_index():
+    md = _metadata()
+    x = np.zeros((1, 3, 10))
+    with pytest.raises(AssertionError):
+        pick_channel_pairs_preprocessor(
+            x,
+            pairs=[("C3", "C4")],
+            _metadata=md,
+            index=None,
+            c_index=None,
+            x_index=None,
+            y_index=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"index": 0},
+        {"index": None, "c_index": -1},
+        {"index": None, "x_index": -1, "y_index": -1},
+        {"index": 0, "c_index": -1, "x_index": -1, "y_index": -1},
+    ],
+    ids=["pair-axis-only", "channel-union-only", "x-and-y-only", "all-targets"],
+)
+def test_pick_channel_pairs_preprocessor_updates_outputs_and_metadata(kwargs):
+    md = _metadata()
+    # 3 channels -> 3 undirected pairs
+    pair_tensor = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+    channel_tensor = np.arange(2 * 3 * 4).reshape(2, 3, 4) + 100
+
+    out_pair, out_ch, out_md = pick_channel_pairs_preprocessor(
+        pair_tensor,
+        channel_tensor,
+        pairs=[("C3", "C4"), ("C4", "Pz")],
+        _metadata=md,
+        axis=-2,
+        c_axis=-2,
+        **kwargs,
+    )
+
+    # Pair selection should reduce pair axis to selected pairs where index targets are used.
+    if kwargs.get("index") is not None:
+        assert out_pair.shape[1] == 2
+    # Channel selection paths can reduce channels to unique channels from selected pairs.
+    if any(k in kwargs for k in ("c_index", "x_index", "y_index")):
+        assert out_ch.shape[1] <= 3
+        assert out_ch.shape[1] >= 1
+
+    assert len(out_md["ch_pair_iterator"].pairs) == 2

--- a/tests/unit_tests/features/feature_bank/test_spectral.py
+++ b/tests/unit_tests/features/feature_bank/test_spectral.py
@@ -75,7 +75,7 @@ def test_spectral_more():
     # lines 27-34: skip_outlier_noise
     # Use longer signal for better frequency resolution to satisfy frequency bands
     # f0 = 2 * fs / n. For fs=100, n=200 -> f0=1.0. Delta starts at 1.0
-    data = np.random.randn(2, 4, 300)
+    data = np.random.randn(2, 4, 512)
     metadata = {"info": {"sfreq": 100.0}}
     f, p = spectral_preprocessor(data, _metadata=metadata, fs=100.0)
 

--- a/tests/unit_tests/features/test_serialization_hotspots.py
+++ b/tests/unit_tests/features/test_serialization_hotspots.py
@@ -1,0 +1,78 @@
+import json
+from functools import partial
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from eegdash.features import serialization as ser
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ({"_": 1, "1": {"-2": {"a": 3}}}, {"": 1, 1: {-2: {"a": 3}}}),
+        ({"+3": 2, "x": {"_": 7}}, {3: 2, "x": {"": 7}}),
+    ],
+)
+def test_adjust_dict_types_converts_numeric_and_underscore_keys(raw, expected):
+    assert ser._adjust_dict_types(raw) == expected
+
+
+def test_func_from_dict_errors_for_unknown_name():
+    with pytest.raises(ValueError, match="not found in feature bank"):
+        ser._func_from_dict({"name": "not_a_real_feature"})
+
+
+def test_func_from_dict_builds_partial_for_args_and_kwargs():
+    fn = ser._func_from_dict({"name": "signal_quantile", "kwargs": {"q": 0.5}})
+    assert isinstance(fn, partial)
+    out = fn(np.array([[1.0, 2.0, 3.0]]))
+    assert out.shape == (1,)
+
+
+def test_feature_extractor_from_dict_raises_on_malformed_feature_dict():
+    bad = {"feature_extractors": {"f": {"unexpected": 1}}}
+    with pytest.raises(ValueError, match="must contain either a 'feature_extractors'"):
+        ser.feature_extractor_from_dict(bad)
+
+
+def test_load_feature_extractor_from_json_calls_factory(monkeypatch, tmp_path: Path):
+    payload = {"feature_extractors": {"m": {"name": "signal_mean"}}}
+    cfg = tmp_path / "f.json"
+    cfg.write_text(json.dumps(payload), encoding="utf-8")
+
+    sentinel = object()
+    monkeypatch.setattr(ser, "feature_extractor_from_dict", lambda d: sentinel)
+    assert ser.load_feature_extractor_from_json(cfg) is sentinel
+
+
+def test_load_feature_extractor_from_yaml_calls_factory(monkeypatch, tmp_path: Path):
+    cfg = tmp_path / "f.yaml"
+    cfg.write_text(
+        "feature_extractors:\n  m:\n    name: signal_mean\n", encoding="utf-8"
+    )
+
+    sentinel = object()
+    monkeypatch.setattr(ser, "feature_extractor_from_dict", lambda d: sentinel)
+    assert ser.load_feature_extractor_from_yaml(cfg) is sentinel
+
+
+def test_load_feature_extractor_from_hocon_calls_factory(monkeypatch, tmp_path: Path):
+    payload = {"feature_extractors": {"m": {"name": "signal_mean"}}}
+    cfg = tmp_path / "f.conf"
+    cfg.write_text("feature_extractors { m { name = signal_mean } }", encoding="utf-8")
+
+    fake_mod = ModuleType("pyhocon")
+
+    class _FakeFactory:
+        @staticmethod
+        def parse_file(_path):
+            return payload
+
+    fake_mod.ConfigFactory = _FakeFactory
+    monkeypatch.setitem(__import__("sys").modules, "pyhocon", fake_mod)
+    sentinel = object()
+    monkeypatch.setattr(ser, "feature_extractor_from_dict", lambda d: sentinel)
+    assert ser.load_feature_extractor_from_hocon(cfg) is sentinel

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -1,118 +1,130 @@
-import mne
-import numpy as np
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from mne_bids import BIDSPath, write_raw_bids
 
-from eegdash.dataset import EEGDashDataset
-from eegdash.paths import get_default_cache_dir
-from eegdash.schemas import create_record
+import eegdash.api as api_module
+from eegdash.api import EEGDash
 
 
-# Fixture to create a dummy BIDS dataset for testing
-@pytest.fixture(scope="module")
-def dummy_bids_dataset(tmpdir_factory):
-    bids_root = tmpdir_factory.mktemp("bids")
-    # Create a simple MNE Raw object
-    ch_names = ["EEG 001", "EEG 002", "EEG 003"]
-    ch_types = ["eeg"] * 3
-    sfreq = 100
-    n_times = 100
-    data = np.random.randn(len(ch_names), n_times)
-    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
-    raw = mne.io.RawArray(data, info)
+@pytest.fixture
+def mocked_client(monkeypatch):
+    client = MagicMock()
+    get_client = MagicMock(return_value=client)
+    monkeypatch.setattr("eegdash.api.get_client", get_client)
+    eeg = EEGDash(database="db", api_url="https://api.test", auth_token="token")
+    get_client.assert_called_once_with("https://api.test", "db", "token")
+    return eeg, client
 
-    # Define BIDS path
-    subject_id = "01"
-    session_id = "01"
-    task_name = "test"
-    run_id = "01"
-    bids_path = BIDSPath(
-        subject=subject_id,
-        session=session_id,
-        task=task_name,
-        run=run_id,
-        root=bids_root,
-        datatype="eeg",
+
+@pytest.mark.parametrize(
+    "limit,skip,expected_forwarded",
+    [
+        (None, None, {}),
+        (10, None, {"limit": 10}),
+        (None, 5, {"skip": 5}),
+        (10, 5, {"limit": 10, "skip": 5}),
+    ],
+)
+def test_find_builds_query_and_forwards_pagination(
+    mocked_client, limit, skip, expected_forwarded
+):
+    eeg, client = mocked_client
+    client.find.return_value = ({"id": 1}, {"id": 2})
+
+    with patch("eegdash.api.merge_query", return_value={"merged": True}) as merge_query:
+        result = eeg.find({"dataset": "ds1"}, subject="01", limit=limit, skip=skip)
+
+    assert result == [{"id": 1}, {"id": 2}]
+    merge_query.assert_called_once_with(
+        {"dataset": "ds1"}, require_query=True, subject="01"
     )
-
-    # Write BIDS data
-    write_raw_bids(raw, bids_path, overwrite=True, format="EEGLAB", allow_preload=True)
-
-    return str(bids_path.fpath)
+    client.find.assert_called_once_with({"merged": True}, **expected_forwarded)
 
 
-def test_eegdashdataset_empty_cache_dir():
-    """Test that EEGDashDataset with an empty cache_dir uses the current directory."""
-    # This test is to verify the behavior of the `cache_dir` argument.
-    # The previous implementation used `get_default_cache_dir()` when an empty
-    # string was passed. The new implementation uses `Path("")`, which resolves
-    # to the current directory.
-    record = create_record(
-        dataset="ds005505",
-        storage_base="s3://test-bucket/ds005505",
-        bids_relpath="sub-01/eeg/sub-01_task-test_eeg.set",
-        subject="01",
-        task="test",
+def test_count_ignores_limit_skip(mocked_client):
+    eeg, client = mocked_client
+    client.count_documents.return_value = 12
+
+    with patch("eegdash.api.merge_query", return_value={"merged": True}) as merge_query:
+        result = eeg.count({"dataset": "ds1"}, subject="01", limit=100, skip=50)
+
+    assert result == 12
+    merge_query.assert_called_once_with(
+        {"dataset": "ds1"}, require_query=False, subject="01"
     )
-    # Add extra fields for length calculation
-    record["sampling_frequency"] = 1
-    record["ntimes"] = 1
-
-    ds = EEGDashDataset(
-        cache_dir="",
-        records=[record],
-        download=False,
-    )
-    assert ds.cache_dir == get_default_cache_dir()
+    client.count_documents.assert_called_once_with({"merged": True})
 
 
-def test_eegdash_api_actions():
-    """Test EEGDash convenience methods with mocked client."""
-    from unittest.mock import MagicMock
+@pytest.mark.parametrize("find_one_result,expected", [({"id": 1}, True), (None, False)])
+def test_exists_delegates_to_find_one(mocked_client, find_one_result, expected):
+    eeg, _ = mocked_client
+    with patch.object(eeg, "find_one", return_value=find_one_result) as find_one:
+        assert eeg.exists(dataset="ds1") is expected
+    find_one.assert_called_once_with(None, dataset="ds1")
 
-    from eegdash.api import EEGDash
 
-    # Mock client
-    with pytest.MonkeyPatch.context() as mp:
-        mock_client = MagicMock()
-        mock_get_client = MagicMock(return_value=mock_client)
-        mp.setattr("eegdash.api.get_client", mock_get_client)
+@pytest.mark.parametrize(
+    "records,insert_one_result,insert_many_result,expected,one_calls,many_calls",
+    [
+        ({"a": 1}, "id1", 0, 1, 1, 0),
+        ([{"a": 1}, {"a": 2}], None, 2, 2, 0, 1),
+    ],
+)
+def test_insert_dispatch(
+    mocked_client,
+    records,
+    insert_one_result,
+    insert_many_result,
+    expected,
+    one_calls,
+    many_calls,
+):
+    eeg, client = mocked_client
+    client.insert_one.return_value = insert_one_result
+    client.insert_many.return_value = insert_many_result
 
-        eeg = EEGDash()
+    assert eeg.insert(records) == expected
+    assert client.insert_one.call_count == one_calls
+    assert client.insert_many.call_count == many_calls
 
-        # 1. find
-        mock_client.find.return_value = [{"id": 1}]
-        assert eeg.find({"dataset": "ds1"}) == [{"id": 1}]
-        # Kwargs handled
-        eeg.find(dataset="ds1", subject="01")
-        # Check call arguments (merged query)
-        args, kwargs = mock_client.find.call_args
-        assert args[0] == {"dataset": "ds1", "subject": "01"}
 
-        # 2. exists (uses find_one)
-        mock_client.find_one.return_value = {"id": 1}
-        assert eeg.exists(dataset="ds1") is True
+def test_find_one_and_update_field_use_merged_query(mocked_client):
+    eeg, client = mocked_client
+    client.find_one.return_value = {"id": 1}
+    client.update_many.return_value = (4, 2)
 
-        mock_client.find_one.return_value = None
-        assert eeg.exists(dataset="missing") is False
-
-        # 3. count
-        mock_client.count_documents.return_value = 42
-        assert eeg.count(dataset="ds1") == 42
-
-        # 4. insert
-        mock_client.insert_one.return_value = "id123"
-        eeg.insert({"dataset": "ds1"})
-        assert mock_client.insert_one.call_count == 1
-
-        mock_client.insert_many.return_value = 2
-        eeg.insert([{"a": 1}, {"b": 2}])
-        assert mock_client.insert_many.call_count == 1
-
-        # 5. update_field
-        mock_client.update_many.return_value = (5, 3)  # matched, modified
-        matched, modified = eeg.update_field(
-            {"dataset": "ds1"}, update={"field": "val"}
+    with patch(
+        "eegdash.api.merge_query", side_effect=[{"q": 1}, {"q": 2}]
+    ) as merge_query:
+        assert eeg.find_one({"dataset": "ds1"}, subject="01") == {"id": 1}
+        assert eeg.update_field({"dataset": "ds1"}, subject="01", update={"x": 1}) == (
+            4,
+            2,
         )
-        assert matched == 5
-        assert modified == 3
+
+    assert merge_query.call_args_list == [
+        call({"dataset": "ds1"}, require_query=True, subject="01"),
+        call({"dataset": "ds1"}, require_query=True, subject="01"),
+    ]
+    client.find_one.assert_called_once_with({"q": 1})
+    client.update_many.assert_called_once_with({"q": 2}, {"x": 1})
+
+
+@pytest.mark.parametrize(
+    "method,args,expected_return",
+    [
+        ("find_datasets", ({"dataset": "ds1"},), [{"dataset": "ds1"}]),
+        ("get_dataset", ("ds1",), {"dataset_id": "ds1"}),
+        ("update_dataset", ("ds1", {"x": 1}), 1),
+    ],
+)
+def test_simple_passthrough_methods(mocked_client, method, args, expected_return):
+    eeg, client = mocked_client
+    getattr(client, method).return_value = expected_return
+
+    assert getattr(eeg, method)(*args) == expected_return
+
+
+def test_module_getattr_invalid_name_raises():
+    with pytest.raises(AttributeError, match="has no attribute"):
+        api_module.__getattr__("does_not_exist")

--- a/tests/unit_tests/test_bids_metadata.py
+++ b/tests/unit_tests/test_bids_metadata.py
@@ -1,526 +1,241 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 
 from eegdash.bids_metadata import (
+    _check_constraint_conflict,
+    attach_participants_extras,
     build_query_from_kwargs,
+    enrich_from_participants,
     get_entities_from_record,
     get_entity_from_record,
+    merge_participants_fields,
     merge_query,
+    normalize_key,
+    participants_extras_from_tsv,
     participants_row_for_subject,
 )
 
 
-def test_get_entity_from_record():
-    # v1 (flat)
-    rec1 = {"subject": "01", "task": "rest"}
-    assert get_entity_from_record(rec1, "subject") == "01"
-    assert get_entity_from_record(rec1, "run") is None
-
-    # v2 (nested)
-    rec2 = {"entities": {"subject": "02", "task": "task"}}
-    assert get_entity_from_record(rec2, "subject") == "02"
-    assert get_entity_from_record(rec2, "run") is None
-
-    # Mixed (nested priority)
-    rec3 = {"entities": {"subject": "03"}, "subject": "04"}
-    assert get_entity_from_record(rec3, "subject") == "03"
+@pytest.mark.parametrize(
+    "record,entity,expected",
+    [
+        ({"subject": "01"}, "subject", "01"),
+        ({"entities": {"subject": "02"}, "subject": "legacy"}, "subject", "02"),
+        ({"entities": {"task": "rest"}}, "subject", None),
+    ],
+)
+def test_get_entity_from_record(record, entity, expected):
+    assert get_entity_from_record(record, entity) == expected
 
 
-def test_get_entities_from_record():
-    rec = {"entities": {"subject": "01", "task": "rest"}, "extra": "val"}
-    ents = get_entities_from_record(rec)
-    assert ents == {"subject": "01", "task": "rest"}
-
-    rec_flat = {"subject": "01", "session": "01"}
-    ents = get_entities_from_record(rec_flat)
-    assert ents == {"subject": "01", "session": "01"}
+def test_get_entities_from_record_filters_missing_values():
+    record = {"entities": {"subject": "01", "task": "rest", "run": None}}
+    assert get_entities_from_record(record) == {"subject": "01", "task": "rest"}
 
 
-def test_build_query_from_kwargs():
-    # Valid
-    q = build_query_from_kwargs(subject="01", task=["rest", "task"])
-    assert q["subject"] == "01"
-    assert q["task"] == {"$in": ["rest", "task"]}
-
-    # Deduplication
-    q = build_query_from_kwargs(session=["1", "1", "2"])
-    assert q["session"] == {"$in": ["1", "2"]}
-
-    # Invalid field
-    with pytest.raises(ValueError, match="Unsupported query field"):
-        build_query_from_kwargs(invalid_field="val")
-
-    # None value
-    with pytest.raises(ValueError, match="Received None"):
-        build_query_from_kwargs(subject=None)
-
-    # Empty list
-    with pytest.raises(ValueError, match="Received an empty list"):
-        build_query_from_kwargs(session=[])
-
-    # List with None or empty strings (should be filtered)
-    q = build_query_from_kwargs(subject=["01", None, "  ", "02"])
-    assert q["subject"] == {"$in": ["01", "02"]}
-
-    # List filtering results in empty list
-    with pytest.raises(ValueError, match="Received an empty list"):
-        build_query_from_kwargs(subject=[None, "   "])
-
-    # Empty string scalar
-    with pytest.raises(ValueError, match="Received an empty string"):
-        build_query_from_kwargs(subject="   ")
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"subject": " 01 "}, {"subject": "01"}),
+        (
+            {"task": ["rest", "rest", " task ", "", None]},
+            {"task": {"$in": ["rest", "task"]}},
+        ),
+        ({"session": ("01", "02")}, {"session": {"$in": ["01", "02"]}}),
+    ],
+)
+def test_build_query_from_kwargs_normalization(kwargs, expected):
+    assert build_query_from_kwargs(**kwargs) == expected
 
 
-def test_merge_query():
-    # Only kwargs
-    q = merge_query(subject="01")
-    assert q == {"subject": "01"}
-
-    # Only raw query
-    q = merge_query(query={"subject": "02"})
-    assert q == {"subject": "02"}
-
-    # Both
-    q = merge_query(query={"subject": "01"}, task="rest")
-    assert q == {"$and": [{"subject": "01"}, {"task": "rest"}]}
-
-    # Both but query=None (safe handling)
-    q = merge_query(query=None, task="rest")
-    assert q == {"task": "rest"}
-
-    # Not require query
-    q = merge_query(require_query=False)
-    assert q == {}
-
-    q = merge_query(query=None, require_query=False)
-    assert q == {}
-
-    # Conflicting
-    with pytest.raises(ValueError, match="Conflicting constraints"):
-        merge_query(query={"subject": "01"}, subject="02")
-
-    # Empty
-    with pytest.raises(ValueError, match="Query required"):
-        merge_query()
-
-    # Explicit empty
-    q = merge_query(query={})
-    assert q == {}
+@pytest.mark.parametrize(
+    "kwargs,error_match",
+    [
+        ({"unknown": "x"}, "Unsupported query field"),
+        ({"subject": None}, "Received None"),
+        ({"subject": "   "}, "empty string"),
+        ({"task": []}, "empty list"),
+        ({"task": [None, " "]}, "empty list"),
+    ],
+)
+def test_build_query_from_kwargs_errors(kwargs, error_match):
+    with pytest.raises(ValueError, match=error_match):
+        build_query_from_kwargs(**kwargs)
 
 
-def test_participants_row_for_subject(tmp_path):
-    # Create dummy participants.tsv
-    tsv = tmp_path / "participants.tsv"
-    df = pd.DataFrame(
-        {"participant_id": ["sub-01", "sub-02"], "age": [20, 25], "sex": ["M", "F"]}
-    )
-    df.to_csv(tsv, sep="\t", index=False)
-
-    # Found
-    row = participants_row_for_subject(tmp_path, "01")
-    assert row is not None
-    assert row["participant_id"] == "sub-01"
-    assert row["age"] == "20"  # read as string usually in helper
-
-    # Found robustly
-    row = participants_row_for_subject(tmp_path, "sub-02")
-    assert row is not None
-    assert row["participant_id"] == "sub-02"
-
-    # Not found
-    row = participants_row_for_subject(tmp_path, "03")
-    assert row is None
-
-    # No file
-    row = participants_row_for_subject(tmp_path / "nonexistent", "01")
-    assert row is None
+@pytest.mark.parametrize(
+    "query,kwargs,require_query,expected",
+    [
+        ({"dataset": "ds1"}, {}, True, {"dataset": "ds1"}),
+        (None, {"subject": "01"}, True, {"subject": "01"}),
+        ({}, {"subject": "01"}, True, {"subject": "01"}),
+        (
+            {"dataset": "ds1"},
+            {"subject": "01"},
+            True,
+            {"$and": [{"dataset": "ds1"}, {"subject": "01"}]},
+        ),
+        (None, {}, False, {}),
+    ],
+)
+def test_merge_query_happy_paths(query, kwargs, require_query, expected):
+    assert merge_query(query=query, require_query=require_query, **kwargs) == expected
 
 
-def test_merge_skips_existing_keys():
-    """Test that keys already in description are not overwritten (line 352-353)."""
-    from eegdash.bids_metadata import merge_participants_fields
-
-    # Description already has 'age'
-    description = {"age": "30", "name": "test"}
-    participants_row = {"age": "25", "sex": "M", "hand": "R"}
-
-    result = merge_participants_fields(
-        description,
-        participants_row,
-        description_fields=["age", "sex"],  # Request age and sex
-    )
-
-    # Line 352-353: key in description -> continue
-    # age should NOT be overwritten
-    assert result["age"] == "30"  # Original value kept
-    assert result["sex"] == "M"  # New value added
-    assert result["hand"] == "R"  # Also added from participants
+@pytest.mark.parametrize(
+    "query,kwargs,error_match",
+    [
+        (None, {}, "Query required"),
+        ({"subject": "01"}, {"subject": "02"}, "Conflicting constraints"),
+    ],
+)
+def test_merge_query_errors(query, kwargs, error_match):
+    with pytest.raises(ValueError, match=error_match):
+        merge_query(query=query, **kwargs)
 
 
-def test_merge_adds_missing_keys():
-    """Test that missing keys are added from participants."""
-    from eegdash.bids_metadata import merge_participants_fields
-
-    description = {"existing": "value"}
-    participants_row = {"new_key": "new_value", "another": "data"}
-
-    result = merge_participants_fields(
-        description, participants_row, description_fields=["new_key"]
-    )
-
-    assert result["new_key"] == "new_value"
-    assert result["another"] == "data"
-
-
-def test_merge_returns_description_when_not_dict():
-    """Test line 342: returns early when inputs are not dicts."""
-    from eegdash.bids_metadata import merge_participants_fields
-
-    # description is not a dict
-    result = merge_participants_fields("not a dict", {"key": "value"})
-    assert result == "not a dict"
-
-    # participants_row is not a dict
-    result = merge_participants_fields({"key": "value"}, "not a dict")
-    assert result == {"key": "value"}
-
-    # Both not dicts
-    result = merge_participants_fields(None, None)
-    assert result is None
-
-
-def test_check_constraint_conflict():
-    """Test _check_constraint_conflict with various inputs."""
-    import pytest
-
-    from eegdash.bids_metadata import _check_constraint_conflict
-
-    # No conflict - one is None
-    _check_constraint_conflict({"key": "a"}, {}, "key")  # No exception
-
-    # No conflict - matching values
-    _check_constraint_conflict({"key": "a"}, {"key": "a"}, "key")  # No exception
-
-    # Conflict - different values
-    with pytest.raises(ValueError, match="Conflicting constraints"):
-        _check_constraint_conflict({"key": "a"}, {"key": "b"}, "key")
-
-    # Conflict with $in operator
+def test_check_constraint_conflict_for_in_sets():
     with pytest.raises(ValueError, match="Conflicting constraints"):
         _check_constraint_conflict(
-            {"key": {"$in": ["a", "b"]}}, {"key": {"$in": ["c", "d"]}}, "key"
+            {"subject": {"$in": ["01", "02"]}},
+            {"subject": {"$in": ["03"]}},
+            "subject",
         )
 
 
-def test_participants_row_for_subject_not_found(tmp_path):
-    """Test participants_row_for_subject when subject not found."""
-    from eegdash.bids_metadata import participants_row_for_subject
-
-    # Create participants.tsv without the target subject
-    tsv_path = tmp_path / "participants.tsv"
-    tsv_path.write_text("participant_id\tsex\nsub-01\tM\n")
-
-    # Line 270: no match found
-    result = participants_row_for_subject(tmp_path, "99")
-    assert result is None
+@pytest.mark.parametrize(
+    "raw_key,expected",
+    [("Age (Years)", "age_years"), (" participant-id ", "participant_id")],
+)
+def test_normalize_key(raw_key, expected):
+    assert normalize_key(raw_key) == expected
 
 
-def test_participants_row_no_id_columns(tmp_path):
-    """Test participants_row_for_subject with no matching ID columns."""
-    from eegdash.bids_metadata import participants_row_for_subject
-
-    # Create participants.tsv with no standard ID column
-    tsv_path = tmp_path / "participants.tsv"
-    tsv_path.write_text("some_column\tvalue\ndata\ttest\n")
-
-    # Line 265: no present_cols
-    result = participants_row_for_subject(tmp_path, "01")
-    assert result is None
-
-
-def test_attach_participants_extras_to_series():
-    """Test attach_participants_extras with pandas Series."""
-    from unittest.mock import MagicMock
-
-    import pandas as pd
-
-    from eegdash.bids_metadata import attach_participants_extras
-
-    mock_raw = MagicMock()
-    mock_raw.info = {"subject_info": None}
-
-    description = pd.Series({"existing": "value"})
-    extras = {"new_field": "new_value", "another": "data"}
-
-    # Lines 409-414: Series update path
-    attach_participants_extras(mock_raw, description, extras)
-
-    # The function adds to Series via .loc[missing] = ...
-    # Check that the description was modified
-    # Since attach_participants_extras modifies in place but may fail silently,
-    # check if keys were added or at least no exception was raised
-    assert "existing" in description.index  # Original key still there
-
-
-def test_attach_participants_extras_empty():
-    """Test attach_participants_extras with empty extras."""
-    from unittest.mock import MagicMock
-
-    from eegdash.bids_metadata import attach_participants_extras
-
-    mock_raw = MagicMock()
-    description = {}
-
-    # Line 387: early return for empty extras
-    attach_participants_extras(mock_raw, description, {})
-    # Should not modify anything
-
-
-def test_enrich_from_participants_no_subject(tmp_path):
-    """Test enrich_from_participants with no subject attribute."""
-    from unittest.mock import MagicMock
-
-    from eegdash.bids_metadata import enrich_from_participants
-
-    mock_bidspath = MagicMock()
-    mock_bidspath.subject = None
-    mock_raw = MagicMock()
-    description = {}
-
-    result = enrich_from_participants(tmp_path, mock_bidspath, mock_raw, description)
-    assert result == {}
-
-
-def test_merge_participants_fields_with_fields():
-    """Test merge_participants_fields with specific description_fields."""
-    from eegdash.bids_metadata import merge_participants_fields
-
-    description = {"existing": "value"}
-    participants_row = {"age": "25", "sex": "M", "hand": "R"}
-
-    # Line 342: specific fields requested
-    result = merge_participants_fields(
-        description, participants_row, description_fields=["age", "sex"]
+def test_participants_row_for_subject_matching_and_missing(tmp_path):
+    participants = tmp_path / "participants.tsv"
+    participants.write_text(
+        "participant_id\tparticipant\tage\nsub-01\tfoo\t20\nsub-02\tbar\t25\n"
     )
 
-    assert "age" in result
-    assert result["age"] == "25"
+    assert participants_row_for_subject(tmp_path, "01")["age"] == "20"
+    assert participants_row_for_subject(tmp_path, "sub-02")["participant"] == "bar"
+    assert participants_row_for_subject(tmp_path, "99") is None
+    assert participants_row_for_subject(tmp_path / "missing", "01") is None
 
 
-def test_bids_meta_get_entity():
-    from eegdash import bids_metadata
-
-    rec_v1 = {"subject": "01"}
-    assert bids_metadata.get_entity_from_record(rec_v1, "subject") == "01"
-
-    rec_v2 = {"entities": {"subject": "02"}}
-    assert bids_metadata.get_entity_from_record(rec_v2, "subject") == "02"
-
-    # Priority
-    rec_mix = {"subject": "01", "entities": {"subject": "02"}}
-    assert bids_metadata.get_entity_from_record(rec_mix, "subject") == "02"
+def test_participants_row_returns_none_without_identifier_columns(tmp_path):
+    (tmp_path / "participants.tsv").write_text("age\n20\n")
+    assert participants_row_for_subject(tmp_path, "01") is None
 
 
-def test_bids_meta_build_query_errors():
-    import pytest
-
-    from eegdash import bids_metadata
-
-    with pytest.raises(ValueError, match="Unsupported query"):
-        bids_metadata.build_query_from_kwargs(invalid_field="x")
-
-    with pytest.raises(ValueError, match="Received None"):
-        bids_metadata.build_query_from_kwargs(subject=None)
-
-    with pytest.raises(ValueError, match="empty list"):
-        bids_metadata.build_query_from_kwargs(subject=[])
-
-    with pytest.raises(ValueError, match="empty string"):
-        bids_metadata.build_query_from_kwargs(subject="")
-
-
-def test_bids_meta_merge_query_conflict():
-    import pytest
-
-    from eegdash import bids_metadata
-
-    q1 = {"subject": "01"}
-    # build_query_from_kwargs converts scalar to scalar, not  for single value
-    # But check_constraint logic handles scalar vs
-
-    with pytest.raises(ValueError, match="Conflicting"):
-        bids_metadata.merge_query(q1, subject="02")
-
-
-def test_bids_meta_participants_tsv(tmp_path):
-    from eegdash import bids_metadata
-
-    d = tmp_path / "ds"
-    d.mkdir()
-
-    # Missing file
-    assert bids_metadata.participants_row_for_subject(d, "01") is None
-
-    # Empty file
-    tsv = d / "participants.tsv"
-    tsv.touch()
-    assert (
-        bids_metadata.participants_row_for_subject(d, "01") is None
-    )  # read_csv might fail or return empty df
-
-    # Valid file
-    tsv.write_text("participant_id\tage\nsub-01\t20\nsub-02\t30")
-    row = bids_metadata.participants_row_for_subject(d, "01")
-    assert row is not None
-    assert row["age"] == "20"
-
-    row2 = bids_metadata.participants_row_for_subject(d, "99")
-    assert row2 is None
-
-
-def test_bids_meta_attach_exceptions():
-    from eegdash import bids_metadata
-
-    # Pass garbage to trigger exceptions
-    bids_metadata.attach_participants_extras("not_raw", {}, {"a": 1})
-    # Should not raise
-
-
-def test_participants_extras_from_tsv(tmp_path):
-    from unittest.mock import patch
-
-    import pandas as pd
-
-    from eegdash import bids_metadata
-
-    d = tmp_path
-
-    # 1. Row is None
-    with patch("eegdash.bids_metadata.participants_row_for_subject", return_value=None):
-        assert bids_metadata.participants_extras_from_tsv(d, "01") == {}
-
-    # 2. Row exists, filtering
+def test_participants_extras_from_tsv_filters_ids_and_na_values(tmp_path):
     row = pd.Series(
-        {"participant_id": "sub-01", "age": "20", "bad_col": "n/a", "empty": ""}
+        {
+            "participant_id": "sub-01",
+            "age": " 20 ",
+            "sex": "N/A",
+            "notes": "unknown",
+            "site": "NYU",
+        }
     )
     with patch("eegdash.bids_metadata.participants_row_for_subject", return_value=row):
-        extras = bids_metadata.participants_extras_from_tsv(d, "01")
-        assert "age" in extras
-        assert "bad_col" not in extras
-        assert "empty" not in extras
-        assert "participant_id" not in extras  # id_columns excluded
+        extras = participants_extras_from_tsv(tmp_path, "01")
+
+    assert extras == {"age": "20", "site": "NYU"}
 
 
-def test_enrich_from_participants(tmp_path):
-    from unittest.mock import MagicMock, patch
-
-    from eegdash import bids_metadata
-
-    mock_raw = MagicMock()
-    mock_raw.info = {}
-    mock_desc = {}
-    mock_bids_path = MagicMock()
-    mock_bids_path.subject = "01"
-
-    with patch("eegdash.bids_metadata.participants_extras_from_tsv") as mock_extras:
-        mock_extras.return_value = {"age": "25"}
-
-        extras = bids_metadata.enrich_from_participants(
-            tmp_path, mock_bids_path, mock_raw, mock_desc
-        )
-
-        assert extras == {"age": "25"}
-        assert mock_raw.info["subject_info"]["participants_extras"]["age"] == "25"
-        assert mock_desc["age"] == "25"
-
-    pass
-
-
-def test_check_constraint_conflict_v2():
-    import pytest
-
-    from eegdash import bids_metadata
-
-    # q1, q2, key
-    # Both have $in, intersection empty
-    q1 = {"k": {"$in": [1, 2]}}
-    q2 = {"k": {"$in": [3, 4]}}
-    with pytest.raises(ValueError, match="Conflicting"):
-        bids_metadata._check_constraint_conflict(q1, q2, "k")
-
-    # One scalar, one $in
-    q3 = {"k": 3}
-    with pytest.raises(ValueError, match="Conflicting"):
-        bids_metadata._check_constraint_conflict(q1, q3, "k")
-
-    # No conflict
-    q4 = {"k": {"$in": [2, 3]}}
-    bids_metadata._check_constraint_conflict(q1, q4, "k")  # Should pass
-
-
-def test_attach_participants_extras_pe_not_dict():
-    """Test attach_participants_extras when participants_extras is not dict."""
-    from unittest.mock import MagicMock
-
-    from eegdash.bids_metadata import attach_participants_extras
-
-    mock_raw = MagicMock()
-    # Line 395: pe not a dict -> reset to {}
-    mock_raw.info = {"subject_info": {"participants_extras": "not a dict"}}
-
-    description = {}
-    extras = {"field": "value"}
-
-    # Should not raise
-    attach_participants_extras(mock_raw, description, extras)
-
-
-def test_attach_participants_extras_subject_info_not_dict():
-    """Test attach_participants_extras when subject_info is not dict."""
-    from unittest.mock import MagicMock
-
-    from eegdash.bids_metadata import attach_participants_extras
-
-    mock_raw = MagicMock()
-    # Line 392: subject_info not a dict -> reset to {}
-    mock_raw.info = {"subject_info": "not a dict"}
-
-    description = {}
-    extras = {"field": "value"}
-
-    # Should not raise, handles the case
-    attach_participants_extras(mock_raw, description, extras)
-
-
-def test_merge_participants_fields_key_already_exists():
-    """Test merge_participants_fields skips keys already in description."""
-    from eegdash.bids_metadata import merge_participants_fields
-
-    # Line 342: key in description -> continue
-    description = {"age": "30", "existing": "value"}
-    participants_row = {"age": "25", "sex": "M"}
-
-    result = merge_participants_fields(
-        description, participants_row, description_fields=["age", "sex"]
+@pytest.mark.parametrize(
+    "description,participants,description_fields,expected",
+    [
+        (
+            {"age": "30"},
+            {"Age": "20", "Sex": "F", "sex": "M", "hand": "R"},
+            ["sex"],
+            {"age": "30", "sex": "F", "hand": "R"},
+        ),
+        (
+            {"existing": "x"},
+            {"Age (Years)": "10"},
+            ["age_years"],
+            {"existing": "x", "age_years": "10"},
+        ),
+    ],
+)
+def test_merge_participants_fields(
+    description, participants, description_fields, expected
+):
+    enriched = merge_participants_fields(
+        description=description,
+        participants_row=participants,
+        description_fields=description_fields,
     )
-
-    # age should NOT be overwritten (already exists)
-    assert result["age"] == "30"
-    assert result["sex"] == "M"
+    assert enriched == expected
 
 
-def test_merge_query_with_empty_kwargs():
-    """Test merge_query returns empty warning (line 211)."""
-    from eegdash import bids_metadata
+@pytest.mark.parametrize(
+    "description,participants",
+    [
+        ("not-a-dict", {"age": "20"}),
+        ({"x": 1}, "not-a-dict"),
+    ],
+)
+def test_merge_participants_fields_returns_input_for_invalid_types(
+    description, participants
+):
+    assert merge_participants_fields(description, participants) == description
 
-    # Empty base_query and no kwargs
-    result = bids_metadata.merge_query({})
-    assert result == {}
+
+@pytest.mark.parametrize(
+    "description_factory",
+    [
+        lambda: {},
+        lambda: pd.Series({"existing": "value"}),
+    ],
+)
+def test_attach_participants_extras_updates_raw_and_description(description_factory):
+    raw = SimpleNamespace(info={"subject_info": {"participants_extras": {"age": "30"}}})
+    description = description_factory()
+
+    attach_participants_extras(raw, description, {"age": "99", "site": "NYU"})
+
+    # setdefault: existing keys are preserved
+    assert raw.info["subject_info"]["participants_extras"]["age"] == "30"
+    assert raw.info["subject_info"]["participants_extras"]["site"] == "NYU"
+
+    if isinstance(description, dict):
+        assert description["site"] == "NYU"
+    else:
+        assert "existing" in description.index
 
 
-def test_participants_row_for_subject_no_file(tmp_path):
-    """Test when participants.tsv doesn't exist."""
-    from eegdash import bids_metadata
+def test_attach_participants_extras_early_return_for_empty_extras():
+    raw = SimpleNamespace(info={"subject_info": {}})
+    description = {}
 
-    result = bids_metadata.participants_row_for_subject(tmp_path, "01")
-    assert result is None
+    attach_participants_extras(raw, description, {})
+
+    assert raw.info == {"subject_info": {}}
+    assert description == {}
+
+
+@pytest.mark.parametrize("subject,expected", [(None, {}), ("01", {"age": "20"})])
+def test_enrich_from_participants(subject, expected, tmp_path):
+    bids_path = SimpleNamespace(subject=subject)
+    raw = SimpleNamespace(info={})
+    description = {}
+
+    with patch(
+        "eegdash.bids_metadata.participants_extras_from_tsv", return_value={"age": "20"}
+    ) as extras:
+        result = enrich_from_participants(tmp_path, bids_path, raw, description)
+
+    assert result == expected
+    if subject is None:
+        extras.assert_not_called()
+    else:
+        extras.assert_called_once()
+        assert raw.info["subject_info"]["participants_extras"]["age"] == "20"
+        assert description["age"] == "20"

--- a/tests/unit_tests/test_doi_utils_core.py
+++ b/tests/unit_tests/test_doi_utils_core.py
@@ -1,0 +1,114 @@
+import socket
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+import eegdash.doi_utils as doi_utils
+
+
+@pytest.mark.parametrize(
+    "raw,expected,valid",
+    [
+        ("10.1000/xyz", "10.1000/xyz", True),
+        (" doi:10.1000/xyz ", "10.1000/xyz", True),
+        ("https://doi.org/10.1000/xyz", "10.1000/xyz", True),
+        ("http://dx.doi.org/10.1000/xyz", "10.1000/xyz", True),
+        ("", None, False),
+        (None, None, False),
+        ("not-a-doi", "not-a-doi", False),
+    ],
+)
+def test_normalize_and_validate_doi(raw, expected, valid):
+    assert doi_utils.normalize_doi(raw) == expected
+    assert doi_utils.is_valid_doi(raw) is valid
+
+
+def test_resolve_doi_success_and_failure(monkeypatch):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            return b'{"title":"T","author":[{"family":"Doe"}],"issued":{"date-parts":[[2024]]}}'
+
+    monkeypatch.setattr(doi_utils.urllib.request, "urlopen", lambda *_a, **_k: _Resp())
+    ok = doi_utils.resolve_doi("10.1000/xyz")
+    assert ok is not None
+    assert ok["title"] == "T"
+
+    def _raise(*_a, **_k):
+        raise urllib.error.URLError("boom")
+
+    monkeypatch.setattr(doi_utils.urllib.request, "urlopen", _raise)
+    assert doi_utils.resolve_doi("10.1000/xyz") is None
+
+
+def test_resolve_doi_handles_socket_timeout(monkeypatch):
+    def _raise_timeout(*_a, **_k):
+        raise socket.timeout("timed out")
+
+    monkeypatch.setattr(doi_utils.urllib.request, "urlopen", _raise_timeout)
+    assert doi_utils.resolve_doi("10.1000/xyz") is None
+
+
+def test_resolve_doi_cached_cache_hit_and_miss(monkeypatch):
+    cache = {"10.1000/xyz": {"title": "cached"}}
+    assert doi_utils.resolve_doi_cached("10.1000/xyz", cache, delay=0) == {
+        "title": "cached"
+    }
+
+    monkeypatch.setattr(
+        doi_utils,
+        "resolve_doi",
+        lambda *_a, **_k: {"title": "T", "author": [], "issued": {}},
+    )
+    monkeypatch.setattr(doi_utils.time, "sleep", lambda *_a, **_k: None)
+    out = doi_utils.resolve_doi_cached("10.1000/new", cache, delay=0)
+    assert out is not None
+    assert "10.1000/new" in cache
+
+
+def test_compact_metadata_extracts_expected_fields():
+    compact = doi_utils._compact_metadata(
+        {
+            "title": "Paper",
+            "type": "article-journal",
+            "author": [{"family": "Doe", "given": "Jane"}, {"literal": "NoName"}],
+            "issued": {"date-parts": [[2023, 5, 1]]},
+        }
+    )
+    assert compact == {
+        "title": "Paper",
+        "authors": [{"family": "Doe", "given": "Jane"}],
+        "year": 2023,
+        "type": "article-journal",
+    }
+
+
+def test_cache_load_and_save_roundtrip(tmp_path: Path):
+    cache_path = tmp_path / "cache.json"
+    data = {"10.1000/a": {"title": "A"}}
+    doi_utils.save_cache(data, cache_path)
+    assert doi_utils.load_cache(cache_path) == data
+    assert doi_utils.load_cache(tmp_path / "missing.json") == {}
+
+
+def test_extract_surnames_and_overlap():
+    a = [{"family": "Doe"}, {"family": "Smith", "given": "A"}, {"given": "NoFamily"}]
+    b = [{"family": "SMITH"}, {"family": "Brown"}]
+    assert doi_utils.extract_surnames(a) == ["doe", "smith"]
+    assert doi_utils.surnames_overlap(a, b) == {"smith"}
+
+
+def test_load_dataset_dois_filters_empty_rows(tmp_path: Path):
+    csv_path = tmp_path / "datasets.csv"
+    csv_path.write_text(
+        "dataset,doi\nds1,10.1000/abc\nds2,\nds3, https://doi.org/10.1000/def \n",
+        encoding="utf-8",
+    )
+    pairs = doi_utils.load_dataset_dois(csv_path)
+    assert pairs == [("ds1", "10.1000/abc"), ("ds3", "https://doi.org/10.1000/def")]

--- a/tests/unit_tests/test_doi_utils_core.py
+++ b/tests/unit_tests/test_doi_utils_core.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-import eegdash.doi_utils as doi_utils
+from scripts.citations import doi_utils
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_doi_validation.py
+++ b/tests/unit_tests/test_doi_validation.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-from eegdash.doi_utils import (
+from scripts.citations.doi_utils import (
     extract_surnames,
     is_valid_doi,
     load_cache,

--- a/tests/unit_tests/test_doi_validation.py
+++ b/tests/unit_tests/test_doi_validation.py
@@ -1,0 +1,362 @@
+"""DOI validation tests for EEGDash datasets.
+
+Offline tests validate DOI format for all datasets in dataset_summary.csv.
+Network tests (marked ``@pytest.mark.network``) resolve DOIs via doi.org
+and verify author metadata.  A persistent JSON cache avoids redundant
+API calls across runs.
+
+Run offline tests only::
+
+    pytest tests/unit_tests/test_doi_validation.py -m "not network"
+
+Run all (including network)::
+
+    pytest tests/unit_tests/test_doi_validation.py -m network
+
+Inspired by MOABB ``moabb/tests/test_doi_validation.py``.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+
+import pytest
+
+from eegdash.doi_utils import (
+    extract_surnames,
+    is_valid_doi,
+    load_cache,
+    load_dataset_dois,
+    normalize_doi,
+    resolve_doi_cached,
+    save_cache,
+    surnames_overlap,
+)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+CACHE_PATH = Path(__file__).resolve().parent.parent / "doi_cache.json"
+CSV_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "eegdash"
+    / "dataset"
+    / "dataset_summary.csv"
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def dataset_dois() -> list[tuple[str, str]]:
+    """All (dataset_id, raw_doi) pairs from the summary CSV."""
+    if not CSV_PATH.exists():
+        pytest.skip(f"dataset_summary.csv not found at {CSV_PATH}")
+    return load_dataset_dois(CSV_PATH)
+
+
+@pytest.fixture(scope="module")
+def doi_cache() -> dict:
+    """Persistent DOI cache loaded once per module."""
+    return load_cache(CACHE_PATH)
+
+
+# ===================================================================
+# Offline tests — no network required
+# ===================================================================
+
+
+class TestDOIFormat:
+    """Validate DOI syntax for every dataset in the CSV."""
+
+    # DOIs known to be invalid upstream (e.g. OpenNeuro placeholder values).
+    KNOWN_BAD_DOIS: set[str] = {"mockDOI"}
+    STRICT = os.getenv("EEGDASH_STRICT_DOI_CSV", "").strip() == "1"
+
+    def test_all_dois_have_valid_format(self, dataset_dois):
+        """Every non-empty DOI should match ``10.XXXX/...``."""
+        bad: list[tuple[str, str]] = []
+        for dataset_id, raw_doi in dataset_dois:
+            norm = normalize_doi(raw_doi)
+            if norm in self.KNOWN_BAD_DOIS:
+                continue
+            if not is_valid_doi(norm):
+                bad.append((dataset_id, raw_doi))
+
+        if bad:
+            msg = "\n".join(f"  {did}: {doi}" for did, doi in bad[:20])
+            extra = f"\n  ... and {len(bad) - 20} more" if len(bad) > 20 else ""
+            pytest.fail(f"{len(bad)} dataset(s) have malformed DOIs:\n{msg}{extra}")
+
+    def test_known_bad_dois_are_flagged(self, dataset_dois):
+        """Datasets with known-bad DOIs should be listed for upstream fix."""
+        flagged: list[tuple[str, str]] = []
+        for dataset_id, raw_doi in dataset_dois:
+            norm = normalize_doi(raw_doi)
+            if norm in self.KNOWN_BAD_DOIS:
+                flagged.append((dataset_id, raw_doi))
+
+        if flagged:
+            msg = "\n".join(f"  {did}: {doi}" for did, doi in flagged)
+            print(
+                f"\n{len(flagged)} dataset(s) with known-bad DOIs "
+                f"(need upstream fix):\n{msg}"
+            )
+
+    def test_no_url_prefix_in_doi_column(self, dataset_dois):
+        """DOIs should be stored without ``https://doi.org/`` prefix."""
+        prefixed: list[tuple[str, str]] = []
+        for dataset_id, raw_doi in dataset_dois:
+            stripped = raw_doi.strip()
+            if stripped.startswith("http"):
+                prefixed.append((dataset_id, raw_doi))
+
+        if prefixed:
+            msg = "\n".join(f"  {did}: {doi}" for did, doi in prefixed[:10])
+            if self.STRICT:
+                pytest.fail(
+                    f"{len(prefixed)} DOIs stored with URL prefix (should be bare):\n{msg}"
+                )
+            print(
+                f"\n{len(prefixed)} DOI(s) stored with URL prefix (normalization will handle it):\n{msg}"
+            )
+
+    def test_no_trailing_whitespace(self, dataset_dois):
+        """DOI strings should not have leading/trailing whitespace."""
+        bad = [(did, doi) for did, doi in dataset_dois if doi != doi.strip()]
+        if bad:
+            msg = "\n".join(f"  {did}: repr={doi!r}" for did, doi in bad[:10])
+            pytest.fail(f"{len(bad)} DOIs with whitespace:\n{msg}")
+
+    def test_doi_coverage(self, dataset_dois):
+        """Report how many datasets have DOIs (informational)."""
+        if not CSV_PATH.exists():
+            pytest.skip("CSV not found")
+        with open(CSV_PATH, newline="") as fh:
+            total = sum(1 for _ in csv.DictReader(fh))
+        with_doi = len(dataset_dois)
+        coverage = with_doi / total * 100 if total else 0
+        print(f"\nDOI coverage: {with_doi}/{total} ({coverage:.1f}%)")
+        # We expect high coverage but don't hard-fail on it.
+        assert coverage > 80, f"DOI coverage dropped below 80%: {coverage:.1f}%"
+
+
+class TestDOICacheCompleteness:
+    """Verify the local cache covers all DOIs in the CSV."""
+
+    STRICT = os.getenv("EEGDASH_STRICT_DOI_CSV", "").strip() == "1"
+
+    def test_cache_exists(self):
+        """The cache file should exist after the initial build."""
+        if not CACHE_PATH.exists():
+            pytest.skip(
+                "doi_cache.json not built yet — run: "
+                "python -m pytest tests/unit_tests/test_doi_validation.py "
+                "-m network -k test_resolve_all_dois"
+            )
+
+    def test_cache_covers_dataset_dois(self, dataset_dois, doi_cache):
+        """Every DOI in the CSV should be in the cache."""
+        if not doi_cache:
+            pytest.skip("Cache is empty — build it with network tests first")
+
+        missing: list[str] = []
+        for _, raw_doi in dataset_dois:
+            norm = normalize_doi(raw_doi)
+            if norm and norm not in doi_cache:
+                missing.append(norm)
+
+        if missing:
+            msg = "\n".join(f"  {d}" for d in missing[:20])
+            extra = f"\n  ... and {len(missing) - 20} more" if len(missing) > 20 else ""
+            if self.STRICT:
+                pytest.fail(
+                    f"{len(missing)} DOI(s) missing from cache "
+                    f"(run network tests to update):\n{msg}{extra}"
+                )
+            pytest.skip(
+                f"Cache incomplete for {len(missing)} DOI(s); run network DOI sync to refresh cache."
+            )
+
+
+# ===================================================================
+# Network tests — require doi.org access
+# ===================================================================
+
+network = pytest.mark.network
+
+
+@network
+class TestDOIResolution:
+    """Resolve DOIs via doi.org and validate metadata."""
+
+    def test_resolve_sample_dois(self, dataset_dois, doi_cache):
+        """Resolve a sample of DOIs to verify they're live."""
+        sample = dataset_dois[:10]  # small sample for quick CI
+        failed: list[tuple[str, str]] = []
+
+        for dataset_id, raw_doi in sample:
+            norm = normalize_doi(raw_doi)
+            if not norm:
+                continue
+            result = resolve_doi_cached(norm, doi_cache, delay=0.2)
+            if result is None:
+                failed.append((dataset_id, raw_doi))
+
+        # Persist updated cache
+        save_cache(doi_cache, CACHE_PATH)
+
+        if failed:
+            msg = "\n".join(f"  {did}: {doi}" for did, doi in failed)
+            pytest.fail(f"{len(failed)} DOI(s) failed to resolve:\n{msg}")
+
+    def test_resolve_all_dois(self, dataset_dois, doi_cache):
+        """Resolve every DOI and build/update the persistent cache.
+
+        This is slow (~2 min for 700 DOIs) — run explicitly::
+
+            pytest -m network -k test_resolve_all_dois -s
+        """
+        failed: list[tuple[str, str, str]] = []
+        resolved = 0
+
+        for i, (dataset_id, raw_doi) in enumerate(dataset_dois):
+            norm = normalize_doi(raw_doi)
+            if not norm:
+                continue
+
+            # Skip if already cached
+            if norm in doi_cache:
+                resolved += 1
+                continue
+
+            result = resolve_doi_cached(norm, doi_cache, delay=0.2)
+            if result is None:
+                failed.append((dataset_id, raw_doi, "resolution failed"))
+            else:
+                resolved += 1
+
+            # Save periodically
+            if (i + 1) % 50 == 0:
+                save_cache(doi_cache, CACHE_PATH)
+                print(
+                    f"  Progress: {i + 1}/{len(dataset_dois)}, "
+                    f"resolved={resolved}, failed={len(failed)}"
+                )
+
+        save_cache(doi_cache, CACHE_PATH)
+
+        print(
+            f"\nFinal: resolved={resolved}, failed={len(failed)}, "
+            f"cache size={len(doi_cache)}"
+        )
+
+        if failed:
+            msg = "\n".join(
+                f"  {did}: {doi} ({reason})" for did, doi, reason in failed[:20]
+            )
+            extra = f"\n  ... and {len(failed) - 20} more" if len(failed) > 20 else ""
+            pytest.fail(f"{len(failed)} DOI(s) failed to resolve:\n{msg}{extra}")
+
+    def test_resolved_dois_have_authors(self, dataset_dois, doi_cache):
+        """Resolved DOIs should have at least one author."""
+        no_authors: list[str] = []
+        for _, raw_doi in dataset_dois:
+            norm = normalize_doi(raw_doi)
+            if not norm or norm not in doi_cache:
+                continue
+            entry = doi_cache[norm]
+            authors = entry.get("authors", [])
+            if not authors:
+                no_authors.append(norm)
+
+        if no_authors:
+            msg = "\n".join(f"  {d}" for d in no_authors[:10])
+            print(
+                f"\nWarning: {len(no_authors)} DOI(s) resolved without "
+                f"authors (may be datasets, not papers):\n{msg}"
+            )
+
+
+# ===================================================================
+# Unit tests for doi_utils helpers
+# ===================================================================
+
+
+class TestNormalizeDOI:
+    def test_bare(self):
+        assert normalize_doi("10.1234/foo") == "10.1234/foo"
+
+    def test_doi_prefix(self):
+        assert normalize_doi("doi:10.1234/foo") == "10.1234/foo"
+
+    def test_https_url(self):
+        assert normalize_doi("https://doi.org/10.1234/foo") == "10.1234/foo"
+
+    def test_http_url(self):
+        assert normalize_doi("http://doi.org/10.1234/foo") == "10.1234/foo"
+
+    def test_dx_url(self):
+        assert normalize_doi("https://dx.doi.org/10.1234/foo") == "10.1234/foo"
+
+    def test_whitespace(self):
+        assert normalize_doi("  10.1234/foo  ") == "10.1234/foo"
+
+    def test_none(self):
+        assert normalize_doi(None) is None
+
+    def test_empty(self):
+        assert normalize_doi("") is None
+
+
+class TestIsValidDOI:
+    def test_valid(self):
+        assert is_valid_doi("10.1234/foo") is True
+        assert is_valid_doi("10.18112/openneuro.ds001785.v1.1.1") is True
+
+    def test_invalid_prefix(self):
+        assert is_valid_doi("11.1234/foo") is False
+
+    def test_short_registrant(self):
+        assert is_valid_doi("10.12/foo") is False
+
+    def test_no_suffix(self):
+        assert is_valid_doi("10.1234/") is False
+
+    def test_none(self):
+        assert is_valid_doi(None) is False
+
+    def test_with_url_prefix(self):
+        assert is_valid_doi("doi:10.1234/foo") is True
+
+
+class TestExtractSurnames:
+    def test_basic(self):
+        authors = [
+            {"family": "Smith", "given": "John"},
+            {"family": "Doe", "given": "Jane"},
+        ]
+        assert extract_surnames(authors) == ["smith", "doe"]
+
+    def test_empty(self):
+        assert extract_surnames([]) == []
+
+    def test_missing_family(self):
+        assert extract_surnames([{"given": "John"}]) == []
+
+
+class TestSurnamesOverlap:
+    def test_overlap(self):
+        a = [{"family": "Smith"}, {"family": "Doe"}]
+        b = [{"family": "Doe"}, {"family": "Roe"}]
+        assert surnames_overlap(a, b) == {"doe"}
+
+    def test_no_overlap(self):
+        a = [{"family": "Smith"}]
+        b = [{"family": "Doe"}]
+        assert surnames_overlap(a, b) == set()

--- a/tests/unit_tests/test_http_api_client.py
+++ b/tests/unit_tests/test_http_api_client.py
@@ -1,247 +1,313 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from eegdash.http_api_client import DEFAULT_API_URL, EEGDashAPIClient
-
-
-def test_client_init_defaults():
-    client = EEGDashAPIClient()
-    assert client.api_url == DEFAULT_API_URL
-    assert client.database == "eegdash"
-
-
-def test_client_auth_injection():
-    # Mock session
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-
-        # 1. Constructor auth
-        _client = EEGDashAPIClient(auth_token="secret")
-        # Session created, headers updated?
-        # The code does session.headers.update(...)
-        session.headers.update.assert_any_call({"Authorization": "Bearer secret"})
-
-        # 2. Admin token env (for dev/test)
-        os.environ["EEGDASH_ADMIN_TOKEN"] = "admin_secret"
-        _client2 = EEGDashAPIClient()
-        session.headers.update.assert_any_call({"X-EEGDASH-TOKEN": "admin_secret"})
-        del os.environ["EEGDASH_ADMIN_TOKEN"]
-
-
-def test_find_pagination():
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-        client = EEGDashAPIClient()
-
-        # Mock 2 pages response
-        # Page 1
-        r1 = MagicMock()
-        r1.json.return_value = {"data": [{"id": i} for i in range(1000)]}
-        # Page 2
-        r2 = MagicMock()
-        r2.json.return_value = {"data": [{"id": i} for i in range(1000, 1100)]}
-
-        session.get.side_effect = [r1, r2]
-
-        # Should fetch all
-        results = client.find(dataset="ds1")
-        assert len(results) == 1100
-        assert results[0]["id"] == 0
-        assert results[-1]["id"] == 1099
-
-        assert session.get.call_count == 2
-
-
-def test_find_pagination_break_empty():
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-        client = EEGDashAPIClient()
-
-        r1 = MagicMock()
-        r1.json.return_value = {"data": []}
-        session.get.return_value = r1
-
-        results = client.find()
-        assert len(results) == 0
-
-
-def test_insert_methods():
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-        client = EEGDashAPIClient()
-
-        # Insert One
-        r_one = MagicMock()
-        r_one.json.return_value = {"insertedId": "abc"}
-        session.post.return_value = r_one
-        assert client.insert_one({"a": 1}) == "abc"
-
-        # Insert Many
-        r_many = MagicMock()
-        r_many.json.return_value = {"insertedCount": 5}
-        session.post.return_value = r_many
-        assert client.insert_many([{"a": 1}]) == 5
-
-
-def test_update_many():
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-        client = EEGDashAPIClient()
-
-        r_patch = MagicMock()
-        r_patch.json.return_value = {"matched_count": 2, "modified_count": 1}
-        session.patch.return_value = r_patch
-
-        m, mod = client.update_many({"a": 1}, {"$set": {"b": 2}})
-        assert m == 2
-        assert mod == 1
-
-
-def test_find_with_skip_parameter():
-    """Test find method with skip parameter."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.http_api_client import EEGDashAPIClient
-
-    with patch("requests.Session") as MockSession:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"data": [{"id": 1}]}
-        mock_response.raise_for_status = MagicMock()
-        MockSession.return_value.get.return_value = mock_response
-
-        client = EEGDashAPIClient()
-        # Use skip parameter (line 73)
-        client.find({"test": "value"}, limit=10, skip=5)
-
-        # Verify skip was passed
-        call_args = MockSession.return_value.get.call_args
-        assert call_args[1]["params"]["skip"] == 5
-
-
-def test_find_none_returns_empty():
-    """Test find_one when no results found."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.http_api_client import EEGDashAPIClient
-
-    with patch("requests.Session") as MockSession:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"data": []}
-        mock_response.raise_for_status = MagicMock()
-        MockSession.return_value.get.return_value = mock_response
-
-        client = EEGDashAPIClient()
-        # Lines 104-105: find_one returning None
-        result = client.find_one({"nonexistent": "query"})
-        assert result is None
-
-
-def test_find_with_skip_parameter_percent():
-    """Test find with skip parameter (line 73)."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.http_api_client import EEGDashAPIClient
-
-    with patch("requests.Session") as mock_session_class:
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"data": [{"id": 1}]}
-        mock_session.get.return_value = mock_response
-
-        client = EEGDashAPIClient()
-        client.find(query={"test": 1}, limit=10, skip=5)
-
-        # Check skip was passed
-        call_args = mock_session.get.call_args
-        assert call_args[1]["params"]["skip"] == 5
-
-
-def test_insert_many():
-    """Test insert_many method (lines 104-105)."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.http_api_client import EEGDashAPIClient
-
-    with patch("requests.Session") as mock_session_class:
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"insertedCount": 2}
-        mock_session.post.return_value = mock_response
-
-        client = EEGDashAPIClient()
-        result = client.insert_many([{"a": 1}, {"b": 2}])
-        assert result == 2
-
-
-def test_api_client_session_auth():
-    import os
-    from unittest.mock import patch
-
-    from eegdash.http_api_client import get_client
-
-    with patch.dict(os.environ, {"EEGDASH_ADMIN_TOKEN": "adm"}):
-        client = get_client(auth_token="usr")
-        assert client._session.headers["Authorization"] == "Bearer usr"
-        assert client._session.headers["X-EEGDASH-TOKEN"] == "adm"
-
-
-def test_api_pagination():
-    from unittest.mock import MagicMock
-
-    from eegdash.http_api_client import get_client
-
-    client = get_client()
-    mock_resp_1 = MagicMock()
-    mock_resp_1.json.return_value = {"data": [{"id": i} for i in range(1000)]}
-    mock_resp_2 = MagicMock()
-    mock_resp_2.json.return_value = {"data": [{"id": 1001}]}
-
-    client._session.get = MagicMock(side_effect=[mock_resp_1, mock_resp_2])
-
-    res = client.find(query={})
-    assert len(res) == 1001
-    assert client._session.get.call_count == 2
-
-
-def test_api_methods():
-    from unittest.mock import MagicMock
-
-    from eegdash.http_api_client import get_client
-
-    client = get_client()
-    client._session.post = MagicMock()
-    client._session.patch = MagicMock()
-
-    client.insert_one({"a": 1})
-    client.insert_many([{"a": 1}])
-    client.update_many({"a": 1}, {"b": 2})
-
-    assert client._session.post.call_count == 2
-    assert client._session.patch.call_count == 1
-
-
-def test_upsert_many():
-    """Test upsert_many method."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.http_api_client import EEGDashAPIClient
-
-    with patch("requests.Session") as mock_session_cls:
-        session = mock_session_cls.return_value
-        client = EEGDashAPIClient()
-
-        r_upsert = MagicMock()
-        r_upsert.json.return_value = {"inserted_count": 10, "updated_count": 5}
-        session.post.return_value = r_upsert
-
-        result = client.upsert_many([{"a": 1}])
-        assert result["inserted_count"] == 10
-        assert result["updated_count"] == 5
-
-        # Verify call arguments
-        session.post.assert_called_once()
-        args, kwargs = session.post.call_args
-        assert kwargs["json"] == [{"a": 1}]
-        assert "records/upsert" in args[0]
+import pytest
+
+from eegdash.http_api_client import (
+    DEFAULT_API_URL,
+    EEGDashAPIClient,
+    _make_session,
+    get_client,
+)
+
+
+def _resp(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+@pytest.mark.parametrize(
+    "auth_token,admin_token,expected_header_updates",
+    [
+        ("user-token", None, [{"Authorization": "Bearer user-token"}]),
+        (None, "admin-token", [{"X-EEGDASH-TOKEN": "admin-token"}]),
+        (
+            "user-token",
+            "admin-token",
+            [
+                {"Authorization": "Bearer user-token"},
+                {"X-EEGDASH-TOKEN": "admin-token"},
+            ],
+        ),
+        (None, None, []),
+    ],
+)
+def test_make_session_header_injection(
+    auth_token, admin_token, expected_header_updates
+):
+    with patch("eegdash.http_api_client.requests.Session") as session_cls:
+        session = session_cls.return_value
+        session.headers = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=False):
+            if admin_token is None:
+                os.environ.pop("EEGDASH_ADMIN_TOKEN", None)
+            else:
+                os.environ["EEGDASH_ADMIN_TOKEN"] = admin_token
+
+            _make_session(auth_token)
+
+        assert [
+            args.args[0] for args in session.headers.update.call_args_list
+        ] == expected_header_updates
+        assert [args.args[0] for args in session.mount.call_args_list] == [
+            "https://",
+            "http://",
+        ]
+
+
+@pytest.mark.parametrize(
+    "api_url_arg,env_api_url,env_auth_token,auth_token_arg,expected_url,expected_auth",
+    [
+        (
+            "https://explicit.test/",
+            "https://env.test/",
+            "env-token",
+            None,
+            "https://explicit.test",
+            "env-token",
+        ),
+        (None, "https://env.test///", None, None, "https://env.test", None),
+        (None, None, None, None, DEFAULT_API_URL, None),
+        (None, None, "env-token", "direct-token", DEFAULT_API_URL, "direct-token"),
+    ],
+)
+def test_client_init_url_and_auth_precedence(
+    monkeypatch,
+    api_url_arg,
+    env_api_url,
+    env_auth_token,
+    auth_token_arg,
+    expected_url,
+    expected_auth,
+):
+    if env_api_url is None:
+        monkeypatch.delenv("EEGDASH_API_URL", raising=False)
+    else:
+        monkeypatch.setenv("EEGDASH_API_URL", env_api_url)
+
+    if env_auth_token is None:
+        monkeypatch.delenv("EEGDASH_API_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("EEGDASH_API_TOKEN", env_auth_token)
+
+    with patch(
+        "eegdash.http_api_client._make_session", return_value=MagicMock()
+    ) as make_session:
+        client = EEGDashAPIClient(
+            api_url=api_url_arg, auth_token=auth_token_arg, database="db"
+        )
+
+    assert client.api_url == expected_url
+    assert client.database == "db"
+    make_session.assert_called_once_with(expected_auth)
+
+
+@pytest.fixture
+def client_and_session():
+    with patch("eegdash.http_api_client.requests.Session") as session_cls:
+        session = session_cls.return_value
+        client = EEGDashAPIClient(api_url="https://api.test")
+        yield client, session
+
+
+@pytest.mark.parametrize(
+    "skip,expected_params",
+    [
+        (0, {"filter": '{"dataset": "ds1"}', "limit": 10}),
+        (5, {"filter": '{"dataset": "ds1"}', "skip": 5, "limit": 10}),
+    ],
+)
+def test_find_with_limit_builds_expected_params(
+    client_and_session, skip, expected_params
+):
+    client, session = client_and_session
+    response = _resp({"data": [{"id": 1}]})
+    session.get.return_value = response
+
+    records = client.find(query={"dataset": "ds1"}, limit=10, skip=skip)
+
+    assert records == [{"id": 1}]
+    session.get.assert_called_once_with(
+        "https://api.test/api/eegdash/records", params=expected_params, timeout=30
+    )
+
+
+@pytest.mark.parametrize(
+    "page_sizes,start_skip,expected_call_skips,expected_total",
+    [
+        ([1000, 1000, 50], 0, [0, 1000, 2000], 2050),
+        ([1000, 0], 25, [25, 1025], 1000),
+        ([0], 0, [0], 0),
+    ],
+)
+def test_find_autopagination(
+    client_and_session, page_sizes, start_skip, expected_call_skips, expected_total
+):
+    client, session = client_and_session
+    responses = [
+        _resp({"data": [{"i": idx} for idx in range(size)]}) for size in page_sizes
+    ]
+    session.get.side_effect = responses
+
+    records = client.find(query={"k": "v"}, skip=start_skip)
+
+    assert len(records) == expected_total
+    observed_skips = [
+        kwargs["params"]["skip"] for _, kwargs in session.get.call_args_list
+    ]
+    assert observed_skips == expected_call_skips
+
+
+@pytest.mark.parametrize(
+    "status_code,payload,expect_none,raises",
+    [
+        (404, {"data": {"dataset_id": "x"}}, True, False),
+        (200, {"data": {"dataset_id": "x"}}, False, False),
+        (500, {}, False, True),
+    ],
+)
+def test_get_dataset_status_handling(
+    client_and_session, status_code, payload, expect_none, raises
+):
+    client, session = client_and_session
+    response = _resp(payload, status_code=status_code)
+    if raises:
+        response.raise_for_status.side_effect = RuntimeError("boom")
+    session.get.return_value = response
+
+    if raises:
+        with pytest.raises(RuntimeError, match="boom"):
+            client.get_dataset("ds1")
+        return
+
+    result = client.get_dataset("ds1")
+    assert (result is None) is expect_none
+    if not expect_none:
+        assert result == {"dataset_id": "x"}
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"data": [{"dataset": "ds1"}]}, [{"dataset": "ds1"}]),
+        ([{"dataset": "ds1"}], [{"dataset": "ds1"}]),
+    ],
+)
+def test_find_datasets_supports_dict_or_list_payload(
+    client_and_session, payload, expected
+):
+    client, session = client_and_session
+    session.get.return_value = _resp(payload)
+
+    result = client.find_datasets(query={"dataset": "ds1"}, limit=50)
+
+    assert result == expected
+    session.get.assert_called_once_with(
+        "https://api.test/api/eegdash/datasets",
+        params={"limit": 50, "filter": '{"dataset": "ds1"}'},
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize(
+    "query,expected_params",
+    [
+        (None, {}),
+        ({"dataset": "ds1"}, {"filter": '{"dataset": "ds1"}'}),
+    ],
+)
+def test_count_documents_optional_filter(client_and_session, query, expected_params):
+    client, session = client_and_session
+    session.get.return_value = _resp({"count": 7})
+
+    assert client.count_documents(query) == 7
+    session.get.assert_called_once_with(
+        "https://api.test/api/eegdash/count", params=expected_params, timeout=30
+    )
+
+
+@pytest.mark.parametrize(
+    "method_name,http_method,args,response_payload,expected_result,expected_timeout,expected_path",
+    [
+        (
+            "insert_one",
+            "post",
+            ({"a": 1},),
+            {"insertedId": "abc"},
+            "abc",
+            30,
+            "/admin/eegdash/records",
+        ),
+        (
+            "insert_many",
+            "post",
+            ([{"a": 1}],),
+            {"insertedCount": 3},
+            3,
+            60,
+            "/admin/eegdash/records/bulk",
+        ),
+        (
+            "update_many",
+            "patch",
+            ({"a": 1}, {"b": 2}),
+            {"matched_count": 4, "modified_count": 1},
+            (4, 1),
+            60,
+            "/admin/eegdash/records",
+        ),
+        (
+            "update_dataset",
+            "patch",
+            ("ds1", {"a": 1}),
+            {"modified_count": 1},
+            1,
+            30,
+            "/admin/eegdash/datasets/ds1",
+        ),
+        (
+            "upsert_many",
+            "post",
+            ([{"a": 1}],),
+            {"inserted_count": 2, "updated_count": 5},
+            {"inserted_count": 2, "updated_count": 5},
+            60,
+            "/admin/eegdash/records/upsert",
+        ),
+    ],
+)
+def test_write_methods(
+    client_and_session,
+    method_name,
+    http_method,
+    args,
+    response_payload,
+    expected_result,
+    expected_timeout,
+    expected_path,
+):
+    client, session = client_and_session
+    mocked_method = getattr(session, http_method)
+    mocked_method.return_value = _resp(response_payload)
+
+    result = getattr(client, method_name)(*args)
+
+    assert result == expected_result
+    request_call = mocked_method.call_args
+    assert request_call.args[0] == f"https://api.test{expected_path}"
+    assert request_call.kwargs["timeout"] == expected_timeout
+
+
+def test_find_one_and_get_client(client_and_session):
+    client, session = client_and_session
+    session.get.return_value = _resp({"data": [{"id": "first"}]})
+    assert client.find_one({"dataset": "ds1"}) == {"id": "first"}
+
+    session.get.return_value = _resp({"data": []})
+    assert client.find_one({"dataset": "missing"}) is None
+
+    wrapped = get_client(api_url="https://api.test", database="db", auth_token="token")
+    assert isinstance(wrapped, EEGDashAPIClient)

--- a/tests/unit_tests/test_local_bids.py
+++ b/tests/unit_tests/test_local_bids.py
@@ -1,196 +1,221 @@
-from eegdash.local_bids import _normalize_modalities, discover_local_bids_records
+from types import SimpleNamespace
+
+import pytest
+
+from eegdash.local_bids import (
+    _get_file_metadata,
+    _normalize_modalities,
+    discover_local_bids_records,
+)
 
 
-def test_normalize_modalities():
-    assert _normalize_modalities(None) == ["eeg", "meg", "ieeg", "nirs", "fnirs", "emg"]
-    assert _normalize_modalities("eeg") == ["eeg"]
-    assert _normalize_modalities(["eeg", "fmri"]) == ["eeg", "fmri"]
-    assert _normalize_modalities("fnirs") == ["nirs"]  # Check alias
+@pytest.mark.parametrize(
+    "modality_filter,expected",
+    [
+        (None, ["eeg", "meg", "ieeg", "nirs", "fnirs", "emg"]),
+        ("fnirs", ["nirs"]),
+        ([" eeg ", "fnirs"], ["eeg", "nirs"]),
+        ([], ["eeg", "meg", "ieeg", "nirs", "fnirs", "emg"]),
+    ],
+)
+def test_normalize_modalities(modality_filter, expected):
+    assert _normalize_modalities(modality_filter) == expected
 
 
-def test_discover_local_bids_records(tmp_path):
-    # Create dummy structure
-    # ds1/
-    #   sub-01/
-    #     eeg/
-    #       sub-01_task-rest_eeg.set
-    #       sub-01_task-rest_eeg.json
-    ds_root = tmp_path / "ds1"
-    sub_dir = ds_root / "sub-01" / "eeg"
-    sub_dir.mkdir(parents=True)
+class _Helper:
+    def __init__(self, *, fail_attr=False, fail_channels=False):
+        self.fail_attr = fail_attr
+        self.fail_channels = fail_channels
 
-    k = sub_dir / "sub-01_task-rest_eeg.set"
-    k.touch()
-    (sub_dir / "sub-01_task-rest_eeg.json").touch()
+    def get_bids_file_attribute(self, name, _path):
+        if self.fail_attr:
+            raise RuntimeError("attr fail")
+        return {"sfreq": 128.0, "nchans": 64, "ntimes": 1024}[name]
 
-    # Filters
-    filters = {"dataset": "ds1", "subject": "01", "modality": "eeg"}
-
-    records = discover_local_bids_records(ds_root, filters)
-
-    assert len(records) == 1
-    rec = records[0]
-    # Entities are nested
-    assert rec["entities"]["subject"] == "01"
-    assert rec["entities"]["task"] == "rest"
-    assert rec["suffix"] == "eeg"
-    assert rec["dataset"] == "ds1"
-    # storage backend should be local
-    assert rec["storage"]["backend"] == "local"
+    def channel_labels(self, _path):
+        if self.fail_channels:
+            raise RuntimeError("ch fail")
+        return ["C3", "C4"]
 
 
-def test_discover_local_bids_records_filtering(tmp_path):
-    # Setup: sub-01 (rest), sub-02 (task)
-    ds_root = tmp_path / "ds2"
-    (ds_root / "sub-01" / "eeg").mkdir(parents=True)
-    (ds_root / "sub-02" / "eeg").mkdir(parents=True)
+@pytest.mark.parametrize(
+    "helper,expected",
+    [
+        (
+            None,
+            {
+                "sampling_frequency": None,
+                "nchans": None,
+                "ntimes": None,
+                "ch_names": None,
+            },
+        ),
+        (
+            _Helper(),
+            {
+                "sampling_frequency": 128.0,
+                "nchans": 64,
+                "ntimes": 1024,
+                "ch_names": ["C3", "C4"],
+            },
+        ),
+        (
+            _Helper(fail_channels=True),
+            {
+                "sampling_frequency": 128.0,
+                "nchans": 64,
+                "ntimes": 1024,
+                "ch_names": None,
+            },
+        ),
+        (
+            _Helper(fail_attr=True),
+            {
+                "sampling_frequency": None,
+                "nchans": None,
+                "ntimes": None,
+                "ch_names": None,
+            },
+        ),
+    ],
+)
+def test_get_file_metadata(helper, expected):
+    assert _get_file_metadata(helper, "dummy-file") == expected
 
-    (ds_root / "sub-01" / "eeg" / "sub-01_task-rest_eeg.vhdr").touch()
-    (ds_root / "sub-02" / "eeg" / "sub-02_task-task_eeg.vhdr").touch()
 
-    # Filter for sub-01 only
-    records = discover_local_bids_records(ds_root, {"dataset": "ds2", "subject": "01"})
+def test_discover_builds_matching_args(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_find_matching_paths(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "eegdash.local_bids.find_matching_paths", fake_find_matching_paths
+    )
+    records = discover_local_bids_records(
+        tmp_path,
+        {
+            "dataset": "ds1",
+            "modality": "eeg",
+            "subject": ["01", "02"],
+            "session": "01",
+            "run": [],
+        },
+    )
+
+    assert records == []
+    assert captured["subjects"] == ["01", "02"]
+    assert captured["sessions"] == ["01"]
+    assert "runs" not in captured
+
+
+def test_discover_filters_missing_derivative_and_invalid_extensions(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "ds1"
+    valid = root / "sub-01" / "eeg" / "sub-01_task-rest_eeg.vhdr"
+    derivative = root / "derivatives" / "sub-01" / "eeg" / "sub-01_task-rest_eeg.vhdr"
+    invalid = root / "sub-01" / "eeg" / "sub-01_task-rest_eeg.json"
+
+    valid.parent.mkdir(parents=True)
+    derivative.parent.mkdir(parents=True)
+    valid.touch()
+    derivative.touch()
+    invalid.touch()
+
+    outside = tmp_path / "outside_task-rest_eeg.vhdr"
+    outside.touch()
+
+    paths = [
+        SimpleNamespace(
+            fpath=str(valid),
+            datatype="eeg",
+            suffix="eeg",
+            subject="01",
+            session=None,
+            task="rest",
+            run=None,
+            acquisition=None,
+        ),
+        SimpleNamespace(
+            fpath=str(derivative),
+            datatype="eeg",
+            suffix="eeg",
+            subject="01",
+            session=None,
+            task="rest",
+            run=None,
+            acquisition=None,
+        ),
+        SimpleNamespace(
+            fpath=str(invalid),
+            datatype="eeg",
+            suffix="eeg",
+            subject="01",
+            session=None,
+            task="rest",
+            run=None,
+            acquisition=None,
+        ),
+        SimpleNamespace(
+            fpath=str(outside),
+            datatype="eeg",
+            suffix="eeg",
+            subject="09",
+            session=None,
+            task="rest",
+            run=None,
+            acquisition=None,
+        ),
+    ]
+
+    monkeypatch.setattr("eegdash.local_bids.find_matching_paths", lambda **_: paths)
+    monkeypatch.setattr(
+        "eegdash.local_bids.EEGBIDSDataset", lambda **_: None, raising=False
+    )
+
+    records = discover_local_bids_records(root, {"dataset": "ds1", "modality": "eeg"})
+
+    assert len(records) == 2
+    assert {record["entities"]["subject"] for record in records} == {"01", "09"}
+    # outside path cannot be made relative, so fallback is basename-only
+    outside_record = [r for r in records if r["entities"]["subject"] == "09"][0]
+    assert outside_record["bids_relpath"] == "outside_task-rest_eeg.vhdr"
+
+
+def test_discover_fallback_glob_after_valueerror(monkeypatch, tmp_path):
+    root = tmp_path / "ds1"
+    eeg_dir = root / "sub-01" / "eeg"
+    eeg_dir.mkdir(parents=True)
+    (eeg_dir / "sub-01_task-rest_run-01_eeg.vhdr").touch()
+    (eeg_dir / "sub-01_task-rest_eeg.json").touch()
+
+    def fail_find_matching_paths(**_kwargs):
+        raise ValueError("bad entity")
+
+    monkeypatch.setattr(
+        "eegdash.local_bids.find_matching_paths", fail_find_matching_paths
+    )
+
+    records = discover_local_bids_records(root, {"dataset": "ds1", "modality": "eeg"})
+
     assert len(records) == 1
     assert records[0]["entities"]["subject"] == "01"
+    assert records[0]["entities"]["run"] == "01"
+    assert records[0]["storage"]["backend"] == "local"
 
-    # Filter for task=task
-    records = discover_local_bids_records(ds_root, {"dataset": "ds2", "task": "task"})
+
+def test_discover_directory_format_fallback(monkeypatch, tmp_path):
+    root = tmp_path / "ds1"
+    ds_dir = root / "sub-01" / "meg" / "sub-01_task-rest_run-01_meg.ds"
+    ds_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("eegdash.local_bids.find_matching_paths", lambda **_: [])
+
+    records = discover_local_bids_records(root, {"dataset": "ds1", "modality": "meg"})
+
     assert len(records) == 1
-    assert records[0]["entities"]["subject"] == "02"
-
-
-def test_load_local_bids_with_list_filters(tmp_path):
-    """Test discover_local_bids_records with list-type filters."""
-    from unittest.mock import patch
-
-    from eegdash.local_bids import discover_local_bids_records
-
-    # Create minimal BIDS structure
-    (tmp_path / "dataset_description.json").write_text('{"Name": "Test"}')
-
-    # Lines 74-77: handle list/tuple/set filters
-    with patch("eegdash.local_bids.find_matching_paths", return_value=[]):
-        records = discover_local_bids_records(
-            dataset_root=str(tmp_path),
-            filters={
-                "dataset": "test_ds",
-                "modality": "eeg",
-                "subject": ["01", "02"],
-                "task": ("rest",),
-            },
-        )
-        assert records == []
-
-
-def test_local_bids_empty_list_filter(tmp_path):
-    """Test filter with empty list is ignored."""
-    from unittest.mock import patch
-
-    from eegdash.local_bids import discover_local_bids_records
-
-    # Line 76: empty entity_vals means continue
-    with patch("eegdash.local_bids.find_matching_paths", return_value=[]):
-        records = discover_local_bids_records(
-            dataset_root=str(tmp_path),
-            filters={
-                "dataset": "test_ds",
-                "modality": "eeg",
-                "subject": [],  # Empty list should be skipped
-            },
-        )
-        assert records == []
-
-
-def test_local_bids_relative_to_fails(tmp_path):
-    """Test bids_relpath fallback when resolve().relative_to() fails."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.local_bids import discover_local_bids_records
-
-    # Create a mock BIDSPath whose file is outside dataset_root
-    mock_bidspath = MagicMock()
-    mock_bidspath.fpath = "/other/location/sub-01_eeg.vhdr"
-    mock_bidspath.datatype = "eeg"
-    mock_bidspath.suffix = "eeg"
-    mock_bidspath.subject = "01"
-    mock_bidspath.session = None
-    mock_bidspath.task = "rest"
-    mock_bidspath.run = None
-
-    # If discover_local_bids_records is called, it iterates over find_matching_paths results
-    # We need to simulate that the file path is not relative to dataset_root
-    with patch("eegdash.local_bids.find_matching_paths", return_value=[mock_bidspath]):
-        # Also need to mock Path.relative_to to raise ValueError
-        with patch("pathlib.Path.relative_to", side_effect=ValueError):
-            # This test is tricky because discover_local_bids_records relies heavily on Path objects
-            # and we are mocking BIDSPath return.
-            # The line 124-125 catch the ValueError and use name
-            records = discover_local_bids_records(
-                str(tmp_path), filters={"dataset": "ds_root"}
-            )
-            # If it doesn't crash, it's good (though records might be empty or specific)
-            # Actually if relative_to fails it uses fpath.name.
-            # We just assert no crash
-            assert isinstance(records, list)
-
-
-def test_normalize_modalities_none():
-    """Test _normalize_modalities with None."""
-    from eegdash.local_bids import _normalize_modalities
-
-    result = _normalize_modalities(None)
-    assert result == ["eeg", "meg", "ieeg", "nirs", "fnirs", "emg"]
-
-
-def test_normalize_modalities_list():
-    """Test _normalize_modalities with list."""
-    from eegdash.local_bids import _normalize_modalities
-
-    result = _normalize_modalities(["eeg", "fnirs"])
-    assert "eeg" in result
-    assert "nirs" in result  # fnirs aliased to nirs
-
-
-def test_normalize_modalities_string():
-    """Test _normalize_modalities with string."""
-    from eegdash.local_bids import _normalize_modalities
-
-    result = _normalize_modalities("meg")
-    assert result == ["meg"]
-
-
-def test_discover_local_bids_records_invalid_extension(tmp_path):
-    """Test that invalid extensions are skipped (lines 120, 124-125)."""
-    from unittest.mock import MagicMock, patch
-
-    from eegdash.local_bids import discover_local_bids_records
-
-    # Create minimal BIDS structure
-    ds = tmp_path / "ds001234"
-    ds.mkdir()
-    (ds / "dataset_description.json").write_text('{"Name": "Test"}')
-    sub_dir = ds / "sub-01" / "eeg"
-    sub_dir.mkdir(parents=True)
-    # Create a .json file (should be skipped)
-    (sub_dir / "sub-01_task-rest_eeg.json").write_text("{}")
-    # Create a valid .set file
-    (sub_dir / "sub-01_task-rest_eeg.set").touch()
-
-    with patch("eegdash.local_bids.find_matching_paths") as mock_find:
-        mock_bp_json = MagicMock()
-        mock_bp_json.fpath = str(sub_dir / "sub-01_task-rest_eeg.json")
-        mock_bp_set = MagicMock()
-        mock_bp_set.fpath = str(sub_dir / "sub-01_task-rest_eeg.set")
-        mock_bp_set.datatype = "eeg"
-        mock_bp_set.suffix = "eeg"
-        mock_bp_set.subject = "01"
-        mock_bp_set.session = None
-        mock_bp_set.task = "rest"
-        mock_bp_set.run = None
-
-        mock_find.return_value = [mock_bp_json, mock_bp_set]
-
-        records = discover_local_bids_records(ds, {"dataset": "ds001234"})
-        # Only .set file should be included
-        assert len(records) == 1
-        assert records[0]["extension"] == ".set"
+    assert records[0]["entities"]["subject"] == "01"
+    assert records[0]["datatype"] == "meg"
+    assert records[0]["suffix"] == "meg"

--- a/tests/unit_tests/test_paths.py
+++ b/tests/unit_tests/test_paths.py
@@ -1,254 +1,48 @@
-import os
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from eegdash.paths import get_default_cache_dir
 
 
-def test_get_default_cache_dir_env(monkeypatch):
-    # Case 1: EEGDASH_CACHE_DIR environment variable is set
-    mock_path = "/tmp/mock_eegdash_cache"
-    monkeypatch.setenv("EEGDASH_CACHE_DIR", mock_path)
+@pytest.mark.parametrize("env_value", ["~/custom_eegdash_cache", "/opt/eegdash-cache"])
+def test_get_default_cache_dir_from_env(monkeypatch, env_value):
+    monkeypatch.setenv("EEGDASH_CACHE_DIR", env_value)
 
-    path = get_default_cache_dir()
-    assert path == Path(mock_path).resolve()
+    assert get_default_cache_dir() == Path(env_value).expanduser().resolve()
 
 
-def test_get_default_cache_dir_local(monkeypatch, tmp_path):
-    # Case 2: No env var, no MNE config -> defaults to local .eegdash_cache
+def test_get_default_cache_dir_prefers_local_hidden_folder(monkeypatch, tmp_path):
     monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
 
-    with patch("eegdash.paths.mne_get_config", return_value=None):
+    with patch("eegdash.paths.mne_get_config", return_value=str(tmp_path / "mne_data")):
         with patch.object(Path, "cwd", return_value=tmp_path):
-            path = get_default_cache_dir()
-            expected = tmp_path / ".eegdash_cache"
-            assert path == expected
-            assert path.exists()
+            resolved = get_default_cache_dir()
+
+    assert resolved == tmp_path / ".eegdash_cache"
+    assert resolved.exists()
 
 
-def test_get_default_cache_dir_mne(monkeypatch, tmp_path):
-    # Case 3: No env var, MNE_DATA config is set -> fallback to MNE_DATA
+@pytest.mark.parametrize(
+    "mne_value,expected_name",
+    [
+        ("~/mne-data", "mne-data"),
+        (None, ".eegdash_cache"),
+    ],
+)
+def test_get_default_cache_dir_fallbacks_when_local_mkdir_fails(
+    monkeypatch, tmp_path, mne_value, expected_name
+):
     monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
 
-    mne_data_path = tmp_path / "mne_data"
+    with patch.object(Path, "cwd", return_value=tmp_path):
+        with patch.object(Path, "mkdir", side_effect=PermissionError("readonly")):
+            with patch("eegdash.paths.mne_get_config", return_value=mne_value):
+                resolved = get_default_cache_dir()
 
-    # We simulate that local .eegdash_cache creation fails or we prefer checking priority order?
-    # Actually, the code checks local *before* MNE data if local creation succeeds.
-    # Wait, reading the code:
-    # 1. Env var
-    # 2. Local .eegdash_cache (if writable)
-    # 3. MNE_DATA
-
-    # So to test MNE_DATA, we need local creation to fail OR we need to verify priority.
-    # The docstring says: "2. A hidden directory ... 3. ... MNE_DATA (fallback)"
-    # But the code says:
-    # 44: local = Path.cwd() / ".eegdash_cache"
-    # 45: try: local.mkdir(...) return local
-    # So if local creation works, it returns local!
-
-    # Thus, MNE_DATA is only reached if local.mkdir raises Exception (e.g. read-only fs)
-
-    with patch("eegdash.paths.mne_get_config", return_value=str(mne_data_path)):
-        # Mock mkdir to raise PermissionError
-        with patch.object(Path, "mkdir", side_effect=PermissionError):
-            path = get_default_cache_dir()
-            assert path == mne_data_path.resolve()
-
-
-def test_paths_gap():
-    # Trigger paths.py fallback
-    os.environ.pop("EEGDASH_CACHE_DIR", None)
-    # Mocking cwd might be hard, but we can at least call it
-    res = get_default_cache_dir()
-    assert isinstance(res, Path)
-
-
-def test_paths_more():
-    from eegdash.paths import get_default_cache_dir
-
-    with patch("pathlib.Path.cwd", return_value=Path("/tmp")):
-        get_default_cache_dir()
-
-
-def test_paths_cache_dir_gap():
-    # get_default_cache_dir
-    # Mocking env vars
-    with patch.dict(os.environ, {}, clear=True):
-        # Should fallback to ~
-        d = get_default_cache_dir()
-        assert isinstance(d, Path)
-
-
-def test_mne_data_returns_configured_path(tmp_path, monkeypatch):
-    """Test that MNE_DATA config is returned when set and other paths don't exist."""
-    # Clear environment variables
-    monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
-    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-
-    mne_data_path = str(tmp_path / "mne_data")
-
-    # Mock Path.exists to return False for ~/.cache/eegdash
-    original_exists = Path.exists
-
-    def mock_exists(self):
-        if "eegdash" in str(self) and ".cache" in str(self):
-            return False
-        return original_exists(self)
-
-    # Mock mne_get_config to return our test path
-    with patch("eegdash.paths.Path.exists", mock_exists):
-        with patch("eegdash.paths.mne_get_config") as mock_mne_config:
-            mock_mne_config.return_value = mne_data_path
-
-            # Force reimport to use our mocks
-            import importlib
-
-            import eegdash.paths
-
-            importlib.reload(eegdash.paths)
-
-            result = eegdash.paths.get_default_cache_dir()
-            # When MNE_DATA is set and cache dir doesn't exist, should return MNE_DATA
-            # The actual behavior depends on the order of checks
-            assert result is not None
-
-    pass
-
-    pass
-
-
-def test_get_default_cache_dir_mne_data_env(tmp_path, monkeypatch):
-    """Test that MNE_DATA environment variable is used when set."""
-    from pathlib import Path
-    from unittest.mock import patch
-
-    from eegdash import paths
-
-    mne_data_path = str(tmp_path / "mne_data_cache")
-
-    # Mock mne.get_config to return the MNE_DATA path
-    with patch.object(paths, "mne_get_config") as mock_mne_config:
-        # First call for EEGDash_CACHE_DIR returns None
-        # We need to also patch the environment and other conditions
-        mock_mne_config.return_value = mne_data_path
-
-        # Create the directory
-        Path(mne_data_path).mkdir(parents=True, exist_ok=True)
-
-        # Remove the environment variable and home config
-        monkeypatch.delenv("EEGDash_CACHE_DIR", raising=False)
-
-        # Mock the home config to not exist
-        with patch("pathlib.Path.exists", return_value=False):
-            with patch("pathlib.Path.is_dir", return_value=False):
-                # Now test when MNE_DATA is configured
-                paths.get_default_cache_dir()
-                # Should use MNE_DATA since other options are not available
-                # The actual behavior depends on what exists
-
-
-def test_get_default_cache_dir_mne_data_fallback(tmp_path, monkeypatch):
-    """Test fallback to MNE_DATA when other paths don't exist."""
-    # Clear all env variables that could set cache
-    monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
-    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-
-    # Set MNE_DATA to our temp path
-    mne_data_path = str(tmp_path / "mne_data")
-    monkeypatch.setattr(
-        "eegdash.paths.mne_get_config",
-        lambda key: mne_data_path if key == "MNE_DATA" else None,
-    )
-
-    # Make sure ~/.cache/eegdash doesn't exist
-    from unittest.mock import patch
-
-    with patch("eegdash.paths.Path.exists", return_value=False):
-        from importlib import reload
-
-        import eegdash.paths as paths_module
-
-        reload(paths_module)
-        result = paths_module.get_default_cache_dir()
-        # Should return MNE_DATA path
-        assert "mne_data" in str(result) or result.exists() is False
-
-
-def test_mne_data_config_returns_path(monkeypatch):
-    """Test that MNE_DATA is returned when set."""
-    from unittest.mock import patch
-
-    from eegdash.paths import get_default_cache_dir
-
-    # Ensure no other env vars are set
-    monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
-    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-
-    # Mock mne_get_config to return a path
-    test_path = "/test/mne_data"
-
-    with patch("eegdash.paths.Path.exists", return_value=False):
-        with patch("eegdash.paths.mne_get_config", return_value=test_path):
-            get_default_cache_dir()
-            # The function may still return local, but we've exercised line 57
-
-
-def test_get_default_cache_dir_env_var(tmp_path, monkeypatch):
-    """Test EEGDASH_CACHE_DIR environment variable."""
-    from eegdash.paths import get_default_cache_dir
-
-    monkeypatch.setenv("EEGDASH_CACHE_DIR", str(tmp_path / "custom_cache"))
-    result = get_default_cache_dir()
-    assert result == (tmp_path / "custom_cache").resolve()
-
-
-def test_get_default_cache_dir_local_fallback(monkeypatch):
-    """Test local .eegdash_cache fallback."""
-    from eegdash.paths import get_default_cache_dir
-
-    monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
-    result = get_default_cache_dir()
-    assert ".eegdash_cache" in str(result)
-
-
-def test_get_default_cache_dir_mne_fallback(tmp_path, monkeypatch):
-    """Test MNE_DATA fallback when local mkdir fails (line 57)."""
-    from pathlib import Path
-    from unittest.mock import patch
-
-    from eegdash.paths import get_default_cache_dir
-
-    monkeypatch.delenv("EEGDASH_CACHE_DIR", raising=False)
-
-    # Mock Path.mkdir to raise an exception
-    original_mkdir = Path.mkdir
-
-    def failing_mkdir(self, *args, **kwargs):
-        if ".eegdash_cache" in str(self):
-            raise PermissionError("Cannot create directory")
-        return original_mkdir(self, *args, **kwargs)
-
-    # Mock MNE_DATA to return a valid path
-    with patch("eegdash.paths.mne_get_config") as mock_mne:
-        mock_mne.return_value = str(tmp_path / "mne_data")
-        with patch.object(Path, "mkdir", failing_mkdir):
-            result = get_default_cache_dir()
-            assert "mne_data" in str(result)
-
-
-def test_paths_resolution(tmp_path):
-    import os
-    from unittest.mock import patch
-
-    from eegdash import paths
-
-    # 1. Env var
-    with patch.dict(os.environ, {"EEGDASH_CACHE_DIR": str(tmp_path / "env")}):
-        assert paths.get_default_cache_dir() == tmp_path / "env"
-
-    # 2. Local fallback (assuming cwd mock hard, but we can verify created logical path)
-    # We can mock cwd
-    with patch("pathlib.Path.cwd", return_value=tmp_path):
-        with patch.dict(os.environ, {}, clear=True):
-            # Ensure hidden dir fallback
-            assert paths.get_default_cache_dir() == tmp_path / ".eegdash_cache"
+    assert resolved.name == expected_name
+    if mne_value is None:
+        assert resolved == tmp_path / ".eegdash_cache"
+    else:
+        assert resolved == Path(mne_value).expanduser().resolve()

--- a/tests_support/__init__.py
+++ b/tests_support/__init__.py
@@ -1,0 +1,1 @@
+"""Test-only support helpers."""

--- a/tests_support/bids_helpers.py
+++ b/tests_support/bids_helpers.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from eegdash.paths import get_default_cache_dir
+
+
+def is_bids_dataset_available() -> tuple[bool, str]:
+    """Check if the shared mini BIDS dataset is available and valid."""
+    cache_dir = Path(get_default_cache_dir())
+    path = cache_dir / "ds005509-bdf-mini"
+
+    if not path.exists():
+        return False, f"BIDS dataset not found at {path}"
+
+    if not (path / "dataset_description.json").exists():
+        return False, "Not a valid BIDS dataset (missing dataset_description.json)"
+
+    bdf_files = list(path.rglob("*.bdf"))
+    edf_files = list(path.rglob("*.edf"))
+    if not bdf_files and not edf_files:
+        return False, "No BDF/EDF data files found in dataset"
+
+    return True, ""


### PR DESCRIPTION
## Summary

- Expand the pytest suite across dataset, features, integration, e2e, and functional layers (~3.4k LOC of new tests, ~1.3k LOC refactored from existing files).
- Add `tests_support/` with shared BIDS helpers used by the new fixtures.
- Move DOI resolution helpers out of the library: `eegdash/doi_utils.py` → `scripts/citations/doi_utils.py`. They are dataset-maintenance utilities, not public API.

## What's new

- **Functional contracts** — `tests/functional/test_api_contracts.py`, `test_dataset_constructor_contracts.py`
- **Integration** — `test_dataset_interactions.py` (+ refactored `test_benchmarks.py`, `test_model_correctness.py`)
- **E2E** — `test_workflow_user_journeys.py` (+ refactored `test_speed_regression.py`)
- **Unit (dataset)** — `test_base_parametrized_helpers.py`, `test_registry.py`, plus expansions to `test_io.py` and `test_dataset_extended.py`
- **Unit (features)** — `feature_bank/test_pick.py`, `test_serialization_hotspots.py`
- **Unit (DOI)** — `test_doi_utils_core.py`, `test_doi_validation.py` (offline + `@pytest.mark.network` tiers)

## Why move `doi_utils`

Nothing inside `eegdash/` imports `doi_utils`; it is used only by the dataset-DOI validation tests and by the citations tooling under `scripts/citations/`. Keeping it in the library would expose maintenance helpers as public API. The script lives next to `fetch.py`, `to_gephi.py`, `to_vosviewer.py`.

## Test plan

- [x] `pytest tests/unit_tests/test_doi_utils_core.py tests/unit_tests/test_doi_validation.py -m "not network"` — 39 passed, 1 skipped (cache-completeness; needs network sync to populate)
- [ ] CI passes the full test suite on `tests/expand-coverage`
- [ ] Spot-check that the new `tests/functional/` and `tests_support/` packages are picked up by pytest collection
- [ ] Verify network DOI tier (`-m network -k test_resolve_all_dois`) still builds the cache after the relocation