### PR TITLE
fix(io): preserve acq_time timezone in scans.tsv repair

### DIFF
--- a/eegdash/dataset/io.py
+++ b/eegdash/dataset/io.py
@@ -1046,7 +1046,20 @@ def _repair_scans_tsv_timestamps(data_dir: Path) -> bool:
                             # and 6-digit microseconds — mne-bids uses
                             # strptime('%Y-%m-%dT%H:%M:%S.%f') which
                             # requires 'T' and fractional seconds.
-                            normalized = dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+                            # For tz-aware inputs, preserve the tz: a
+                            # plain "%Y-%m-%dT%H:%M:%S.%f" silently
+                            # strips trailing 'Z' / '+HH:MM' offsets.
+                            if dt.tzinfo is not None:
+                                normalized = dt.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
+                                # %z emits +HHMM; restore RFC 3339 'Z'
+                                # for UTC, otherwise insert the ISO
+                                # 8601 extended-form colon.
+                                if normalized.endswith("+0000"):
+                                    normalized = normalized[:-5] + "Z"
+                                else:
+                                    normalized = normalized[:-2] + ":" + normalized[-2:]
+                            else:
+                                normalized = dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
                             if normalized != ts:
                                 cols[acq_idx] = normalized
                                 changed = True

--- a/tests/unit_tests/dataset/test_io.py
+++ b/tests/unit_tests/dataset/test_io.py
@@ -385,8 +385,30 @@ def test_read_bids_channels_tsv_parametrized(tmp_path, rows, expected):
         ("2024-01-02 03:04:05", "2024-01-02T03:04:05.000000", True),
         ("2024-01-02T03:04:99", "n/a", True),
         ("2024-01-02T03:04:05.000000", "2024-01-02T03:04:05.000000", False),
+        (
+            "2024-01-02T03:04:05.000000Z",
+            "2024-01-02T03:04:05.000000Z",
+            False,
+        ),
+        (
+            "2024-01-02T03:04:05.000000+00:00",
+            "2024-01-02T03:04:05.000000Z",
+            True,
+        ),
+        (
+            "2024-01-02T03:04:05.000000-05:00",
+            "2024-01-02T03:04:05.000000-05:00",
+            False,
+        ),
     ],
-    ids=["normalize_space_separator", "invalid_timestamp_to_na", "already_normalized"],
+    ids=[
+        "normalize_space_separator",
+        "invalid_timestamp_to_na",
+        "already_normalized",
+        "preserve_z_suffix_utc",
+        "normalize_plus_zero_offset_to_z",
+        "preserve_negative_offset",
+    ],
 )
 def test_repair_scans_tsv_timestamps_parametrized(
     tmp_path, acq_time, expected_time, expected_repaired


### PR DESCRIPTION
## Summary

`_repair_scans_tsv_timestamps` was silently stripping the timezone suffix from valid `acq_time` cells in `*_scans.tsv` and persisting the corrupted form back to disk on every load. The function parses each cell with `datetime.fromisoformat(ts)` (which since Python 3.11 accepts the RFC 3339 `Z` shorthand and explicit offsets), but the renormalization step used `dt.strftime("%Y-%m-%dT%H:%M:%S.%f")` — no `%z`, so tz info was dropped. The `if normalized != ts` guard could not skip the rewrite because the strftime output structurally cannot contain a `Z`, so every UTC-suffixed row took the "differ" branch.

### Observed corruption

Confirmed on `ds005420` (37/37 `*_scans.tsv` files) and `ds006126` (15/15) — every `acq_time` cell mutated from `2016-10-14T12:37:25.000000Z` → `2016-10-14T12:37:25.000000` on first load.

### Fix

Split the normalization on `dt.tzinfo`. Tz-aware inputs go through `strftime("%Y-%m-%dT%H:%M:%S.%f%z")`; UTC is restored to literal `Z` (RFC 3339), other offsets get the ISO 8601 extended-form colon (`+HH:MM`). Naive-input path and the unparseable → `"n/a"` path are unchanged. Net behavior:

| Input | Output | Rewritten? |
|---|---|---|
| `...Z` (RFC 3339 UTC) | `...Z` | no — byte-identical (**the bug**) |
| `...+00:00` | `...Z` | yes — lossless, prefers RFC 3339 |
| `...-05:00` | `...-05:00` | no — byte-identical |
| `2024-01-02 03:04:05` (space sep) | `...T...` | yes — existing behavior |
| invalid (e.g. seconds ≥ 60) | `n/a` | yes — existing behavior |

## Test plan

- [x] `tests/unit_tests/dataset/test_io.py::test_repair_scans_tsv_timestamps_parametrized` — 6 cases pass (3 pre-existing + 3 new regression cases: `preserve_z_suffix_utc`, `normalize_plus_zero_offset_to_z`, `preserve_negative_offset`)
- [x] `tests/unit_tests/dataset/test_base.py` — 3 pre-existing standalone `_repair_scans_tsv_timestamps` tests pass
- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)