### PR TITLE
fix(io): preserve non-numeric TSV cells in decimal separator repair

### DIFF
--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -543,12 +543,19 @@ DataFile={vhdr_name.replace(".vhdr", ".eeg")}
         return False
 
 
-# Match digits separated by a comma that looks like a European decimal separator,
-# e.g. "4,988" → "4.988".  This intentionally treats ALL digit,digit patterns as
-# decimals.  Thousands separators like "10,000" would also be rewritten, but in
-# practice European-locale datasets that use comma-as-decimal use dot or space for
+# Match a TSV cell whose entire content is a European-decimal numeric scalar,
+# e.g. "4,988" → "4.988" (or "-0,5" → "-0.5").  Anchored to cell boundaries
+# (start-of-line or tab on the left; tab, newline, or end-of-string on the
+# right) so interior commas of free-form text cells are never touched —
+# notably EEGLAB stim codes like "B2,4,8,16(240)" in BIDS event ``value``
+# columns, which are categorical labels per the BIDS-EEG spec.  Thousands
+# separators like "10,000" would still be rewritten, but in practice
+# European-locale datasets that use comma-as-decimal use dot or space for
 # thousands grouping, so the ambiguity does not arise in real BIDS TSV files.
-_DECIMAL_COMMA_RE = re.compile(r"(?<!\w)(\d+),(\d+)(?!\w)")
+_DECIMAL_COMMA_RE = re.compile(
+    r"(?:^|(?<=\t))(-?\d+),(\d+)(?=\t|\r?\n|$)",
+    re.MULTILINE,
+)
 
 
 def _repair_tsv_decimal_separators(data_dir: Path) -> bool:

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -808,8 +808,7 @@ def test_repair_tsv_decimal_separators_mixed_numeric_and_text(tmp_path):
     """
     tsv_path = tmp_path / "sub-01_task-mix_events.tsv"
     tsv_path.write_text(
-        "onset\tduration\tsample\tvalue\n"
-        "4,988\t0,5\t1247\tB2,4,8,16(240)\n"
+        "onset\tduration\tsample\tvalue\n4,988\t0,5\t1247\tB2,4,8,16(240)\n"
     )
 
     assert _repair_tsv_decimal_separators(tmp_path) is True
@@ -827,10 +826,7 @@ def test_repair_tsv_decimal_separators_is_idempotent_across_repeated_calls(tmp_p
     first pass exposed a new match).
     """
     tsv_path = tmp_path / "sub-001_task-PY_events.tsv"
-    original = (
-        "onset\tduration\tsample\tvalue\n"
-        "0.10\t0.0\t26\tB2,4,8,16(240)\n"
-    )
+    original = "onset\tduration\tsample\tvalue\n0.10\t0.0\t26\tB2,4,8,16(240)\n"
     tsv_path.write_text(original)
 
     for _ in range(3):

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -786,6 +786,68 @@ def test_repair_tsv_decimal_separators_preserves_tab_commas(tmp_path):
     assert _repair_tsv_decimal_separators(tmp_path) is False
 
 
+def test_repair_tsv_decimal_separators_preserves_stim_code_value_column(tmp_path):
+    """Free-form text cells (e.g. EEGLAB ``B2,4,8,16(240)`` stim codes) must
+    not be rewritten — only whole-cell numeric scalars are decimal candidates.
+    """
+    tsv_path = tmp_path / "sub-001_task-PY_events.tsv"
+    original = (
+        "onset\tduration\tsample\tvalue\n"
+        "0.1015625000\t0.0000000000\t26\tB2,4,8,16(240)\n"
+        "1.0039062500\t0.0000000000\t257\tB18,20,24,32(241)\n"
+    )
+    tsv_path.write_text(original)
+
+    assert _repair_tsv_decimal_separators(tmp_path) is False
+    assert tsv_path.read_text() == original
+
+
+def test_repair_tsv_decimal_separators_mixed_numeric_and_text(tmp_path):
+    """Numeric decimal-comma cells are still repaired even when the same row
+    carries a free-form text cell containing interior commas.
+    """
+    tsv_path = tmp_path / "sub-01_task-mix_events.tsv"
+    tsv_path.write_text(
+        "onset\tduration\tsample\tvalue\n"
+        "4,988\t0,5\t1247\tB2,4,8,16(240)\n"
+    )
+
+    assert _repair_tsv_decimal_separators(tmp_path) is True
+
+    content = tsv_path.read_text()
+    assert "4.988\t0.5\t1247\tB2,4,8,16(240)" in content
+
+
+def test_repair_tsv_decimal_separators_is_idempotent_across_repeated_calls(tmp_path):
+    """Repeated invocations on the same file must not cascade.
+
+    Regression for the ds004771 corruption: the file-level regex used to
+    rewrite ``B2,4,8,16(240)`` to ``B2,4.8,16(240)`` on the first pass, then
+    to ``B2,4.8.16(240)`` on the second pass (the ``.`` introduced by the
+    first pass exposed a new match).
+    """
+    tsv_path = tmp_path / "sub-001_task-PY_events.tsv"
+    original = (
+        "onset\tduration\tsample\tvalue\n"
+        "0.10\t0.0\t26\tB2,4,8,16(240)\n"
+    )
+    tsv_path.write_text(original)
+
+    for _ in range(3):
+        _repair_tsv_decimal_separators(tmp_path)
+    assert tsv_path.read_text() == original
+
+
+def test_repair_tsv_decimal_separators_negative_decimal(tmp_path):
+    """Signed European-decimal cells (``-0,5``) are rewritten."""
+    tsv_path = tmp_path / "sub-01_electrodes.tsv"
+    tsv_path.write_text("name\tx\ty\tz\nFp1\t-5,004\t-3,2\t1,001\n")
+
+    assert _repair_tsv_decimal_separators(tmp_path) is True
+    content = tsv_path.read_text()
+    assert "-5.004\t-3.2\t1.001" in content
+
+
 # ── _repair_tsv_na_whitespace ──
 
 


### PR DESCRIPTION
## Summary

- Anchor `_DECIMAL_COMMA_RE` in [eegdash/dataset/io.py](eegdash/dataset/io.py) to TSV cell boundaries (`(?:^|(?<=\t))(-?\d+),(\d+)(?=\t|\r?\n|$)` with `re.MULTILINE`) so `_repair_tsv_decimal_separators` only rewrites whole-cell numeric scalars.
- The prior file-level regex matched any `digit,digit` pair surrounded by non-word chars anywhere in `*_events.tsv` / `*_electrodes.tsv` / `*_channels.tsv`, including inside free-form text cells. On **ds004771** this silently mutated all 61 `_task-PY_events.tsv` files — EEGLAB stim codes like `B2,4,8,16(240)` in the `value` column were rewritten because the interior commas matched.
- Because the repair runs once per `BaseDataset._ensure_raw` and many `BaseDataset` instances share the same `sub-XXX/eeg/` directory, repeated invocations cascaded: `B2,4,8,16(240)` → `B2,4.8,16(240)` (first pass) → `B2,4.8.16(240)` (second pass, since the new `.` is non-word). The new anchor makes the function strictly idempotent on already-correct content.

## Behavior

| Cell                                | Before                | After    |
| ----------------------------------- | --------------------- | -------- |
| `4,988` (numeric scalar)            | rewritten ✓           | rewritten ✓ |
| `-0,5` (signed numeric scalar)      | rewritten ✓           | rewritten ✓ |
| `B2,4,8,16(240)` (EEGLAB stim code) | **corrupted**         | preserved |
| `Cz, ground at AFz` (free text)     | preserved (by accident) | preserved |
| `10,000` (thousands sep, edge case) | rewritten (documented trade-off) | rewritten (same trade-off) |

## Test plan

- [x] `pytest tests/unit_tests/dataset/test_io.py -k decimal` — 6 existing + 4 new regression tests all pass:
  - `test_repair_tsv_decimal_separators_preserves_stim_code_value_column` — the ds004771 case (no mutation)
  - `test_repair_tsv_decimal_separators_mixed_numeric_and_text` — numeric repair still fires alongside stim-code cells
  - `test_repair_tsv_decimal_separators_is_idempotent_across_repeated_calls` — pins cascade-resistance across 3 passes
  - `test_repair_tsv_decimal_separators_negative_decimal` — signed decimals
- [x] `pytest tests/unit_tests/dataset/test_io.py` — full 134 tests in the file remain green.
- [x] End-to-end repro on a synthetic ds004771-shaped events.tsv: stim-code rows byte-identical across 5 invocations, legitimate `4,988`/`0,5` row still rewritten, second pass on the repaired file is a no-op (only one INFO log fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)