### PR TITLE
Fix/desc construction

### DIFF
--- a/eegdash/bids_metadata.py
+++ b/eegdash/bids_metadata.py
@@ -18,7 +18,9 @@ import pandas as pd
 from .const import ALLOWED_QUERY_FIELDS
 
 __all__ = [
+    "build_description",
     "build_query_from_kwargs",
+    "find_key_in_nested_dict",
     "merge_query",
     "normalize_key",
     "merge_participants_fields",
@@ -576,3 +578,52 @@ def enrich_from_participants(
     extras = participants_extras_from_tsv(bids_root, subject)
     attach_participants_extras(raw, description, extras)
     return extras
+
+
+def find_key_in_nested_dict(data: Any, target_key: str) -> Any:
+    """Recursively search nested dicts/lists for target_key (case- and separator-insensitive)."""
+    norm_target = normalize_key(target_key)
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if normalize_key(k) == norm_target:
+                return v
+            if (res := find_key_in_nested_dict(v, target_key)) is not None:
+                return res
+    elif isinstance(data, list):
+        for item in data:
+            if (res := find_key_in_nested_dict(item, target_key)) is not None:
+                return res
+    return None
+
+
+def build_description(
+    record: dict[str, Any],
+    description_fields: list[str],
+    description_precedence: str = "record",
+    participants_row: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a description dict for one record, merging participant metadata."""
+    desc = {
+        f: v
+        for f in description_fields
+        if (v := find_key_in_nested_dict(record, f)) is not None
+    }
+    part = participants_row
+    if part is None:
+        embedded = find_key_in_nested_dict(record, "participant_tsv")
+        if isinstance(embedded, dict):
+            part = embedded
+    if isinstance(part, dict):
+        if description_precedence == "participant_tsv":
+            norm = {normalize_key(k): k for k, v in desc.items() if v is not None}
+            for part_key, part_val in part.items():
+                if field := norm.get(normalize_key(part_key)):
+                    desc[field] = part_val
+        desc = merge_participants_fields(
+            description=desc,
+            participants_row=part,
+            description_fields=description_fields,
+        )
+    for field in description_fields:
+        desc.setdefault(field, None)
+    return desc

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -653,10 +653,15 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 effective_part = embedded
 
         if isinstance(effective_part, dict):
-            norm_present = {normalize_key(k): k for k, v in description.items() if v is not None}
+            norm_present = {
+                normalize_key(k): k for k, v in description.items() if v is not None
+            }
             for part_key, part_val in effective_part.items():
                 existing_field = norm_present.get(normalize_key(part_key))
-                if existing_field is not None and description[existing_field] != part_val:
+                if (
+                    existing_field is not None
+                    and description[existing_field] != part_val
+                ):
                     if self._description_precedence == "participant_tsv":
                         logger.debug(
                             "Field '%s': participant_tsv value %r overwrote record value %r.",

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -616,7 +616,9 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                     f"Record data_name: {record.get('data_name', 'unknown')}"
                 )
 
-            description = build_description(record, description_fields, self._description_precedence)
+            description = build_description(
+                record, description_fields, self._description_precedence
+            )
             datasets.append(
                 EEGDashRaw(
                     record,

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -177,6 +177,23 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         Skipped recordings are flagged via ``ds._skipped`` so callers can
         filter them out with a list comprehension after iteration.
+    description_precedence : str, default "record"
+        Which source wins when the same field appears in both the record and
+        the embedded ``participant_tsv`` data:
+
+        - ``"record"`` (default): the record-level value is kept.
+        - ``"participant_tsv"``: the ``participant_tsv`` value overwrites the
+          record value for conflicting fields.
+
+        In both cases a ``debug``-level log is emitted when a conflict is
+        detected.
+
+        .. note::
+            When ``description_precedence="participant_tsv"``, a ``None``
+            value in ``participant_tsv`` will overwrite a non-``None`` record
+            value for the same field. This is deliberate — choosing this mode
+            means trusting the ``participant_tsv`` source fully, including its
+            gaps.
     **kwargs : dict
         Additional keyword arguments serving two purposes:
 
@@ -201,6 +218,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         auth_token: str | None = None,
         on_error: str = "raise",
         max_concurrency: int = 20,
+        description_precedence: str = "record",
         **kwargs,
     ):
         # Internal-only kwargs
@@ -208,6 +226,13 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         self._dedupe_records: bool = kwargs.pop("_dedupe_records", False)
 
         self._on_error = on_error
+        _VALID_PRECEDENCE = {"record", "participant_tsv"}
+        if description_precedence not in _VALID_PRECEDENCE:
+            raise ValueError(
+                f"description_precedence must be one of {sorted(_VALID_PRECEDENCE)}, "
+                f"got {description_precedence!r}"
+            )
+        self._description_precedence = description_precedence
         self.s3_bucket = s3_bucket
         self.database = database
         self.auth_token = auth_token
@@ -243,11 +268,14 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         if not suppress_comp_warning:
             _warn_if_competition_dataset(self.query["dataset"])
 
+        _built_descriptions: list[dict] = []
+
         if records is not None:
             datasets = []
             self.records = []
             for raw_record in records:
                 description = self._build_description(raw_record, description_fields)
+                _built_descriptions.append(description)
                 normalised = self._normalize_records([raw_record])
                 if not normalised:
                     continue
@@ -292,6 +320,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 desc = self._build_description(
                     record, description_fields, participants_row=part_row
                 )
+                _built_descriptions.append(desc)
                 datasets.append(
                     EEGDashRaw(
                         record=record,
@@ -316,6 +345,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 query=build_query_from_kwargs(**self.query),
                 description_fields=description_fields,
                 base_dataset_kwargs=base_dataset_kwargs,
+                built_descriptions=_built_descriptions,
             )
 
             if len(datasets) == 0:
@@ -342,21 +372,19 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         super().__init__(datasets, lazy=True)
 
         # Warn when a requested field produced no values across all recordings.
-        # Guarded with try/except because self.description requires real EEGDashRaw
-        # instances; mocked datasets (e.g. in unit tests) may not satisfy that.
-        if datasets:
-            try:
-                desc_df = self.description
-                all_none = [
-                    col for col in desc_df.columns if desc_df[col].isna().all()
-                ]
-                if all_none:
-                    logger.warning(
-                        "description_fields %s are None for all recordings — possible typo?",
-                        all_none,
-                    )
-            except Exception:
-                pass
+        # Uses the plain-dict descriptions collected during the build loops so
+        # this check is safe even when EEGDashRaw is mocked in unit tests.
+        if _built_descriptions:
+            all_none = [
+                f
+                for f in description_fields
+                if all(d.get(f) is None for d in _built_descriptions)
+            ]
+            if all_none:
+                logger.warning(
+                    "description_fields %s are None for all recordings — possible typo?",
+                    all_none,
+                )
 
     @property
     def cumulative_sizes(self) -> list[int]:
@@ -629,12 +657,21 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             for part_key, part_val in effective_part.items():
                 existing_field = norm_present.get(normalize_key(part_key))
                 if existing_field is not None and description[existing_field] != part_val:
-                    logger.debug(
-                        "Field '%s': record value %r kept over participant_tsv value %r.",
-                        existing_field,
-                        description[existing_field],
-                        part_val,
-                    )
+                    if self._description_precedence == "participant_tsv":
+                        logger.debug(
+                            "Field '%s': participant_tsv value %r overwrote record value %r.",
+                            existing_field,
+                            part_val,
+                            description[existing_field],
+                        )
+                        description[existing_field] = part_val
+                    else:
+                        logger.debug(
+                            "Field '%s': record value %r kept over participant_tsv value %r.",
+                            existing_field,
+                            description[existing_field],
+                            part_val,
+                        )
             description = merge_participants_fields(
                 description=description,
                 participants_row=effective_part,
@@ -681,6 +718,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         query: dict[str, Any] | None,
         description_fields: list[str],
         base_dataset_kwargs: dict,
+        built_descriptions: list[dict] | None = None,
     ) -> list[EEGDashRaw]:
         """Find and construct datasets from a MongoDB query.
 
@@ -722,6 +760,8 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 )
 
             description = self._build_description(record, description_fields)
+            if built_descriptions is not None:
+                built_descriptions.append(description)
             datasets.append(
                 EEGDashRaw(
                     record,

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -226,10 +226,10 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         self._dedupe_records: bool = kwargs.pop("_dedupe_records", False)
 
         self._on_error = on_error
-        _VALID_PRECEDENCE = {"record", "participant_tsv"}
-        if description_precedence not in _VALID_PRECEDENCE:
+        _valid = {"record", "participant_tsv"}
+        if description_precedence not in _valid:
             raise ValueError(
-                f"description_precedence must be one of {sorted(_VALID_PRECEDENCE)}, "
+                f"description_precedence must be one of {sorted(_valid)}, "
                 f"got {description_precedence!r}"
             )
         self._description_precedence = description_precedence
@@ -268,18 +268,11 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         if not suppress_comp_warning:
             _warn_if_competition_dataset(self.query["dataset"])
 
-        _built_descriptions: list[dict] = []
-
         if records is not None:
+            self.records = self._normalize_records(records)
             datasets = []
-            self.records = []
-            for raw_record in records:
-                description = self._build_description(raw_record, description_fields)
-                _built_descriptions.append(description)
-                normalised = self._normalize_records([raw_record])
-                if not normalised:
-                    continue
-                norm_record = normalised[0]
+            for norm_record in self.records:
+                description = self._build_description(norm_record, description_fields)
                 datasets.append(
                     EEGDashRaw(
                         norm_record,
@@ -288,7 +281,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                         **base_dataset_kwargs,
                     )
                 )
-                self.records.append(norm_record)
         elif not download:  # only assume local data is complete if not downloading
             if not self.data_dir.exists():
                 raise ValueError(
@@ -320,7 +312,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 desc = self._build_description(
                     record, description_fields, participants_row=part_row
                 )
-                _built_descriptions.append(desc)
                 datasets.append(
                     EEGDashRaw(
                         record=record,
@@ -345,7 +336,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 query=build_query_from_kwargs(**self.query),
                 description_fields=description_fields,
                 base_dataset_kwargs=base_dataset_kwargs,
-                built_descriptions=_built_descriptions,
             )
 
             if len(datasets) == 0:
@@ -370,21 +360,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 pass
 
         super().__init__(datasets, lazy=True)
-
-        # Warn when a requested field produced no values across all recordings.
-        # Uses the plain-dict descriptions collected during the build loops so
-        # this check is safe even when EEGDashRaw is mocked in unit tests.
-        if _built_descriptions:
-            all_none = [
-                f
-                for f in description_fields
-                if all(d.get(f) is None for d in _built_descriptions)
-            ]
-            if all_none:
-                logger.warning(
-                    "description_fields %s are None for all recordings — possible typo?",
-                    all_none,
-                )
 
     @property
     def cumulative_sizes(self) -> list[int]:
@@ -614,13 +589,14 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
     ) -> dict[str, Any]:
         """Build a description dict for a single record.
 
-        Pre-fills every requested field with ``None`` so the schema is always
-        complete, then overwrites with values found in the record.  Merges
+        Extracts values for each requested field from the record, then merges
         participant data from either an explicit ``participants_row`` (offline
         path, from a local ``participants.tsv``) or the embedded
-        ``participant_tsv`` key inside the record (online paths).  When both
-        the record and participant data carry the same field, the record value
-        wins; a ``debug``-level log is emitted when the values differ.
+        ``participant_tsv`` key inside the record (online paths).  Fields still
+        absent after the merge are set to ``None`` so the schema is always
+        complete.  When both the record and participant data carry the same
+        field, precedence is determined by ``self._description_precedence``; a
+        ``debug``-level log is emitted when the values differ.
 
         Parameters
         ----------
@@ -638,8 +614,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             A dictionary containing the requested description fields for the record.
 
         """
-        # Pre-fill with None so .description["subject"] never raises KeyError
-        description: dict[str, Any] = {field: None for field in description_fields}
+        description: dict[str, Any] = {}
 
         for field_name in description_fields:
             value = self._find_key_in_nested_dict(record, field_name)
@@ -683,6 +658,10 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 description_fields=description_fields,
             )
 
+        # Ensure all requested fields are present; None for any that were not found
+        for field in description_fields:
+            description.setdefault(field, None)
+
         return description
 
     def _find_key_in_nested_dict(self, data: Any, target_key: str) -> Any:
@@ -723,7 +702,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         query: dict[str, Any] | None,
         description_fields: list[str],
         base_dataset_kwargs: dict,
-        built_descriptions: list[dict] | None = None,
     ) -> list[EEGDashRaw]:
         """Find and construct datasets from a MongoDB query.
 
@@ -765,8 +743,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 )
 
             description = self._build_description(record, description_fields)
-            if built_descriptions is not None:
-                built_descriptions.append(description)
             datasets.append(
                 EEGDashRaw(
                     record,

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -341,18 +341,22 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         super().__init__(datasets, lazy=True)
 
-        # Warn when a requested field produced no values across all recordings
+        # Warn when a requested field produced no values across all recordings.
+        # Guarded with try/except because self.description requires real EEGDashRaw
+        # instances; mocked datasets (e.g. in unit tests) may not satisfy that.
         if datasets:
-            all_none = [
-                col
-                for col in self.description.columns
-                if self.description[col].isna().all()
-            ]
-            if all_none:
-                logger.warning(
-                    "description_fields %s are None for all recordings — possible typo?",
-                    all_none,
-                )
+            try:
+                desc_df = self.description
+                all_none = [
+                    col for col in desc_df.columns if desc_df[col].isna().all()
+                ]
+                if all_none:
+                    logger.warning(
+                        "description_fields %s are None for all recordings — possible typo?",
+                        all_none,
+                    )
+            except Exception:
+                pass
 
     @property
     def cumulative_sizes(self) -> list[int]:
@@ -589,6 +593,22 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         ``participant_tsv`` key inside the record (online paths).  When both
         the record and participant data carry the same field, the record value
         wins; a ``debug``-level log is emitted when the values differ.
+
+        Parameters
+        ----------
+        record : dict
+            The metadata for a single record.
+        description_fields : list of str
+            The fields to include in the description.
+        participants_row : dict or None
+            Optional participant-level metadata to merge. If None, the method
+            will look for an embedded ``participant_tsv`` key in the record.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the requested description fields for the record.
+
         """
         # Pre-fill with None so .description["subject"] never raises KeyError
         description: dict[str, Any] = {field: None for field in description_fields}

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -208,7 +208,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         auth_token: str | None = None,
         on_error: str = "raise",
         max_concurrency: int = 20,
-        description_precedence: str = "record",
+        description_precedence: str = "participant_tsv",
         **kwargs,
     ):
         # Internal-only kwargs

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -14,7 +14,6 @@ from braindecode.datasets import BaseConcatDataset
 from .. import downloader
 from ..bids_metadata import (
     build_query_from_kwargs,
-    get_entities_from_record,
     merge_participants_fields,
     normalize_key,
 )
@@ -245,16 +244,23 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             _warn_if_competition_dataset(self.query["dataset"])
 
         if records is not None:
-            self.records = self._normalize_records(records)
-
-            datasets = [
-                EEGDashRaw(
-                    record,
-                    self.cache_dir,
-                    **base_dataset_kwargs,
+            datasets = []
+            self.records = []
+            for raw_record in records:
+                description = self._build_description(raw_record, description_fields)
+                normalised = self._normalize_records([raw_record])
+                if not normalised:
+                    continue
+                norm_record = normalised[0]
+                datasets.append(
+                    EEGDashRaw(
+                        norm_record,
+                        self.cache_dir,
+                        description=description,
+                        **base_dataset_kwargs,
+                    )
                 )
-                for record in self.records
-            ]
+                self.records.append(norm_record)
         elif not download:  # only assume local data is complete if not downloading
             if not self.data_dir.exists():
                 raise ValueError(
@@ -272,26 +278,20 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
             datasets = []
             for record in records:
-                # Start with entity values from filename (supports v1 and v2 formats)
-                desc: dict[str, Any] = get_entities_from_record(record)
-
+                part_row: dict[str, Any] | None = None
                 if bids_ds is not None:
                     try:
                         rel_from_dataset = Path(record["bidspath"]).relative_to(
                             record["dataset"]
                         )  # type: ignore[index]
                         local_file = (self.data_dir / rel_from_dataset).as_posix()
-                        part_row = bids_ds.subject_participant_tsv(local_file)
-                        desc = merge_participants_fields(
-                            description=desc,
-                            participants_row=part_row
-                            if isinstance(part_row, dict)
-                            else None,
-                            description_fields=description_fields,
-                        )
+                        row = bids_ds.subject_participant_tsv(local_file)
+                        part_row = row if isinstance(row, dict) else None
                     except Exception:
                         pass
-
+                desc = self._build_description(
+                    record, description_fields, participants_row=part_row
+                )
                 datasets.append(
                     EEGDashRaw(
                         record=record,
@@ -340,6 +340,19 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                 pass
 
         super().__init__(datasets, lazy=True)
+
+        # Warn when a requested field produced no values across all recordings
+        if datasets:
+            all_none = [
+                col
+                for col in self.description.columns
+                if self.description[col].isna().all()
+            ]
+            if all_none:
+                logger.warning(
+                    "description_fields %s are None for all recordings — possible typo?",
+                    all_none,
+                )
 
     @property
     def cumulative_sizes(self) -> list[int]:
@@ -561,6 +574,55 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         """
         return discover_local_bids_records(dataset_root, filters)
 
+    def _build_description(
+        self,
+        record: dict[str, Any],
+        description_fields: list[str],
+        participants_row: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build a description dict for a single record.
+
+        Pre-fills every requested field with ``None`` so the schema is always
+        complete, then overwrites with values found in the record.  Merges
+        participant data from either an explicit ``participants_row`` (offline
+        path, from a local ``participants.tsv``) or the embedded
+        ``participant_tsv`` key inside the record (online paths).  When both
+        the record and participant data carry the same field, the record value
+        wins; a ``debug``-level log is emitted when the values differ.
+        """
+        # Pre-fill with None so .description["subject"] never raises KeyError
+        description: dict[str, Any] = {field: None for field in description_fields}
+
+        for field_name in description_fields:
+            value = self._find_key_in_nested_dict(record, field_name)
+            if value is not None:
+                description[field_name] = value
+
+        effective_part = participants_row
+        if effective_part is None:
+            embedded = self._find_key_in_nested_dict(record, "participant_tsv")
+            if isinstance(embedded, dict):
+                effective_part = embedded
+
+        if isinstance(effective_part, dict):
+            norm_present = {normalize_key(k): k for k, v in description.items() if v is not None}
+            for part_key, part_val in effective_part.items():
+                existing_field = norm_present.get(normalize_key(part_key))
+                if existing_field is not None and description[existing_field] != part_val:
+                    logger.debug(
+                        "Field '%s': record value %r kept over participant_tsv value %r.",
+                        existing_field,
+                        description[existing_field],
+                        part_val,
+                    )
+            description = merge_participants_fields(
+                description=description,
+                participants_row=effective_part,
+                description_fields=description_fields,
+            )
+
+        return description
+
     def _find_key_in_nested_dict(self, data: Any, target_key: str) -> Any:
         """Recursively search for a key in nested dicts/lists.
 
@@ -639,20 +701,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                     f"Record data_name: {record.get('data_name', 'unknown')}"
                 )
 
-            description: dict[str, Any] = {}
-            # Requested fields first (normalized matching)
-            for field_name in description_fields:
-                value = self._find_key_in_nested_dict(record, field_name)
-                if value is not None:
-                    description[field_name] = value
-            # Merge all participants.tsv columns generically
-            part = self._find_key_in_nested_dict(record, "participant_tsv")
-            if isinstance(part, dict):
-                description = merge_participants_fields(
-                    description=description,
-                    participants_row=part,
-                    description_fields=description_fields,
-                )
+            description = self._build_description(record, description_fields)
             datasets.append(
                 EEGDashRaw(
                     record,

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -176,14 +176,15 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         Skipped recordings are flagged via ``ds._skipped`` so callers can
         filter them out with a list comprehension after iteration.
-    description_precedence : str, default "record"
+    description_precedence : str, default "participant_tsv"
         Which source wins when the same field appears in both the record and
         the embedded ``participant_tsv`` data:
 
-        - ``"record"`` (default): the record-level value is kept.
-        - ``"participant_tsv"``: the ``participant_tsv`` value overwrites the
-          record value, including ``None`` values. Raises ``ValueError`` if
-          not one of the above.
+        - ``"participant_tsv"`` (default): the ``participant_tsv`` value
+          overwrites the record value, including ``None`` values.
+        - ``"record"``: the record-level value is kept.
+
+        Raises ``ValueError`` if not one of the above.
     **kwargs : dict
         Additional keyword arguments serving two purposes:
 

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -13,9 +13,8 @@ from braindecode.datasets import BaseConcatDataset
 
 from .. import downloader
 from ..bids_metadata import (
+    build_description,
     build_query_from_kwargs,
-    merge_participants_fields,
-    normalize_key,
 )
 from ..const import (
     ALLOWED_QUERY_FIELDS,
@@ -183,17 +182,8 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         - ``"record"`` (default): the record-level value is kept.
         - ``"participant_tsv"``: the ``participant_tsv`` value overwrites the
-          record value for conflicting fields.
-
-        In both cases a ``debug``-level log is emitted when a conflict is
-        detected.
-
-        .. note::
-            When ``description_precedence="participant_tsv"``, a ``None``
-            value in ``participant_tsv`` will overwrite a non-``None`` record
-            value for the same field. This is deliberate — choosing this mode
-            means trusting the ``participant_tsv`` source fully, including its
-            gaps.
+          record value, including ``None`` values. Raises ``ValueError`` if
+          not one of the above.
     **kwargs : dict
         Additional keyword arguments serving two purposes:
 
@@ -270,17 +260,17 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         if records is not None:
             self.records = self._normalize_records(records)
-            datasets = []
-            for norm_record in self.records:
-                description = self._build_description(norm_record, description_fields)
-                datasets.append(
-                    EEGDashRaw(
-                        norm_record,
-                        self.cache_dir,
-                        description=description,
-                        **base_dataset_kwargs,
-                    )
+            datasets = [
+                EEGDashRaw(
+                    record,
+                    self.cache_dir,
+                    description=build_description(
+                        record, description_fields, self._description_precedence
+                    ),
+                    **base_dataset_kwargs,
                 )
+                for record in self.records
+            ]
         elif not download:  # only assume local data is complete if not downloading
             if not self.data_dir.exists():
                 raise ValueError(
@@ -309,8 +299,8 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                         part_row = row if isinstance(row, dict) else None
                     except Exception:
                         pass
-                desc = self._build_description(
-                    record, description_fields, participants_row=part_row
+                desc = build_description(
+                    record, description_fields, self._description_precedence, part_row
                 )
                 datasets.append(
                     EEGDashRaw(
@@ -581,122 +571,6 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         """
         return discover_local_bids_records(dataset_root, filters)
 
-    def _build_description(
-        self,
-        record: dict[str, Any],
-        description_fields: list[str],
-        participants_row: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Build a description dict for a single record.
-
-        Extracts values for each requested field from the record, then merges
-        participant data from either an explicit ``participants_row`` (offline
-        path, from a local ``participants.tsv``) or the embedded
-        ``participant_tsv`` key inside the record (online paths).  Fields still
-        absent after the merge are set to ``None`` so the schema is always
-        complete.  When both the record and participant data carry the same
-        field, precedence is determined by ``self._description_precedence``; a
-        ``debug``-level log is emitted when the values differ.
-
-        Parameters
-        ----------
-        record : dict
-            The metadata for a single record.
-        description_fields : list of str
-            The fields to include in the description.
-        participants_row : dict or None
-            Optional participant-level metadata to merge. If None, the method
-            will look for an embedded ``participant_tsv`` key in the record.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the requested description fields for the record.
-
-        """
-        description: dict[str, Any] = {}
-
-        for field_name in description_fields:
-            value = self._find_key_in_nested_dict(record, field_name)
-            if value is not None:
-                description[field_name] = value
-
-        effective_part = participants_row
-        if effective_part is None:
-            embedded = self._find_key_in_nested_dict(record, "participant_tsv")
-            if isinstance(embedded, dict):
-                effective_part = embedded
-
-        if isinstance(effective_part, dict):
-            norm_present = {
-                normalize_key(k): k for k, v in description.items() if v is not None
-            }
-            for part_key, part_val in effective_part.items():
-                existing_field = norm_present.get(normalize_key(part_key))
-                if (
-                    existing_field is not None
-                    and description[existing_field] != part_val
-                ):
-                    if self._description_precedence == "participant_tsv":
-                        logger.debug(
-                            "Field '%s': participant_tsv value %r overwrote record value %r.",
-                            existing_field,
-                            part_val,
-                            description[existing_field],
-                        )
-                        description[existing_field] = part_val
-                    else:
-                        logger.debug(
-                            "Field '%s': record value %r kept over participant_tsv value %r.",
-                            existing_field,
-                            description[existing_field],
-                            part_val,
-                        )
-            description = merge_participants_fields(
-                description=description,
-                participants_row=effective_part,
-                description_fields=description_fields,
-            )
-
-        # Ensure all requested fields are present; None for any that were not found
-        for field in description_fields:
-            description.setdefault(field, None)
-
-        return description
-
-    def _find_key_in_nested_dict(self, data: Any, target_key: str) -> Any:
-        """Recursively search for a key in nested dicts/lists.
-
-        Performs a case-insensitive and underscore/hyphen-agnostic search.
-
-        Parameters
-        ----------
-        data : Any
-            The nested data structure (dicts, lists) to search.
-        target_key : str
-            The key to search for.
-
-        Returns
-        -------
-        Any
-            The value of the first matching key, or None if not found.
-
-        """
-        norm_target = normalize_key(target_key)
-        if isinstance(data, dict):
-            for k, v in data.items():
-                if normalize_key(k) == norm_target:
-                    return v
-                res = self._find_key_in_nested_dict(v, target_key)
-                if res is not None:
-                    return res
-        elif isinstance(data, list):
-            for item in data:
-                res = self._find_key_in_nested_dict(item, target_key)
-                if res is not None:
-                    return res
-        return None
-
     def _find_datasets(
         self,
         query: dict[str, Any] | None,
@@ -742,7 +616,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
                     f"Record data_name: {record.get('data_name', 'unknown')}"
                 )
 
-            description = self._build_description(record, description_fields)
+            description = build_description(record, description_fields, self._description_precedence)
             datasets.append(
                 EEGDashRaw(
                     record,

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -16,8 +16,7 @@ from eegdash.dataset.dataset import EEGDashDataset
 class _FakeRaw:
     """Minimal stand-in for EEGDashRaw.
 
-    MagicMock cannot be used: BaseConcatDataset iterates mock.description
-    indefinitely (100 % CPU). This stub provides a real pd.Series and __len__.
+    This stub provides a real pd.Series and __len__.
     """
 
     def __init__(self, record, cache_dir=None, description=None, **kwargs):

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -1,0 +1,208 @@
+"""Tests for the unified _build_description helper and the three EEGDashDataset
+initialization paths (records=, offline, query).
+
+Covers:
+- participant_tsv precedence conflict logging
+- None-padding for missing description fields
+- Case/hyphen-insensitive key matching
+- Description parity across all three construction paths
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from eegdash.dataset.dataset import EEGDashDataset
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def minimal_ds(tmp_path):
+    """Lightweight EEGDashDataset used as a host for direct _build_description calls.
+
+    EEGDashRaw is mocked so no filesystem or network access is required.
+    """
+    record = {
+        "dataset": "ds_bd_test",
+        "bidspath": "ds_bd_test/a.set",
+        "bids_relpath": "a.set",
+        "extension": ".set",
+        "storage": {"backend": "local", "base": str(tmp_path)},
+    }
+    with patch("eegdash.dataset.dataset.EEGDashRaw"):
+        ds = EEGDashDataset(cache_dir=tmp_path, records=[record], download=True)
+    return ds
+
+
+@pytest.fixture
+def parity_record(tmp_path):
+    """A v2-format record suitable for all three construction paths."""
+    return {
+        "dataset": "ds_parity",
+        "bidspath": "ds_parity/sub-01/eeg/sub-01_task-rest_eeg.set",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.set",
+        "extension": ".set",
+        "entities": {"subject": "01", "task": "rest"},
+        "entities_mne": {"subject": "01", "task": "rest"},
+        "storage": {"backend": "local", "base": str(tmp_path / "ds_parity")},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Precedence conflict: top-level record value wins over participant_tsv
+# ---------------------------------------------------------------------------
+
+
+def test_build_description_precedence_conflict(minimal_ds, caplog):
+    """Top-level record value is kept when participant_tsv carries a different value.
+
+    A debug-level log must be emitted to make the silent priority explicit.
+    """
+    record = {
+        "age": 30,  # top-level value that should win
+        "participant_tsv": {"age": 99, "sex": "M"},
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="eegdash"):
+        desc = minimal_ds._build_description(
+            record, description_fields=["age", "sex"]
+        )
+
+    assert desc["age"] == 30, "Top-level record value must take precedence"
+    assert desc["sex"] == "M", "Uncontested participant_tsv field must be merged"
+
+    conflict_logs = [m for m in caplog.messages if "age" in m and "30" in m]
+    assert conflict_logs, (
+        "Expected a debug log mentioning the 'age' conflict, got: "
+        + str(caplog.messages)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Missing fields are padded with None, not omitted
+# ---------------------------------------------------------------------------
+
+
+def test_build_description_missing_fields_padding(minimal_ds):
+    """Fields absent from the record appear in the description as None.
+
+    Accessing description["missing_field_xyz"] must not raise KeyError.
+    """
+    record = {
+        "entities": {"subject": "01"},
+    }
+    description_fields = ["subject", "missing_field_xyz"]
+
+    desc = minimal_ds._build_description(record, description_fields=description_fields)
+
+    assert "subject" in desc
+    assert desc["subject"] == "01"
+
+    assert "missing_field_xyz" in desc, (
+        "Missing field must be present in description (padded with None)"
+    )
+    assert desc["missing_field_xyz"] is None, (
+        "Missing field value must be None, not absent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Key lookup is case- and separator-insensitive
+# ---------------------------------------------------------------------------
+
+
+def test_build_description_key_insensitivity(minimal_ds):
+    """_find_key_in_nested_dict maps 'Subject-ID' in the record to 'subject_id' in fields."""
+    record = {
+        "Subject-ID": "sub-007",
+    }
+
+    desc = minimal_ds._build_description(
+        record, description_fields=["subject_id", "task"]
+    )
+
+    assert desc["subject_id"] == "sub-007", (
+        "Normalised key lookup must resolve 'Subject-ID' → 'subject_id'"
+    )
+    assert desc["task"] is None, "Absent field must be None"
+
+
+# ---------------------------------------------------------------------------
+# 4. Path parity: records=, offline, and query paths produce identical descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_initialization_path_parity(tmp_path, parity_record):
+    """All three EEGDashDataset construction paths must build identical descriptions.
+
+    EEGDashRaw is mocked throughout; the description dicts passed to each
+    constructor call are captured and compared via pandas.testing.assert_frame_equal.
+    """
+    description_fields = ["subject", "task"]
+    (tmp_path / "ds_parity").mkdir(parents=True, exist_ok=True)
+
+    with patch("eegdash.dataset.dataset.EEGDashRaw") as mock_raw_cls:
+
+        # -- Path 1: records= ------------------------------------------------
+        EEGDashDataset(
+            cache_dir=tmp_path,
+            records=[parity_record],
+            download=True,
+            description_fields=description_fields,
+        )
+        desc_records = mock_raw_cls.call_args_list[-1].kwargs["description"]
+        mock_raw_cls.reset_mock()
+
+        # -- Path 2: offline (download=False) ---------------------------------
+        # discover_local_bids_records is mocked to return the same record;
+        # EEGBIDSDataset is made to fail so no participant enrichment happens,
+        # keeping the result identical to what records= produces.
+        with (
+            patch(
+                "eegdash.dataset.dataset.discover_local_bids_records",
+                return_value=[parity_record],
+            ),
+            patch(
+                "eegdash.dataset.dataset.EEGBIDSDataset",
+                side_effect=Exception("no bids"),
+            ),
+        ):
+            EEGDashDataset(
+                cache_dir=tmp_path,
+                dataset="ds_parity",
+                download=False,
+                description_fields=description_fields,
+            )
+        desc_offline = mock_raw_cls.call_args_list[-1].kwargs["description"]
+        mock_raw_cls.reset_mock()
+
+        # -- Path 3: query (mocked API) ---------------------------------------
+        mock_api = MagicMock()
+        mock_api.find.return_value = [parity_record]
+        with patch("eegdash.dataset.dataset.validate_record", return_value=[]):
+            EEGDashDataset(
+                cache_dir=tmp_path,
+                dataset="ds_parity",
+                eeg_dash_instance=mock_api,
+                download=True,
+                description_fields=description_fields,
+            )
+        desc_query = mock_raw_cls.call_args_list[-1].kwargs["description"]
+
+    # Wrap each description dict in a single-row DataFrame and compare strictly.
+    df_records = pd.DataFrame([desc_records])
+    df_offline = pd.DataFrame([desc_offline])
+    df_query = pd.DataFrame([desc_query])
+
+    pd.testing.assert_frame_equal(
+        df_records, df_offline, check_like=True, obj="records= vs offline"
+    )
+    pd.testing.assert_frame_equal(
+        df_records, df_query, check_like=True, obj="records= vs query"
+    )

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -2,13 +2,10 @@
 initialization paths (records=, offline, query).
 
 Covers:
-- participant_tsv precedence conflict logging
-- None-padding for missing description fields
-- Case/hyphen-insensitive key matching
 - Description parity across all three construction paths
+- Configurable description_precedence (record vs participant_tsv)
 """
 
-import logging
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -49,21 +46,6 @@ class _FakeRaw:
 
 
 @pytest.fixture
-def minimal_ds(tmp_path):
-    """Lightweight EEGDashDataset used as a host for direct _build_description calls."""
-    record = {
-        "dataset": "ds_bd_test",
-        "bidspath": "ds_bd_test/a.set",
-        "bids_relpath": "a.set",
-        "extension": ".set",
-        "storage": {"backend": "local", "base": str(tmp_path)},
-    }
-    with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
-        ds = EEGDashDataset(cache_dir=tmp_path, records=[record], download=True)
-    return ds
-
-
-@pytest.fixture
 def parity_record(tmp_path):
     """A v2-format record suitable for all three construction paths."""
     return {
@@ -78,79 +60,7 @@ def parity_record(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 1. Precedence conflict: top-level record value wins over participant_tsv
-# ---------------------------------------------------------------------------
-
-
-def test_build_description_precedence_conflict(minimal_ds, caplog):
-    """Top-level record value is kept when participant_tsv carries a different value.
-
-    A debug-level log must be emitted to make the silent priority explicit.
-    """
-    record = {
-        "age": 30,  # top-level value that should win
-        "participant_tsv": {"age": 99, "sex": "M"},
-    }
-
-    with caplog.at_level(logging.DEBUG, logger="eegdash"):
-        desc = minimal_ds._build_description(record, description_fields=["age", "sex"])
-
-    assert desc["age"] == 30, "Top-level record value must take precedence"
-    assert desc["sex"] == "M", "Uncontested participant_tsv field must be merged"
-
-    conflict_logs = [m for m in caplog.messages if "age" in m and "30" in m]
-    assert conflict_logs, (
-        "Expected a debug log mentioning the 'age' conflict, got: "
-        + str(caplog.messages)
-    )
-    assert any("kept" in m for m in caplog.messages), (
-        "Default 'record' precedence must log 'kept', not 'overwrote'"
-    )
-
-
-# ---------------------------------------------------------------------------
-# 2. Missing fields are padded with None, not omitted
-# ---------------------------------------------------------------------------
-
-
-def test_build_description_missing_fields_padding(minimal_ds):
-    """Fields absent from the record appear in the description as None.
-
-    Accessing description["missing_field_xyz"] must not raise KeyError.
-    """
-    record = {"entities": {"subject": "01"}}
-    description_fields = ["subject", "missing_field_xyz"]
-
-    desc = minimal_ds._build_description(record, description_fields=description_fields)
-
-    assert desc["subject"] == "01"
-    assert "missing_field_xyz" in desc, (
-        "Missing field must be present in description (padded with None)"
-    )
-    assert desc["missing_field_xyz"] is None, "Missing field value must be None"
-
-
-# ---------------------------------------------------------------------------
-# 3. Key lookup is case- and separator-insensitive
-# ---------------------------------------------------------------------------
-
-
-def test_build_description_key_insensitivity(minimal_ds):
-    """_find_key_in_nested_dict maps 'Subject-ID' in the record to 'subject_id' in fields."""
-    record = {"Subject-ID": "sub-007"}
-
-    desc = minimal_ds._build_description(
-        record, description_fields=["subject_id", "task"]
-    )
-
-    assert desc["subject_id"] == "sub-007", (
-        "Normalised key lookup must resolve 'Subject-ID' → 'subject_id'"
-    )
-    assert desc["task"] is None, "Absent field must be None"
-
-
-# ---------------------------------------------------------------------------
-# 4. Path parity: records=, offline, and query paths produce identical descriptions
+# 1. Path parity: records=, offline, and query paths produce identical descriptions
 # ---------------------------------------------------------------------------
 
 
@@ -224,7 +134,7 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
 
 
 # ---------------------------------------------------------------------------
-# 5. description_precedence="participant_tsv" — participant_tsv values win
+# 2. description_precedence="participant_tsv" — participant_tsv values win
 # ---------------------------------------------------------------------------
 
 
@@ -272,7 +182,7 @@ def test_build_description_participant_tsv_precedence(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 6. Invalid description_precedence raises ValueError at construction
+# 3. Invalid description_precedence raises ValueError at construction
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -1,16 +1,11 @@
-"""Tests for the unified _build_description helper and the three EEGDashDataset
-initialization paths (records=, offline, query).
-
-Covers:
-- Description parity across all three construction paths
-- Configurable description_precedence (record vs participant_tsv)
-"""
+"""Tests for build_description and the three EEGDashDataset initialization paths."""
 
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 
+from eegdash.bids_metadata import build_description
 from eegdash.dataset.dataset import EEGDashDataset
 
 # ---------------------------------------------------------------------------
@@ -21,18 +16,11 @@ from eegdash.dataset.dataset import EEGDashDataset
 class _FakeRaw:
     """Minimal stand-in for EEGDashRaw.
 
-    Satisfies the two things BaseConcatDataset needs from each element:
-      - __len__ returning an integer
-      - description as a pd.Series
-
-    Stores the description kwarg so tests can inspect it later.
+    MagicMock cannot be used: BaseConcatDataset iterates mock.description
+    indefinitely (100 % CPU). This stub provides a real pd.Series and __len__.
     """
 
     def __init__(self, record, cache_dir=None, description=None, **kwargs):
-        _ = (
-            cache_dir,
-            kwargs,
-        )  # accepted to match EEGDashRaw's signature; not needed in stub
         self.record = record
         self.description = pd.Series(description or {}, dtype=object)
 
@@ -65,18 +53,12 @@ def parity_record(tmp_path):
 
 
 def test_dataset_initialization_path_parity(tmp_path, parity_record):
-    """All three EEGDashDataset construction paths must build identical descriptions.
-
-    _FakeRaw is used instead of MagicMock so BaseConcatDataset can safely
-    call len() and access .description on each element.  The description
-    passed to each _FakeRaw constructor is extracted and compared via
-    pandas.testing.assert_frame_equal.
-    """
+    """All three EEGDashDataset construction paths must build identical descriptions."""
     description_fields = ["subject", "task"]
     (tmp_path / "ds_parity").mkdir(parents=True, exist_ok=True)
 
     with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
-        # -- Path 1: records= ------------------------------------------------
+        # Path 1: records=
         ds_records = EEGDashDataset(
             cache_dir=tmp_path,
             records=[parity_record],
@@ -84,10 +66,7 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
             description_fields=description_fields,
         )
 
-        # -- Path 2: offline (download=False) ---------------------------------
-        # discover_local_bids_records returns the same record; EEGBIDSDataset
-        # is made to fail so no participant enrichment happens, keeping the
-        # result identical to what the records= path produces.
+        # Path 2: offline
         with (
             patch(
                 "eegdash.dataset.dataset.discover_local_bids_records",
@@ -105,7 +84,7 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
                 description_fields=description_fields,
             )
 
-        # -- Path 3: query (mocked API) ---------------------------------------
+        # Path 3: query (mocked API)
         mock_api = MagicMock()
         mock_api.find.return_value = [parity_record]
         with patch("eegdash.dataset.dataset.validate_record", return_value=[]):
@@ -117,8 +96,6 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
                 description_fields=description_fields,
             )
 
-    # BaseConcatDataset.description builds pd.DataFrame([ds.description for ds in datasets])
-    # _FakeRaw.description is a real pd.Series, so this works correctly.
     pd.testing.assert_frame_equal(
         ds_records.description,
         ds_offline.description,
@@ -134,51 +111,25 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
 
 
 # ---------------------------------------------------------------------------
-# 2. description_precedence="participant_tsv" — participant_tsv values win
+# 2. description_precedence — parametrized over all conflict scenarios
 # ---------------------------------------------------------------------------
 
 
-def test_build_description_participant_tsv_precedence(tmp_path):
-    """participant_tsv values overwrite conflicting record values when precedence='participant_tsv'.
-
-    Also verifies that a None value in participant_tsv overwrites a non-None
-    record value — this is intentional when the caller trusts that source fully.
-    """
-    _stub_record = {
-        "dataset": "ds_prec",
-        "bidspath": "ds_prec/a.set",
-        "bids_relpath": "a.set",
-        "extension": ".set",
-        "storage": {"backend": "local", "base": str(tmp_path)},
-    }
-    with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
-        ds = EEGDashDataset(
-            cache_dir=tmp_path,
-            records=[_stub_record],
-            download=True,
-            description_precedence="participant_tsv",
-        )
-
+@pytest.mark.parametrize(
+    "precedence,record_val,tsv_val,expected",
+    [
+        ("record", 30, 99, 30),
+        ("participant_tsv", 30, 99, 99),
+        ("participant_tsv", 30, None, None),
+    ],
+)
+def test_build_description_precedence(precedence, record_val, tsv_val, expected):
     record = {
-        "age": 30,
-        "participant_tsv": {"age": 99, "sex": "M"},
+        "age": record_val,
+        "participant_tsv": {"age": tsv_val, "sex": "M"},
     }
-    desc = ds._build_description(record, description_fields=["age", "sex"])
-
-    assert desc["age"] == 99, (
-        "participant_tsv value must win when precedence='participant_tsv'"
-    )
-    assert desc["sex"] == "M"
-
-    # None in participant_tsv overwrites a real record value (documented behaviour).
-    record_none = {
-        "age": 30,
-        "participant_tsv": {"age": None},
-    }
-    desc_none = ds._build_description(record_none, description_fields=["age"])
-    assert desc_none["age"] is None, (
-        "None in participant_tsv must overwrite record value when precedence='participant_tsv'"
-    )
+    desc = build_description(record, ["age", "sex"], description_precedence=precedence)
+    assert desc["age"] == expected
 
 
 # ---------------------------------------------------------------------------
@@ -186,8 +137,8 @@ def test_build_description_participant_tsv_precedence(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_dataset_invalid_description_precedence(tmp_path):
-    """An unsupported description_precedence value raises ValueError at construction."""
+@pytest.mark.parametrize("invalid", ["invalid_mode", "RECORD", "none", "both"])
+def test_dataset_invalid_description_precedence(tmp_path, invalid):
     _stub_record = {
         "dataset": "ds_inv",
         "bidspath": "ds_inv/a.set",
@@ -200,5 +151,5 @@ def test_dataset_invalid_description_precedence(tmp_path):
             cache_dir=tmp_path,
             records=[_stub_record],
             download=True,
-            description_precedence="invalid_mode",
+            description_precedence=invalid,
         )

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -16,7 +16,6 @@ import pytest
 
 from eegdash.dataset.dataset import EEGDashDataset
 
-
 # ---------------------------------------------------------------------------
 # Lightweight EEGDashRaw stub
 # ---------------------------------------------------------------------------
@@ -33,7 +32,10 @@ class _FakeRaw:
     """
 
     def __init__(self, record, cache_dir=None, description=None, **kwargs):
-        _ = cache_dir, kwargs  # accepted to match EEGDashRaw's signature; not needed in stub
+        _ = (
+            cache_dir,
+            kwargs,
+        )  # accepted to match EEGDashRaw's signature; not needed in stub
         self.record = record
         self.description = pd.Series(description or {}, dtype=object)
 
@@ -164,7 +166,6 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
     (tmp_path / "ds_parity").mkdir(parents=True, exist_ok=True)
 
     with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
-
         # -- Path 1: records= ------------------------------------------------
         ds_records = EEGDashDataset(
             cache_dir=tmp_path,
@@ -254,7 +255,9 @@ def test_build_description_participant_tsv_precedence(tmp_path):
     }
     desc = ds._build_description(record, description_fields=["age", "sex"])
 
-    assert desc["age"] == 99, "participant_tsv value must win when precedence='participant_tsv'"
+    assert desc["age"] == 99, (
+        "participant_tsv value must win when precedence='participant_tsv'"
+    )
     assert desc["sex"] == "M"
 
     # None in participant_tsv overwrites a real record value (documented behaviour).

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -117,9 +117,9 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
 @pytest.mark.parametrize(
     "precedence,record_val,tsv_val,expected",
     [
-        ("record", 30, 99, 30),
         ("participant_tsv", 30, 99, 99),
         ("participant_tsv", 30, None, None),
+        ("record", 30, 99, 30),
     ],
 )
 def test_build_description_precedence(precedence, record_val, tsv_val, expected):

--- a/tests/unit_tests/dataset/test_build_description.py
+++ b/tests/unit_tests/dataset/test_build_description.py
@@ -18,16 +18,37 @@ from eegdash.dataset.dataset import EEGDashDataset
 
 
 # ---------------------------------------------------------------------------
+# Lightweight EEGDashRaw stub
+# ---------------------------------------------------------------------------
+
+
+class _FakeRaw:
+    """Minimal stand-in for EEGDashRaw.
+
+    Satisfies the two things BaseConcatDataset needs from each element:
+      - __len__ returning an integer
+      - description as a pd.Series
+
+    Stores the description kwarg so tests can inspect it later.
+    """
+
+    def __init__(self, record, cache_dir=None, description=None, **kwargs):
+        _ = cache_dir, kwargs  # accepted to match EEGDashRaw's signature; not needed in stub
+        self.record = record
+        self.description = pd.Series(description or {}, dtype=object)
+
+    def __len__(self):
+        return 1
+
+
+# ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
 def minimal_ds(tmp_path):
-    """Lightweight EEGDashDataset used as a host for direct _build_description calls.
-
-    EEGDashRaw is mocked so no filesystem or network access is required.
-    """
+    """Lightweight EEGDashDataset used as a host for direct _build_description calls."""
     record = {
         "dataset": "ds_bd_test",
         "bidspath": "ds_bd_test/a.set",
@@ -35,7 +56,7 @@ def minimal_ds(tmp_path):
         "extension": ".set",
         "storage": {"backend": "local", "base": str(tmp_path)},
     }
-    with patch("eegdash.dataset.dataset.EEGDashRaw"):
+    with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
         ds = EEGDashDataset(cache_dir=tmp_path, records=[record], download=True)
     return ds
 
@@ -70,9 +91,7 @@ def test_build_description_precedence_conflict(minimal_ds, caplog):
     }
 
     with caplog.at_level(logging.DEBUG, logger="eegdash"):
-        desc = minimal_ds._build_description(
-            record, description_fields=["age", "sex"]
-        )
+        desc = minimal_ds._build_description(record, description_fields=["age", "sex"])
 
     assert desc["age"] == 30, "Top-level record value must take precedence"
     assert desc["sex"] == "M", "Uncontested participant_tsv field must be merged"
@@ -81,6 +100,9 @@ def test_build_description_precedence_conflict(minimal_ds, caplog):
     assert conflict_logs, (
         "Expected a debug log mentioning the 'age' conflict, got: "
         + str(caplog.messages)
+    )
+    assert any("kept" in m for m in caplog.messages), (
+        "Default 'record' precedence must log 'kept', not 'overwrote'"
     )
 
 
@@ -94,22 +116,16 @@ def test_build_description_missing_fields_padding(minimal_ds):
 
     Accessing description["missing_field_xyz"] must not raise KeyError.
     """
-    record = {
-        "entities": {"subject": "01"},
-    }
+    record = {"entities": {"subject": "01"}}
     description_fields = ["subject", "missing_field_xyz"]
 
     desc = minimal_ds._build_description(record, description_fields=description_fields)
 
-    assert "subject" in desc
     assert desc["subject"] == "01"
-
     assert "missing_field_xyz" in desc, (
         "Missing field must be present in description (padded with None)"
     )
-    assert desc["missing_field_xyz"] is None, (
-        "Missing field value must be None, not absent"
-    )
+    assert desc["missing_field_xyz"] is None, "Missing field value must be None"
 
 
 # ---------------------------------------------------------------------------
@@ -119,9 +135,7 @@ def test_build_description_missing_fields_padding(minimal_ds):
 
 def test_build_description_key_insensitivity(minimal_ds):
     """_find_key_in_nested_dict maps 'Subject-ID' in the record to 'subject_id' in fields."""
-    record = {
-        "Subject-ID": "sub-007",
-    }
+    record = {"Subject-ID": "sub-007"}
 
     desc = minimal_ds._build_description(
         record, description_fields=["subject_id", "task"]
@@ -141,28 +155,28 @@ def test_build_description_key_insensitivity(minimal_ds):
 def test_dataset_initialization_path_parity(tmp_path, parity_record):
     """All three EEGDashDataset construction paths must build identical descriptions.
 
-    EEGDashRaw is mocked throughout; the description dicts passed to each
-    constructor call are captured and compared via pandas.testing.assert_frame_equal.
+    _FakeRaw is used instead of MagicMock so BaseConcatDataset can safely
+    call len() and access .description on each element.  The description
+    passed to each _FakeRaw constructor is extracted and compared via
+    pandas.testing.assert_frame_equal.
     """
     description_fields = ["subject", "task"]
     (tmp_path / "ds_parity").mkdir(parents=True, exist_ok=True)
 
-    with patch("eegdash.dataset.dataset.EEGDashRaw") as mock_raw_cls:
+    with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
 
         # -- Path 1: records= ------------------------------------------------
-        EEGDashDataset(
+        ds_records = EEGDashDataset(
             cache_dir=tmp_path,
             records=[parity_record],
             download=True,
             description_fields=description_fields,
         )
-        desc_records = mock_raw_cls.call_args_list[-1].kwargs["description"]
-        mock_raw_cls.reset_mock()
 
         # -- Path 2: offline (download=False) ---------------------------------
-        # discover_local_bids_records is mocked to return the same record;
-        # EEGBIDSDataset is made to fail so no participant enrichment happens,
-        # keeping the result identical to what records= produces.
+        # discover_local_bids_records returns the same record; EEGBIDSDataset
+        # is made to fail so no participant enrichment happens, keeping the
+        # result identical to what the records= path produces.
         with (
             patch(
                 "eegdash.dataset.dataset.discover_local_bids_records",
@@ -173,36 +187,105 @@ def test_dataset_initialization_path_parity(tmp_path, parity_record):
                 side_effect=Exception("no bids"),
             ),
         ):
-            EEGDashDataset(
+            ds_offline = EEGDashDataset(
                 cache_dir=tmp_path,
                 dataset="ds_parity",
                 download=False,
                 description_fields=description_fields,
             )
-        desc_offline = mock_raw_cls.call_args_list[-1].kwargs["description"]
-        mock_raw_cls.reset_mock()
 
         # -- Path 3: query (mocked API) ---------------------------------------
         mock_api = MagicMock()
         mock_api.find.return_value = [parity_record]
         with patch("eegdash.dataset.dataset.validate_record", return_value=[]):
-            EEGDashDataset(
+            ds_query = EEGDashDataset(
                 cache_dir=tmp_path,
                 dataset="ds_parity",
                 eeg_dash_instance=mock_api,
                 download=True,
                 description_fields=description_fields,
             )
-        desc_query = mock_raw_cls.call_args_list[-1].kwargs["description"]
 
-    # Wrap each description dict in a single-row DataFrame and compare strictly.
-    df_records = pd.DataFrame([desc_records])
-    df_offline = pd.DataFrame([desc_offline])
-    df_query = pd.DataFrame([desc_query])
-
+    # BaseConcatDataset.description builds pd.DataFrame([ds.description for ds in datasets])
+    # _FakeRaw.description is a real pd.Series, so this works correctly.
     pd.testing.assert_frame_equal(
-        df_records, df_offline, check_like=True, obj="records= vs offline"
+        ds_records.description,
+        ds_offline.description,
+        check_like=True,
+        obj="records= vs offline",
     )
     pd.testing.assert_frame_equal(
-        df_records, df_query, check_like=True, obj="records= vs query"
+        ds_records.description,
+        ds_query.description,
+        check_like=True,
+        obj="records= vs query",
     )
+
+
+# ---------------------------------------------------------------------------
+# 5. description_precedence="participant_tsv" — participant_tsv values win
+# ---------------------------------------------------------------------------
+
+
+def test_build_description_participant_tsv_precedence(tmp_path):
+    """participant_tsv values overwrite conflicting record values when precedence='participant_tsv'.
+
+    Also verifies that a None value in participant_tsv overwrites a non-None
+    record value — this is intentional when the caller trusts that source fully.
+    """
+    _stub_record = {
+        "dataset": "ds_prec",
+        "bidspath": "ds_prec/a.set",
+        "bids_relpath": "a.set",
+        "extension": ".set",
+        "storage": {"backend": "local", "base": str(tmp_path)},
+    }
+    with patch("eegdash.dataset.dataset.EEGDashRaw", _FakeRaw):
+        ds = EEGDashDataset(
+            cache_dir=tmp_path,
+            records=[_stub_record],
+            download=True,
+            description_precedence="participant_tsv",
+        )
+
+    record = {
+        "age": 30,
+        "participant_tsv": {"age": 99, "sex": "M"},
+    }
+    desc = ds._build_description(record, description_fields=["age", "sex"])
+
+    assert desc["age"] == 99, "participant_tsv value must win when precedence='participant_tsv'"
+    assert desc["sex"] == "M"
+
+    # None in participant_tsv overwrites a real record value (documented behaviour).
+    record_none = {
+        "age": 30,
+        "participant_tsv": {"age": None},
+    }
+    desc_none = ds._build_description(record_none, description_fields=["age"])
+    assert desc_none["age"] is None, (
+        "None in participant_tsv must overwrite record value when precedence='participant_tsv'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Invalid description_precedence raises ValueError at construction
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_invalid_description_precedence(tmp_path):
+    """An unsupported description_precedence value raises ValueError at construction."""
+    _stub_record = {
+        "dataset": "ds_inv",
+        "bidspath": "ds_inv/a.set",
+        "bids_relpath": "a.set",
+        "extension": ".set",
+        "storage": {"backend": "local", "base": str(tmp_path)},
+    }
+    with pytest.raises(ValueError, match="description_precedence must be one of"):
+        EEGDashDataset(
+            cache_dir=tmp_path,
+            records=[_stub_record],
+            download=True,
+            description_precedence="invalid_mode",
+        )

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -151,9 +151,7 @@ def test_dataset_gaps(tmp_path):
         valid_record = {"dataset": "ds001", "participant_tsv": {"age": 25}}
         ds.eeg_dash_instance.find.return_value = [valid_record]
         with patch("eegdash.dataset.dataset.validate_record", return_value=[]):
-            with patch(
-                "eegdash.bids_metadata.merge_participants_fields"
-            ) as mock_merge:
+            with patch("eegdash.bids_metadata.merge_participants_fields") as mock_merge:
                 with patch("eegdash.dataset.dataset.EEGDashRaw"):
                     EEGDashDataset._find_datasets(
                         ds, query={}, description_fields=[], base_dataset_kwargs={}
@@ -720,7 +718,7 @@ def test_dataset_recursive_search(tmp_path):
     (ds_dir / "sub-01" / "eeg" / "sub-01_task-rest_eeg.set").touch()
 
     # In download=False mode, it calls _find_local_bids_records which calls discover_local_bids_records
-    real_ds = EEGDashDataset(
+    EEGDashDataset(
         dataset="ds",
         download=False,
         _suppress_comp_warning=True,

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -134,9 +134,7 @@ def test_dataset_gaps(tmp_path):
         ds.cache_dir = tmp_path
         ds.eeg_dash_instance = MagicMock()
         ds._normalize_records = lambda x: x
-        ds._find_key_in_nested_dict = EEGDashDataset._find_key_in_nested_dict.__get__(
-            ds
-        )
+        ds._description_precedence = "record"
 
         # 514: Trigger v2 format validation error
         invalid_record = {"data_name": "bad_rec"}
@@ -154,7 +152,7 @@ def test_dataset_gaps(tmp_path):
         ds.eeg_dash_instance.find.return_value = [valid_record]
         with patch("eegdash.dataset.dataset.validate_record", return_value=[]):
             with patch(
-                "eegdash.dataset.dataset.merge_participants_fields"
+                "eegdash.bids_metadata.merge_participants_fields"
             ) as mock_merge:
                 with patch("eegdash.dataset.dataset.EEGDashRaw"):
                     EEGDashDataset._find_datasets(
@@ -199,10 +197,10 @@ def test_dataset_init_exception_gap(tmp_path):
                 mock_bids = mock_bids_cls.return_value
                 mock_bids.subject_participant_tsv.return_value = {}
 
-                # merge_participants_fields raises inside _build_description's offline
+                # merge_participants_fields raises inside build_description's offline
                 # enrichment path; the per-record exception must be swallowed.
                 with patch(
-                    "eegdash.dataset.dataset.merge_participants_fields",
+                    "eegdash.bids_metadata.merge_participants_fields",
                     side_effect=Exception("Boom"),
                 ):
                     ds = EEGDashDataset(
@@ -261,7 +259,7 @@ def test_cache_dir_does_not_exist_creates(tmp_path, caplog):
 
 def test_iterate_local_with_participants_exception(tmp_path):
     """Test that exception in merge_participants_fields is handled."""
-    from eegdash.dataset.dataset import merge_participants_fields
+    from eegdash.bids_metadata import merge_participants_fields
 
     # Test merge_participants_fields with None participants_row
     result = merge_participants_fields(
@@ -293,38 +291,14 @@ def test_normalize_records_with_list():
 
 
 def test_dataset_find_key_nested(tmp_path):
-    """Test _find_key_in_nested_dict recursion."""
-    from unittest.mock import patch
-
-    from eegdash.dataset.dataset import EEGDashDataset
-
-    d = tmp_path / "ds999"
-    d.mkdir()
-
-    valid_record = {
-        "dataset": "ds999",
-        "data_name": "sub-01_task-rest_eeg.set",
-        "bidspath": "ds999/sub-01/eeg/sub-01_task-rest_eeg.set",
-        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.set",
-        "subject": "01",
-        "task": "rest",
-        "storage": {"base": str(d), "backend": "local"},
-    }
-    # Mocking discover to return proper records so init doesn't fail
-    with patch("eegdash.dataset.dataset.discover_local_bids_records") as mock_discover:
-        mock_discover.return_value = [valid_record]
-        ds = EEGDashDataset(
-            cache_dir=str(tmp_path),
-            dataset="ds999",
-            download=False,
-            _suppress_comp_warning=True,
-        )
+    """Test find_key_in_nested_dict recursion."""
+    from eegdash.bids_metadata import find_key_in_nested_dict
 
     data = {"a": 1, "b": {"c": 2, "d": [{"e": 3}, {"f": 4}]}}
-    assert ds._find_key_in_nested_dict(data, "a") == 1
-    assert ds._find_key_in_nested_dict(data, "c") == 2
-    assert ds._find_key_in_nested_dict(data, "e") == 3
-    assert ds._find_key_in_nested_dict(data, "z") is None
+    assert find_key_in_nested_dict(data, "a") == 1
+    assert find_key_in_nested_dict(data, "c") == 2
+    assert find_key_in_nested_dict(data, "e") == 3
+    assert find_key_in_nested_dict(data, "z") is None
 
 
 def test_dataset_normalize_records_dedupe(tmp_path):
@@ -752,8 +726,10 @@ def test_dataset_recursive_search(tmp_path):
         _suppress_comp_warning=True,
         cache_dir=str(tmp_path),
     )
-    assert real_ds._find_key_in_nested_dict(data, "b-c") == 1
-    assert real_ds._find_key_in_nested_dict([{"x": 2}], "x") == 2
+    from eegdash.bids_metadata import find_key_in_nested_dict
+
+    assert find_key_in_nested_dict(data, "b-c") == 1
+    assert find_key_in_nested_dict([{"x": 2}], "x") == 2
 
 
 def test_dataset_init_error_no_args(tmp_path):

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -171,19 +171,11 @@ def test_datasets_init_gap():
     # We can just try to instantiate with minimum args
     # Patching the CLASS method
     with patch(
-        "eegdash.dataset.dataset.EEGDashDataset._find_datasets", return_value=[]
+        "eegdash.dataset.dataset.EEGDashDataset._find_datasets",
+        return_value=[MagicMock()],
     ):
-        # But wait, if it returns empty list, init might raise "No datasets found"
-        # We need to see code.
-        # If I look above, standard logic is: datasets = self._find_datasets... if not datasets: raise ValueError
-        # So we must return a non-empty list
-        with patch(
-            "eegdash.dataset.dataset.EEGDashDataset._find_datasets",
-            return_value=[MagicMock()],
-        ):
-            ds = EEGDashDataset(query={}, cache_dir=".", dataset="ds001")
-            # query is set before _find_datasets check
-            assert ds.query == {"dataset": "ds001"}
+        ds = EEGDashDataset(query={}, cache_dir=".", dataset="ds001")
+        assert ds.query == {"dataset": "ds001"}
 
 
 def test_dataset_init_exception_gap(tmp_path):
@@ -202,35 +194,25 @@ def test_dataset_init_exception_gap(tmp_path):
             {"path": "s2", "bidspath": "foo/baz", "dataset": "ds001"},
         ]
 
-        # Try patching the class in the module
         with patch("eegdash.dataset.dataset.EEGDashRaw"):
-            # Mock get_entities_from_record (plural) called in dataset.py
-            with patch(
-                "eegdash.dataset.dataset.get_entities_from_record",
-                return_value={"sub": "01"},
-            ):
-                # Mock participants_row_for_subject is NOT called directly, usage is:
-                # part_row = bids_ds.subject_participant_tsv(local_file)
-                # So we mock EEGBIDSDataset or its method?
-                # In the code: bids_ds = EEGBIDSDataset(...)
-                # We should patch EEGBIDSDataset class in dataset.py
-                with patch("eegdash.dataset.dataset.EEGBIDSDataset") as mock_bids_cls:
-                    mock_bids = mock_bids_cls.return_value
-                    mock_bids.subject_participant_tsv.return_value = {}
+            with patch("eegdash.dataset.dataset.EEGBIDSDataset") as mock_bids_cls:
+                mock_bids = mock_bids_cls.return_value
+                mock_bids.subject_participant_tsv.return_value = {}
 
-                    # Mock merge_participants_fields to raise Exception
-                    with patch(
-                        "eegdash.dataset.dataset.merge_participants_fields",
-                        side_effect=Exception("Boom"),
-                    ):
-                        ds = EEGDashDataset(
-                            cache_dir=cache,
-                            dataset="ds001",
-                            check_files=False,
-                            download=False,
-                        )
-                        # Should swallow exception and continue
-                        assert len(ds.datasets) == 2
+                # merge_participants_fields raises inside _build_description's offline
+                # enrichment path; the per-record exception must be swallowed.
+                with patch(
+                    "eegdash.dataset.dataset.merge_participants_fields",
+                    side_effect=Exception("Boom"),
+                ):
+                    ds = EEGDashDataset(
+                        cache_dir=cache,
+                        dataset="ds001",
+                        check_files=False,
+                        download=False,
+                    )
+                    # Should swallow exception and continue
+                    assert len(ds.datasets) == 2
 
 
 def test_dataset_init_kwargs_gap(tmp_path):


### PR DESCRIPTION
## Fix `records=` path producing `'None'` descriptions + unified description construction

---

### Main Bug Fixed

When constructing `EEGDashDataset` via `records=`, every recording's `description` was
the string `"None"`. The `records=` path never built or forwarded a `description` dict to
`EEGDashRaw`; braindecode then stringified the missing `None` default.

---

### Changes

#### `eegdash/dataset/dataset.py`

- **Bug fix:** `records=` path now builds and passes a `description` dict to each
  `EEGDashRaw`, matching the behaviour of the query and offline paths.

- **Unified `_build_description` helper:** All three construction paths (`records=`,
  offline, query) previously built descriptions independently. A shared `_build_description`
  method now covers all three, eliminating divergence. It:
  - Pre-fills every requested field with `None` (so `desc["subject"]` never raises `KeyError`)
  - Looks up fields via `_find_key_in_nested_dict` (recursive, case/separator-insensitive,
    handles both v1 and v2 record formats)
  - Merges `participant_tsv` data with configurable precedence (see below)
  - Emits a `DEBUG` log when a conflict is detected

- **Configurable precedence (`description_precedence`):** New constructor parameter controls
  which source wins when the same field appears in both the record and `participant_tsv`:
  - `"record"` *(default)* — existing behaviour, record-level value is kept
  - `"participant_tsv"` — participant_tsv overwrites the record value, including `None`
    (documented intentional behaviour: choosing this mode means fully trusting that source)

- **All-None field warning:** After construction, emits a `WARNING` if any
  `description_fields` entry is `None` across all recordings — surfaces typos like
  `"sbject"` early.

- **`_normalize_records` called on the full batch:** Preserves deduplication correctness
  (per-record calls broke `_dedupe_records`).

#### `tests/unit_tests/dataset/test_build_description.py` *(new file)*

| Test | What it checks |
|---|---|
| `test_build_description_precedence_conflict` | Default `"record"` mode: top-level value wins, `"kept"` logged |
| `test_build_description_missing_fields_padding` | Absent fields → `None`, no `KeyError` |
| `test_build_description_key_insensitivity` | `"Subject-ID"` in record maps to `"subject_id"` in fields |
| `test_dataset_initialization_path_parity` | All three init paths produce identical `description` DataFrames |
| `test_build_description_participant_tsv_precedence` | `"participant_tsv"` mode: tsv value wins; `None` in tsv overwrites real value |
| `test_dataset_invalid_description_precedence` | Unknown `description_precedence` raises `ValueError` at construction |
