### PR TITLE
Stack 2/3: refactor(configs) — Pydantic-settings for all 4 stage CLIs + validate.py consolidation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,9 @@ repos:
         types: [python]
         files: ^(eegdash|docs|scripts)/
         exclude: (\.ipynb$|docs/source/generated/|docs/_build/|docs/source/conf\.py)
+    -   id: find-leaked-creds
+        name: Block leaked credentials in staged changes
+        entry: bash scripts/ingestions/scripts/find_leaked_creds.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/eegdash/testing.py
+++ b/eegdash/testing.py
@@ -1,0 +1,146 @@
+"""Lazy fetch of the eegdash binary test corpus.
+
+The raw signal fixtures (BDF, EDF, SET, VHDR, SNIRF, FIF, MEF3 ...) live in
+the separate `eegdash/eegdash-testing-data
+<https://github.com/eegdash/eegdash-testing-data>`__ repository, modeled
+after ``mne-testing-data``. The first time a test asks for one we download
+the pinned tarball, verify its SHA-256, and unpack into a per-user cache.
+
+Pin (bump both lines when re-tagging the upstream repo):
+
+* :data:`VERSION` — git tag on ``eegdash-testing-data``
+* :data:`SHA256` — sha256 of the codeload tarball for that tag
+
+Environment overrides
+---------------------
+``EEGDASH_TESTING_DATA_DIR``
+    Cache directory (default: ``~/.cache/eegdash/testing-data``).
+``EEGDASH_SKIP_TESTING_DATA=true``
+    Skip every ``@requires_testing_data`` test; used by air-gapped CI.
+
+Examples
+--------
+>>> from eegdash.testing import data_path  # doctest: +SKIP
+>>> bdf = data_path() / "eeg" / "sub-001_ses-01_task-meditation_eeg.bdf"
+
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+import pooch
+import pytest
+
+VERSION = "0.2.0"
+SHA256 = "8669d60b052b4d7fcc5f929f79f600cec35f8b7c8bdffc1785bc6d09667cd8ca"
+URL = (
+    "https://codeload.github.com/eegdash/eegdash-testing-data/"
+    f"tar.gz/refs/tags/v{VERSION}"
+)
+
+_DEFAULT_CACHE = Path.home() / ".cache" / "eegdash" / "testing-data"
+# GitHub's codeload tarball unpacks into ``<name>-<tag>/`` at the top.
+_ROOT_NAME = f"eegdash-testing-data-{VERSION}"
+_TARBALL_NAME = f"{_ROOT_NAME}.tar.gz"
+
+
+def _cache_dir() -> Path:
+    return Path(os.environ.get("EEGDASH_TESTING_DATA_DIR", _DEFAULT_CACHE))
+
+
+def _skip_requested() -> bool:
+    return os.environ.get("EEGDASH_SKIP_TESTING_DATA", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def has_testing_data() -> bool:
+    """Return True if the corpus is already unpacked in the cache."""
+    root = _cache_dir() / _ROOT_NAME
+    return root.is_dir() and any(root.iterdir())
+
+
+@lru_cache(maxsize=1)
+def data_path() -> Path:
+    """Return the root of the test corpus, fetching on first use.
+
+    Returns
+    -------
+    Path
+        The unpacked ``eegdash-testing-data-{VERSION}/`` directory.
+
+    Raises
+    ------
+    RuntimeError
+        If the download is required but ``EEGDASH_SKIP_TESTING_DATA=true``
+        is set, or if pooch fails to retrieve the tarball.
+
+    """
+    cache = _cache_dir()
+    root = cache / _ROOT_NAME
+    if root.is_dir() and any(root.iterdir()):
+        return root
+
+    if _skip_requested():
+        raise RuntimeError("EEGDASH_SKIP_TESTING_DATA=true — refusing to fetch corpus")
+
+    cache.mkdir(parents=True, exist_ok=True)
+    pooch.retrieve(
+        url=URL,
+        known_hash=f"sha256:{SHA256}",
+        fname=_TARBALL_NAME,
+        path=str(cache),
+        processor=pooch.Untar(extract_dir=str(cache)),
+    )
+    if not (root.is_dir() and any(root.iterdir())):
+        raise RuntimeError(
+            f"pooch reported success but {root} is empty; "
+            "tarball layout may have changed upstream"
+        )
+    return root
+
+
+def data_file(relpath: str) -> Path:
+    """Convenience: ``data_path() / relpath`` as a single call."""
+    return data_path() / relpath
+
+
+def requires_testing_data(func):
+    """Pytest decorator: skip if the corpus is unavailable.
+
+    Skips when ``EEGDASH_SKIP_TESTING_DATA=true`` or the corpus cannot
+    be fetched (e.g. offline CI without a cache hit). The decorator
+    triggers the fetch at collection time so tests that depend on the
+    corpus all share a single download.
+    """
+    reason: str | None
+    if _skip_requested():
+        reason = "EEGDASH_SKIP_TESTING_DATA=true"
+    else:
+        try:
+            data_path()
+            reason = None
+        except Exception as exc:  # noqa: BLE001 — any fetch failure = skip
+            reason = f"eegdash-testing-data unavailable: {exc}"
+
+    return pytest.mark.skipif(reason is not None, reason=reason or "")(func)
+
+
+def _main() -> int:
+    """``python -m eegdash.testing`` — eagerly download the corpus."""
+    try:
+        root = data_path()
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed: {exc}")
+        return 1
+    print(f"ok: {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ tests = [
     'pytest-benchmark',
     'plotly',
     'moabb',
+    # tests/unit_tests/test_annex_key_utils.py + tests/unit_tests/test_digest_parsers.py
+    # import from scripts/ingestions/_file_utils.py + 3_digest.py, which require
+    # these at module top after the PEP-8 import-lift sweep.
+    'tenacity>=8',
+    'pydantic-settings>=2',
 ]
 dev = [
   "pre-commit",
@@ -168,11 +173,24 @@ target-version = "py311"
 
 [tool.ruff.lint]
 ignore-init-module-imports = true
-select = ["E", "W", "F", "D", "I", "NPY201"]
+select = ["E", "W", "F", "D", "I", "NPY201", "PLC0415"]
 ignore = ["E402", "E501", "D100", "D101", "D102", "D103", "D104", "D105", "D107", "D205", "D400", "D415", "D417", "F403", "D401", "E741", "E722", "D419"]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["I"]
+# PLC0415 grace list — legacy lazy imports for optional deps + circular-
+# import guards. Each entry is a candidate for cleanup in a follow-up; the
+# rule still fires on any NEW function-scoped import in untouched files.
+"eegdash/__init__.py" = ["PLC0415"]
+"eegdash/api.py" = ["PLC0415"]
+"eegdash/dataset/base.py" = ["PLC0415"]
+"eegdash/dataset/dataset.py" = ["PLC0415"]
+"eegdash/dataset/io.py" = ["PLC0415"]
+"eegdash/dataset/registry.py" = ["PLC0415"]
+"eegdash/features/extractors.py" = ["PLC0415"]
+"eegdash/features/serialization.py" = ["PLC0415"]
+"eegdash/local_bids.py" = ["PLC0415"]
+"eegdash/viz/identity.py" = ["PLC0415"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["eegdash", "braindecode"]

--- a/scripts/ingestions/.gitignore
+++ b/scripts/ingestions/.gitignore
@@ -1,0 +1,20 @@
+# Mutation-testing working directory (mutmut 3.x scratch space)
+mutants/
+.mutmut-cache
+.mutmut-cache/
+
+# pytest / coverage outputs
+.coverage
+.coverage.*
+htmlcov/
+.pytest_cache/
+__pycache__/
+
+# Hypothesis examples cache
+.hypothesis/
+
+# pytest-benchmark history
+.benchmarks/
+
+# Local sandbox data
+.cache/

--- a/scripts/ingestions/4_validate_output.py
+++ b/scripts/ingestions/4_validate_output.py
@@ -1,576 +1,57 @@
 #!/usr/bin/env python3
-"""Validate digestion output for consistency and correctness.
+"""CLI wrapper around :mod:`_validate` — exit-code semantics + JSON output.
 
-This script checks that digested records and datasets are valid:
-- Storage URLs match the source (no OpenNeuro with OSF URLs!)
-- Required fields are present for eegdash compatibility
-- Datasets have records (not empty)
-- No duplicate records
-- Source is set and valid for all entries
+The validation logic itself lives in :mod:`_validate`. This script is the
+argv-bound entry point: it parses the config, calls either
+:func:`validate_pre_digestion` or :func:`validate_digestion_output`, and
+emits a human-readable summary (or JSON via ``--json``).
 
-Usage:
-    # Post-digestion validation (default)
-    python validate_output.py --input digestion_output
-
-    # Pre-digestion validation (check manifests)
-    python validate_output.py --pre-check --input data/cloned
-
-    # Strict mode - fail on warnings too
-    python validate_output.py --input digestion_output --strict
+See ``python 4_validate_output.py --help``.
 """
 
-import argparse
 import json
-import re
 import sys
-from collections import Counter
-from pathlib import Path
 
 from pydantic import ValidationError
 
-from eegdash.schemas import DatasetModel, ManifestFileModel, ManifestModel, RecordModel
-
-# Valid storage URL patterns per source
-VALID_STORAGE_PATTERNS = {
-    "openneuro": r"^s3://openneuro\.org/ds\d+",
-    "nemar": r"^s3://(nemar|nmdatasets)/",
-    "osf": r"^https://files\.osf\.io/",
-    "figshare": r"^https://(figshare\.com|ndownloader|.*\.figshare\.com)",
-    "zenodo": r"^https://zenodo\.org/",
-    "scidb": r"^https://(www\.)?scidb\.cn/",
-    "datarn": r"^https://webdav\.data\.ru\.nl/",
-    "gin": r"^https://gin\.g-node\.org/",
-}
-
-# Recommended fields (warnings if missing)
-RECOMMENDED_RECORD_FIELDS = ["entities", "datatype", "suffix", "extension"]
-RECOMMENDED_DATASET_FIELDS = [
-    "name",
-    "datatypes",
-    "demographics",
-    "ingestion_fingerprint",
-]
-
-# Data quality fields - these should have values for usable records
-DATA_QUALITY_FIELDS = ["nchans", "sampling_frequency"]
-
-# Valid sources
-VALID_SOURCES = {
-    "openneuro",
-    "nemar",
-    "gin",
-    "figshare",
-    "zenodo",
-    "osf",
-    "scidb",
-    "datarn",
-    "hbn",
-}
-
-# Data file extensions that indicate valid neurophysiology data
-NEURO_EXTENSIONS = {
-    ".edf",
-    ".bdf",
-    ".vhdr",
-    ".set",
-    ".fif",
-    ".ds",
-    ".con",
-    ".sqd",
-    ".pdf",
-    ".mef",
-    ".nwb",
-    ".snirf",
-}
-
-
-class ValidationResult:
-    """Container for validation results."""
-
-    def __init__(self):
-        self.errors = []
-        self.warnings = []
-        self.stats = {
-            "datasets_checked": 0,
-            "records_checked": 0,
-            "storage_errors": 0,
-            "missing_mandatory": 0,
-            "missing_recommended": 0,
-            "empty_datasets": 0,
-            "invalid_source": 0,
-            "zip_placeholders": 0,
-            "missing_nchans": 0,
-            "missing_sampling_frequency": 0,
-        }
-        self.source_distribution = {}
-        self.modality_distribution = {}
-        self.empty_datasets = []
-        self.zip_placeholder_datasets = []
-        self.data_quality_issues = []  # Datasets with missing nchans/sampling_frequency
-
-    def add_error(self, dataset: str, message: str, field: str = None):
-        self.errors.append(
-            {
-                "dataset": dataset,
-                "message": message,
-                "field": field,
-            }
-        )
-
-    def add_warning(self, dataset: str, message: str, field: str = None):
-        self.warnings.append(
-            {
-                "dataset": dataset,
-                "message": message,
-                "field": field,
-            }
-        )
-
-    def is_valid(self) -> bool:
-        return len(self.errors) == 0
-
-    def summary(self) -> str:
-        total_records = self.stats["records_checked"]
-        missing_nchans = self.stats["missing_nchans"]
-        missing_sampling_frequency = self.stats["missing_sampling_frequency"]
-        nchans_pct = (missing_nchans / total_records * 100) if total_records > 0 else 0
-        sampling_frequency_pct = (
-            (missing_sampling_frequency / total_records * 100)
-            if total_records > 0
-            else 0
-        )
-
-        lines = [
-            "=" * 60,
-            "VALIDATION SUMMARY",
-            "=" * 60,
-            f"Datasets checked: {self.stats['datasets_checked']}",
-            f"Records checked: {self.stats['records_checked']}",
-            "",
-            f"Errors: {len(self.errors)}",
-            f"  - Storage URL errors: {self.stats['storage_errors']}",
-            f"  - Missing mandatory fields: {self.stats['missing_mandatory']}",
-            f"  - Invalid source: {self.stats['invalid_source']}",
-            "",
-            f"Warnings: {len(self.warnings)}",
-            f"  - Empty datasets (0 records): {self.stats['empty_datasets']}",
-            f"  - Missing recommended fields: {self.stats['missing_recommended']}",
-            f"  - ZIP placeholders (needs extraction): {self.stats['zip_placeholders']}",
-            "",
-            "Data Quality:",
-            f"  - Records missing nchans: {missing_nchans} ({nchans_pct:.1f}%)",
-            f"  - Records missing sampling_frequency: {missing_sampling_frequency} ({sampling_frequency_pct:.1f}%)",
-        ]
-
-        if self.empty_datasets:
-            lines.append("")
-            lines.append(f"Empty datasets ({len(self.empty_datasets)}):")
-            for ds in self.empty_datasets[:10]:
-                lines.append(f"  - {ds}")
-            if len(self.empty_datasets) > 10:
-                lines.append(f"  ... and {len(self.empty_datasets) - 10} more")
-
-        if self.data_quality_issues:
-            lines.append("")
-            lines.append(
-                f"Data quality issues ({len(self.data_quality_issues)} datasets):"
-            )
-            for issue in self.data_quality_issues[:10]:
-                lines.append(f"  - {issue}")
-            if len(self.data_quality_issues) > 10:
-                lines.append(f"  ... and {len(self.data_quality_issues) - 10} more")
-
-        if self.errors:
-            lines.append("")
-            lines.append("Sample errors (first 10):")
-            for err in self.errors[:10]:
-                field_info = f" [{err['field']}]" if err.get("field") else ""
-                lines.append(f"  [{err['dataset']}]{field_info} {err['message']}")
-
-        if self.warnings and len(self.errors) == 0:
-            lines.append("")
-            lines.append("Sample warnings (first 5):")
-            for warn in self.warnings[:5]:
-                lines.append(f"  [{warn['dataset']}] {warn['message']}")
-
-        lines.append("=" * 60)
-        return "\n".join(lines)
-
-
-def validate_storage_url(source: str, storage_base: str) -> tuple[bool, str]:
-    """Validate that storage URL matches the source."""
-    if source not in VALID_STORAGE_PATTERNS:
-        return True, ""  # Unknown source, can't validate
-
-    pattern = VALID_STORAGE_PATTERNS[source]
-    if re.match(pattern, storage_base):
-        return True, ""
-
-    return (
-        False,
-        f"Storage '{storage_base}' doesn't match expected pattern for {source}",
-    )
-
-
-def _add_pydantic_errors(
-    result: "ValidationResult",
-    *,
-    dataset_id: str,
-    exc: ValidationError,
-    prefix: str | None = None,
-):
-    for err in exc.errors():
-        loc = [str(p) for p in err.get("loc", [])]
-        if prefix:
-            loc = [prefix, *loc]
-        field_path = ".".join(loc) if loc else None
-        result.add_error(dataset_id, err.get("msg", "Invalid value"), field=field_path)
-        if err.get("type") == "missing":
-            result.stats["missing_mandatory"] += 1
-
-
-def validate_record(
-    record: dict,
-    dataset_id: str,
-    source: str,
-    result: ValidationResult,
-    record_idx: int = 0,
-):
-    """Validate a single record for mandatory fields."""
-    try:
-        RecordModel.model_validate(record)
-    except ValidationError as exc:
-        _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="record")
-
-    # Validate storage URL matches source
-    storage = record.get("storage", {})
-    if storage:
-        storage_base = storage.get("base", "")
-        is_valid, error_msg = validate_storage_url(source, storage_base)
-        if not is_valid:
-            result.add_error(dataset_id, error_msg, field="storage.base")
-            result.stats["storage_errors"] += 1
-
-    # Check recommended fields (warnings only, first record only)
-    if record_idx == 0:
-        for field in RECOMMENDED_RECORD_FIELDS:
-            if field not in record or record[field] is None:
-                result.add_warning(
-                    dataset_id,
-                    f"Missing recommended field: {field}",
-                    field=field,
-                )
-                result.stats["missing_recommended"] += 1
-
-    # Check data quality fields (nchans, sampling_frequency) - critical for usability
-    nchans = record.get("nchans")
-    sampling_frequency = record.get("sampling_frequency")
-    if nchans is None or nchans == 0:
-        result.stats["missing_nchans"] += 1
-    if sampling_frequency is None or sampling_frequency == 0:
-        result.stats["missing_sampling_frequency"] += 1
-
-
-def validate_dataset(dataset: dict, result: ValidationResult):
-    """Validate a single dataset document for mandatory fields."""
-    dataset_id = dataset.get("dataset_id", "unknown")
-
-    try:
-        DatasetModel.model_validate(dataset)
-    except ValidationError as exc:
-        _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="dataset")
-
-    # Check source is valid
-    source = dataset.get("source")
-    if source and source not in VALID_SOURCES:
-        result.add_warning(dataset_id, f"Unknown source: {source}", field="source")
-        result.stats["invalid_source"] += 1
-
-    # Check recommended fields
-    for field in RECOMMENDED_DATASET_FIELDS:
-        if field not in dataset or dataset[field] is None:
-            result.add_warning(
-                dataset_id,
-                f"Missing recommended field: {field}",
-                field=field,
-            )
-
-
-def validate_digestion_output(
-    input_dir: Path,
-    verbose: bool = False,
-    strict: bool = False,
-) -> ValidationResult:
-    """Validate all digestion output in a directory.
-
-    Args:
-        input_dir: Directory containing digested datasets
-        verbose: Print progress information
-        strict: Treat warnings as errors
-
-    Returns:
-        ValidationResult with all findings
-
-    """
-    result = ValidationResult()
-
-    if not input_dir.exists():
-        result.add_error("", f"Input directory does not exist: {input_dir}")
-        return result
-
-    dataset_dirs = [d for d in input_dir.iterdir() if d.is_dir()]
-
-    if verbose:
-        print(f"Found {len(dataset_dirs)} dataset directories to validate")
-
-    sources = Counter()
-    modalities = Counter()
-
-    for dataset_dir in dataset_dirs:
-        dataset_id = dataset_dir.name
-        records_file = dataset_dir / f"{dataset_id}_records.json"
-        dataset_file = dataset_dir / f"{dataset_id}_dataset.json"
-
-        source = "unknown"
-        record_count = 0
-
-        # Load dataset first to get source
-        if dataset_file.exists():
-            try:
-                with open(dataset_file) as f:
-                    dataset = json.load(f)
-
-                result.stats["datasets_checked"] += 1
-                validate_dataset(dataset, result)
-                source = dataset.get("source", "unknown")
-                sources[source] += 1
-
-            except json.JSONDecodeError as e:
-                result.add_error(dataset_id, f"Invalid JSON in dataset file: {e}")
-            except Exception as e:
-                result.add_error(dataset_id, f"Error reading dataset: {e}")
-
-        # Validate records
-        if records_file.exists():
-            try:
-                with open(records_file) as f:
-                    data = json.load(f)
-
-                records = data.get("records", [])
-                record_count = len(records)
-                result.stats["records_checked"] += record_count
-
-                has_zip_placeholder = False
-                has_missing_nchans = False
-                has_missing_sampling_frequency = False
-                for idx, record in enumerate(records):
-                    validate_record(record, dataset_id, source, result, idx)
-                    mods = record.get("recording_modality", ["unknown"])
-                    if isinstance(mods, str):
-                        mods = [mods]
-                    for mod in mods:
-                        modalities[mod] += 1
-
-                    # Track ZIP placeholders
-                    if record.get("needs_extraction") or record.get(
-                        "zip_contains_bids"
-                    ):
-                        has_zip_placeholder = True
-
-                    # Track data quality at dataset level
-                    if record.get("nchans") is None or record.get("nchans") == 0:
-                        has_missing_nchans = True
-                    if (
-                        record.get("sampling_frequency") is None
-                        or record.get("sampling_frequency") == 0
-                    ):
-                        has_missing_sampling_frequency = True
-
-                if has_missing_nchans or has_missing_sampling_frequency:
-                    issue_parts = []
-                    if has_missing_nchans:
-                        issue_parts.append("nchans")
-                    if has_missing_sampling_frequency:
-                        issue_parts.append("sampling_frequency")
-                    result.data_quality_issues.append(
-                        f"{dataset_id} ({source}): missing {', '.join(issue_parts)}"
-                    )
-
-                if has_zip_placeholder:
-                    result.stats["zip_placeholders"] += 1
-                    result.zip_placeholder_datasets.append(f"{dataset_id} ({source})")
-
-            except json.JSONDecodeError as e:
-                result.add_error(dataset_id, f"Invalid JSON in records file: {e}")
-            except Exception as e:
-                result.add_error(dataset_id, f"Error reading records: {e}")
-
-        # Flag empty datasets
-        if record_count == 0:
-            result.stats["empty_datasets"] += 1
-            result.empty_datasets.append(f"{dataset_id} ({source})")
-            if strict:
-                result.add_error(
-                    dataset_id,
-                    "Dataset has 0 records - cannot be used in eegdash",
-                )
-            else:
-                result.add_warning(
-                    dataset_id,
-                    "Dataset has 0 records - no usable data files found",
-                )
-
-    result.source_distribution = dict(sources)
-    result.modality_distribution = dict(modalities)
-
-    return result
-
-
-def validate_pre_digestion(input_dir: Path, verbose: bool = False) -> ValidationResult:
-    """Pre-digestion validation: check manifests have valid data files.
-
-    Args:
-        input_dir: Directory containing cloned datasets with manifest.json files
-        verbose: Print progress information
-
-    Returns:
-        ValidationResult with findings
-
-    """
-    result = ValidationResult()
-
-    if not input_dir.exists():
-        result.add_error("", f"Input directory does not exist: {input_dir}")
-        return result
-
-    dataset_dirs = [
-        d for d in input_dir.iterdir() if d.is_dir() and (d / "manifest.json").exists()
-    ]
-
-    if verbose:
-        print(f"Found {len(dataset_dirs)} manifests to check")
-
-    sources = Counter()
-
-    for dataset_dir in dataset_dirs:
-        dataset_id = dataset_dir.name
-        manifest_path = dataset_dir / "manifest.json"
-
-        try:
-            with open(manifest_path) as f:
-                manifest = json.load(f)
-
-            try:
-                manifest_model = ManifestModel.model_validate(manifest)
-            except ValidationError as exc:
-                _add_pydantic_errors(
-                    result, dataset_id=dataset_id, exc=exc, prefix="manifest"
-                )
-                continue
-
-            source = manifest_model.source or "unknown"
-            sources[source] += 1
-            result.stats["datasets_checked"] += 1
-
-            files = manifest_model.files
-
-            # Count potential data files and CTF .ds directories
-            data_file_count = 0
-            ctf_ds_dirs = set()
-
-            for f in files:
-                if isinstance(f, str):
-                    filepath = f
-                elif isinstance(f, ManifestFileModel):
-                    filepath = f.path_or_name()
-                else:
-                    filepath = ""
-                filepath_lower = filepath.lower()
-
-                # Track CTF .ds directories (files inside .ds/ paths)
-                if ".ds/" in filepath_lower:
-                    ds_idx = filepath_lower.index(".ds/") + 3
-                    ds_path = filepath[:ds_idx]
-                    ctf_ds_dirs.add(ds_path)
-                    continue
-
-                # Check if this could be a neurophysiology data file
-                for ext in NEURO_EXTENSIONS:
-                    if filepath_lower.endswith(ext):
-                        data_file_count += 1
-                        break
-
-            # Add CTF .ds directories count
-            data_file_count += len(ctf_ds_dirs)
-            result.stats["records_checked"] += data_file_count
-
-            if data_file_count == 0:
-                result.stats["empty_datasets"] += 1
-                result.empty_datasets.append(f"{dataset_id} ({source})")
-                result.add_warning(
-                    dataset_id,
-                    f"No recognized neurophysiology files in manifest "
-                    f"({len(files)} total files)",
-                )
-
-            if verbose and data_file_count > 0:
-                print(f"  {dataset_id}: {data_file_count} data files")
-
-        except json.JSONDecodeError as e:
-            result.add_error(dataset_id, f"Invalid JSON in manifest: {e}")
-        except Exception as e:
-            result.add_error(dataset_id, f"Error reading manifest: {e}")
-
-    result.source_distribution = dict(sources)
-
-    return result
+from _validate import (  # noqa: F401 — re-export for time_openneuro_pipeline.py subprocess invocation
+    DATA_QUALITY_FIELDS,
+    NEURO_EXTENSIONS,
+    RECOMMENDED_DATASET_FIELDS,
+    RECOMMENDED_RECORD_FIELDS,
+    VALID_SOURCES,
+    VALID_STORAGE_PATTERNS,
+    ValidationResult,
+    _add_pydantic_errors,
+    validate_dataset,
+    validate_digestion_output,
+    validate_pre_digestion,
+    validate_record,
+    validate_storage_url,
+)
+from _validate_config import load_validate_config_from_argv
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Validate digestion output for eegdash compatibility"
-    )
-    parser.add_argument(
-        "--input",
-        "-i",
-        type=Path,
-        default=Path("digestion_output"),
-        help="Input directory (digestion_output or data/cloned for --pre-check)",
-    )
-    parser.add_argument(
-        "--pre-check",
-        action="store_true",
-        help="Pre-digestion validation: check manifests have valid data files",
-    )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Print verbose output",
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Treat warnings as errors (empty datasets become errors)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output results as JSON",
-    )
+    try:
+        cfg = load_validate_config_from_argv()
+    except ValidationError as exc:
+        print("Config error(s):", file=sys.stderr)
+        for err in exc.errors():
+            field = ".".join(str(p) for p in err.get("loc", []))
+            print(f"  {field}: {err.get('msg')}", file=sys.stderr)
+        return 1
 
-    args = parser.parse_args()
-
-    if args.pre_check:
-        result = validate_pre_digestion(args.input, verbose=args.verbose)
+    if cfg.pre_check:
+        result = validate_pre_digestion(cfg.input, verbose=cfg.verbose)
     else:
         result = validate_digestion_output(
-            args.input,
-            verbose=args.verbose,
-            strict=args.strict,
+            cfg.input,
+            verbose=cfg.verbose,
+            strict=cfg.strict,
         )
 
-    if args.json:
+    if cfg.json_output:
         output = {
             "valid": result.is_valid(),
             "stats": result.stats,
@@ -598,9 +79,7 @@ def main():
             ):
                 print(f"  {mod}: {count}")
 
-    # Exit with error code if validation failed
-    # In strict mode, warnings also cause failure
-    if args.strict and result.warnings:
+    if cfg.strict and result.warnings:
         sys.exit(1)
     sys.exit(0 if result.is_valid() else 1)
 

--- a/scripts/ingestions/__init__.py
+++ b/scripts/ingestions/__init__.py
@@ -1,0 +1,11 @@
+"""eegdash ingestion pipeline.
+
+Five-stage pipeline (``1_fetch_sources`` / ``2_clone`` / ``3_digest`` /
+``4_validate_output`` / ``5_inject``) ingesting BIDS EEG/MEG/iEEG datasets
+into the eegdash MongoDB. Shared helpers live in the underscore-prefixed
+sibling modules.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/scripts/ingestions/_clone_config.py
+++ b/scripts/ingestions/_clone_config.py
@@ -1,0 +1,151 @@
+"""Pydantic-settings config for 2_clone.py (C8).
+
+Final stage in the C6.5-style config refactor — completes the pattern
+across all 4 main()-style scripts (digest, validate, inject, clone).
+
+The HANDLERS dict in 2_clone.py is treated as the source of truth for
+``--sources`` choices, same as stage 4's _validate.py is for the
+validators that consume it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Source names that 2_clone.py's HANDLERS dict knows how to clone.
+# Kept aligned with HANDLERS — adding a new source there requires adding
+# it here too (or refactoring to import HANDLERS lazily; that's a
+# future round if the list grows).
+KNOWN_SOURCES: frozenset[str] = frozenset(
+    {
+        "openneuro",
+        "nemar",
+        "gin",
+        "figshare",
+        "zenodo",
+        "osf",
+        "scidb",
+        "datarn",
+        "hbn",
+        "neurips25",
+        "unknown",
+    }
+)
+
+
+class CloneConfig(BaseSettings):
+    """Validated config for the clone stage.
+
+    Same pattern as ``InjectConfig`` / ``DigestConfig`` / ``ValidateConfig``.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_CLONE_",
+        extra="ignore",
+    )
+
+    input: Path = Field(
+        default=Path("consolidated"),
+        description=(
+            "Input JSON file or directory containing the consolidated "
+            "per-source listings (output of stage 1)."
+        ),
+    )
+    output: Path = Field(
+        default=Path("data/cloned"),
+        description="Output directory for cloned datasets + manifests.",
+    )
+    sources: list[str] | None = Field(
+        default=None,
+        description=(
+            "Process only specific sources. Default: all sources in "
+            "HANDLERS. Must be a subset of KNOWN_SOURCES."
+        ),
+    )
+    timeout: int = Field(
+        default=300,
+        ge=1,
+        le=60 * 60 * 6,  # 6h ceiling — anything bigger means a hung handler
+        description="Per-dataset handler timeout in seconds (max 6h).",
+    )
+    workers: int = Field(
+        default=8,
+        ge=1,
+        le=128,
+        description="Parallel worker threads (1 = sequential).",
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum datasets to process (total, after limit-per-source).",
+    )
+    limit_per_source: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum datasets per source.",
+    )
+    datasets: list[str] | None = Field(
+        default=None,
+        description="Process only specific dataset IDs.",
+    )
+    manifest_only: bool = Field(
+        default=False,
+        description="Skip git clones; only emit manifests.",
+    )
+
+    @field_validator("sources")
+    @classmethod
+    def _sources_must_be_known(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return value
+        unknown = set(value) - KNOWN_SOURCES
+        if unknown:
+            raise ValueError(
+                f"unknown source(s): {sorted(unknown)}; valid: {sorted(KNOWN_SOURCES)}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> CloneConfig:
+        if not self.input.exists():
+            raise ValueError(f"--input does not exist: {self.input}")
+        return self
+
+
+def load_clone_config_from_argv(
+    argv: list[str] | None = None,
+) -> CloneConfig:
+    """Parse argv (or sys.argv) into a validated :class:`CloneConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Clone or fetch datasets per consolidated source listings "
+            "(stage 2 of the ingest pipeline)."
+        )
+    )
+    parser.add_argument("--input", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        default=None,
+        choices=sorted(KNOWN_SOURCES),
+    )
+    parser.add_argument("--timeout", type=int, default=None)
+    parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--limit-per-source", type=int, default=None, dest="limit_per_source"
+    )
+    parser.add_argument("--datasets", nargs="+", default=None)
+    parser.add_argument("--manifest-only", action="store_true", dest="manifest_only")
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    # Drop False bools (action="store_true" default) AND None values so
+    # the model defaults apply.
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None and v is not False}
+    return CloneConfig(**kwargs)

--- a/scripts/ingestions/_digest_config.py
+++ b/scripts/ingestions/_digest_config.py
@@ -1,0 +1,99 @@
+"""Pydantic-settings config for 3_digest.py (C7.2).
+
+Same pattern as ``_inject_config.py`` (C6.5) and ``_validate_config.py``
+(C7.1). Replaces the argparse + ``_positive_float`` custom-type
+boilerplate with declarative bounds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_DATASET_TIMEOUT_SECONDS = 2 * 60  # mirrors 3_digest.py
+
+
+class DigestConfig(BaseSettings):
+    """Validated config for the BIDS digest stage.
+
+    Sources, in precedence order: constructor kwargs → CLI args
+    (via :func:`load_digest_config_from_argv`) → env vars → defaults.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_DIGEST_",
+        extra="ignore",
+    )
+
+    input: Path = Field(
+        default=Path("data/cloned"),
+        description="Directory containing cloned datasets.",
+    )
+    output: Path = Field(
+        default=Path("digestion_output"),
+        description="Output directory for JSON files.",
+    )
+    datasets: list[str] | None = Field(
+        default=None,
+        description="Specific dataset IDs to digest (default: all).",
+    )
+    workers: int = Field(
+        default=1,
+        ge=1,
+        le=128,
+        description="Parallel worker processes (1 = sequential).",
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Stop after digesting N datasets (test-mode short-circuit).",
+    )
+    dataset_timeout: float = Field(
+        default=float(DEFAULT_DATASET_TIMEOUT_SECONDS),
+        gt=0.0,
+        le=60 * 60 * 4.0,  # 4-hour ceiling — anything bigger is a misconfig
+        description=(
+            "Seconds before killing a worker. Default: 120s. Ceiling: 4h "
+            "(beyond that, fix the underlying slowness instead of waiting)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> DigestConfig:
+        if not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+
+def load_digest_config_from_argv(
+    argv: list[str] | None = None,
+) -> DigestConfig:
+    """Parse argv (or sys.argv) into a validated :class:`DigestConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Digest BIDS datasets and generate Dataset + Record JSON for MongoDB."
+        )
+    )
+    parser.add_argument("--input", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--datasets", nargs="+", default=None)
+    parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--dataset-timeout",
+        type=float,
+        default=None,
+        dest="dataset_timeout",
+        help=(
+            "Seconds to allow one dataset before killing its worker "
+            f"(default: {DEFAULT_DATASET_TIMEOUT_SECONDS:g})"
+        ),
+    )
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None}
+    return DigestConfig(**kwargs)

--- a/scripts/ingestions/_inject_config.py
+++ b/scripts/ingestions/_inject_config.py
@@ -1,0 +1,275 @@
+"""Pydantic-settings config for 5_inject.py CLI + env vars."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import httpx
+from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_API_URL = "https://data.eegdash.org"
+
+# Fallback contract; drift is detected when /admin/valid-databases is reachable.
+LOCAL_FALLBACK_DATABASES: frozenset[str] = frozenset(
+    {
+        "eegdash",
+        "eegdash_dev",
+        "eegdash_archive",
+        "eegdash_staging",
+        "eegdash_v1",
+    }
+)
+
+# Per-API-URL cache; cleared by tests via clear_valid_databases_cache().
+_valid_databases_cache: dict[str, frozenset[str]] = {}
+
+
+def fetch_valid_databases_from_api(
+    api_url: str,
+    token: str | None,
+    *,
+    timeout: float = 5.0,
+) -> frozenset[str] | None:
+    """Return the API Gateway's valid_databases set, or None on any failure."""
+    if api_url in _valid_databases_cache:
+        cached = _valid_databases_cache[api_url]
+        return cached if cached else None  # empty frozenset is "API previously failed"
+
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(f"{api_url}/admin/valid-databases", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            valid = frozenset(data["databases"])
+    except (httpx.HTTPError, KeyError, ValueError, TypeError):
+        _valid_databases_cache[api_url] = frozenset()  # sentinel "no api data"
+        return None
+
+    _valid_databases_cache[api_url] = valid
+    return valid
+
+
+def clear_valid_databases_cache() -> None:
+    """Test helper. Resets the per-api_url cache."""
+    _valid_databases_cache.clear()
+
+
+# str alias; accepted values are checked dynamically at validation time.
+DatabaseName = str
+
+
+class InjectConfig(BaseSettings):
+    """Validated injection-pipeline config (kwargs > CLI > env > defaults)."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_INJECT_",
+        extra="ignore",
+    )
+
+    # ─── Required: target database ────────────────────────────────────────
+    database: DatabaseName = Field(
+        description="Target MongoDB database; validated against the API or LOCAL_FALLBACK_DATABASES.",
+    )
+
+    @field_validator("database")
+    @classmethod
+    def _database_must_be_valid(cls, value: str, info) -> str:
+        """Reject databases not in the union of the API set and LOCAL_FALLBACK_DATABASES."""
+        # api_url / token may not yet be validated; fall back to defaults.
+        api_url = info.data.get("api_url") or DEFAULT_API_URL
+        token = info.data.get("token")
+
+        api_set = fetch_valid_databases_from_api(api_url, token)
+        if api_set is None:
+            logging.getLogger(__name__).warning(
+                "Could not reach %s/admin/valid-databases; using "
+                "LOCAL_FALLBACK_DATABASES alone. Database-list drift "
+                "will not be detected this run.",
+                api_url,
+            )
+        valid: frozenset[str] = (api_set or frozenset()) | LOCAL_FALLBACK_DATABASES
+
+        if value not in valid:
+            raise ValueError(
+                f"database={value!r} is not in the valid set "
+                f"({sorted(valid)}); update the API's valid_databases or "
+                f"LOCAL_FALLBACK_DATABASES if you are adding a new one."
+            )
+        return value
+
+    # ─── I/O ─────────────────────────────────────────────────────────────
+    input: Path = Field(
+        default=Path("digestion_output"),
+        description="Directory containing digested datasets.",
+    )
+    api_url: str = Field(
+        default=DEFAULT_API_URL,
+        description="EEGDash API Gateway URL.",
+    )
+
+    # ─── Auth (env-var fallback: EEGDASH_ADMIN_TOKEN) ────────────────────
+    token: str | None = Field(
+        default=None,
+        description="Admin Bearer token (env fallback: EEGDASH_ADMIN_TOKEN).",
+        validation_alias=AliasChoices("token", "EEGDASH_ADMIN_TOKEN"),
+    )
+
+    # ─── Filters ─────────────────────────────────────────────────────────
+    datasets: list[str] | None = Field(
+        default=None,
+        description=(
+            "Specific dataset IDs to inject. Default: all datasets in --input."
+        ),
+    )
+
+    # ─── Behaviour flags ─────────────────────────────────────────────────
+    dry_run: bool = Field(default=False, description="Validate without uploading.")
+    batch_size: int = Field(
+        default=1000,
+        ge=1,
+        le=10_000,
+        description="Max records per API request.",
+    )
+    only_datasets: bool = Field(default=False)
+    only_records: bool = Field(default=False)
+    only_montages: bool = Field(default=False)
+    skip_montages: bool = Field(default=False)
+    force: bool = Field(
+        default=False,
+        description="Inject even if ingestion_fingerprint matches existing.",
+    )
+    skip_validation: bool = Field(
+        default=False,
+        description="Skip validation before injection (not recommended).",
+    )
+    data_quality_threshold: float = Field(
+        default=10.0,
+        ge=0.0,
+        le=100.0,
+        description=(
+            "Max percentage of records with missing nchans/sampling_frequency "
+            "before failing the pre-inject quality gate."
+        ),
+    )
+    compute_stats: bool = Field(
+        default=False,
+        description="Recompute dataset stats after injection.",
+    )
+
+    # ─── Validators ──────────────────────────────────────────────────────
+
+    @model_validator(mode="after")
+    def _only_flags_are_mutually_exclusive(self) -> InjectConfig:
+        """At most one of --only-datasets / --only-records / --only-montages."""
+        only_flags = sum((self.only_datasets, self.only_records, self.only_montages))
+        if only_flags > 1:
+            raise ValueError(
+                "--only-datasets, --only-records, --only-montages are "
+                "mutually exclusive (max one)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _only_and_skip_montages_are_contradictory(self) -> InjectConfig:
+        if self.only_montages and self.skip_montages:
+            raise ValueError(
+                "--only-montages and --skip-montages contradict each other"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _input_dir_must_exist_unless_dry_run(self) -> InjectConfig:
+        """Require the input directory to exist, unless dry_run skips actual I/O."""
+        if not self.dry_run and not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+    # ─── Convenience accessors ───────────────────────────────────────────
+
+    @property
+    def want_datasets(self) -> bool:
+        return not self.only_records and not self.only_montages
+
+    @property
+    def want_records(self) -> bool:
+        return not self.only_datasets and not self.only_montages
+
+    @property
+    def want_montages(self) -> bool:
+        if self.only_datasets or self.only_records:
+            return False
+        if self.skip_montages:
+            return False
+        return True
+
+
+def load_inject_config_from_argv(argv: list[str] | None = None) -> InjectConfig:
+    """Parse argv (or sys.argv) into a validated :class:`InjectConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject digested datasets and records into MongoDB via "
+            "the EEGDash API Gateway."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Directory containing digested datasets (default: digestion_output/).",
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        required=True,
+        help=(
+            "Target MongoDB database: eegdash | eegdash_dev | eegdash_archive | "
+            "eegdash_staging | eegdash_v1."
+        ),
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        default=None,
+        dest="api_url",
+        help=f"EEGDash API URL (default: {DEFAULT_API_URL}).",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Admin token (env fallback: EEGDASH_ADMIN_TOKEN).",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=None,
+        help="Specific dataset IDs to inject (default: all).",
+    )
+    parser.add_argument("--dry-run", action="store_true", dest="dry_run")
+    parser.add_argument("--batch-size", type=int, default=None, dest="batch_size")
+    parser.add_argument("--only-datasets", action="store_true", dest="only_datasets")
+    parser.add_argument("--only-records", action="store_true", dest="only_records")
+    parser.add_argument("--only-montages", action="store_true", dest="only_montages")
+    parser.add_argument("--skip-montages", action="store_true", dest="skip_montages")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--skip-validation", action="store_true", dest="skip_validation"
+    )
+    parser.add_argument(
+        "--data-quality-threshold",
+        type=float,
+        default=None,
+        dest="data_quality_threshold",
+    )
+    parser.add_argument("--compute-stats", action="store_true", dest="compute_stats")
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    # Omit None so Field defaults take effect.
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None}
+    return InjectConfig(**kwargs)

--- a/scripts/ingestions/_validate.py
+++ b/scripts/ingestions/_validate.py
@@ -1,7 +1,6 @@
-"""Validation utilities for injection scripts.
+"""Validation utilities for the ingestion pipeline.
 
-This module re-exports the validation functions from 4_validate_output.py
-for use in other ingestion scripts.
+``4_validate_output.py`` is a thin CLI wrapper that imports from here.
 """
 
 import json
@@ -11,7 +10,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from eegdash.schemas import DatasetModel, RecordModel
+from eegdash.schemas import DatasetModel, ManifestFileModel, ManifestModel, RecordModel
 
 # Valid storage URL patterns per source
 VALID_STORAGE_PATTERNS = {
@@ -89,9 +88,9 @@ class ValidationResult:
         self.modality_distribution = {}
         self.empty_datasets = []
         self.zip_placeholder_datasets = []
-        self.data_quality_issues = []  # Datasets with missing nchans/sampling_frequency
+        self.data_quality_issues = []
 
-    def add_error(self, dataset: str, message: str, field: str = None):
+    def add_error(self, dataset: str, message: str, field: str | None = None):
         self.errors.append(
             {
                 "dataset": dataset,
@@ -100,7 +99,7 @@ class ValidationResult:
             }
         )
 
-    def add_warning(self, dataset: str, message: str, field: str = None):
+    def add_warning(self, dataset: str, message: str, field: str | None = None):
         self.warnings.append(
             {
                 "dataset": dataset,
@@ -225,7 +224,6 @@ def validate_record(
     except ValidationError as exc:
         _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="record")
 
-    # Validate storage URL matches source
     storage = record.get("storage", {})
     if storage:
         storage_base = storage.get("base", "")
@@ -234,7 +232,6 @@ def validate_record(
             result.add_error(dataset_id, error_msg, field="storage.base")
             result.stats["storage_errors"] += 1
 
-    # Check recommended fields (warnings only, first record only)
     if record_idx == 0:
         for field in RECOMMENDED_RECORD_FIELDS:
             if field not in record or record[field] is None:
@@ -245,7 +242,6 @@ def validate_record(
                 )
                 result.stats["missing_recommended"] += 1
 
-    # Check data quality fields (nchans, sampling_frequency) - critical for usability
     nchans = record.get("nchans")
     sampling_frequency = record.get("sampling_frequency")
     if nchans is None or nchans == 0:
@@ -284,17 +280,7 @@ def validate_digestion_output(
     verbose: bool = False,
     strict: bool = False,
 ) -> ValidationResult:
-    """Validate all digestion output in a directory.
-
-    Args:
-        input_dir: Directory containing digested datasets
-        verbose: Print progress information
-        strict: Treat warnings as errors
-
-    Returns:
-        ValidationResult with all findings
-
-    """
+    """Validate all digestion output in a directory."""
     result = ValidationResult()
 
     if not input_dir.exists():
@@ -317,7 +303,6 @@ def validate_digestion_output(
         source = "unknown"
         record_count = 0
 
-        # Load dataset first to get source
         if dataset_file.exists():
             try:
                 with open(dataset_file) as f:
@@ -330,10 +315,13 @@ def validate_digestion_output(
 
             except json.JSONDecodeError as e:
                 result.add_error(dataset_id, f"Invalid JSON in dataset file: {e}")
-            except Exception as e:
+            except (OSError, KeyError, ValueError, TypeError) as e:
+                # OSError: file disappeared / permission. KeyError: missing
+                # 'datasets' or other expected fields. ValueError/TypeError:
+                # validate_dataset received an unexpected shape. All
+                # accumulate into result.errors rather than crashing.
                 result.add_error(dataset_id, f"Error reading dataset: {e}")
 
-        # Validate records
         if records_file.exists():
             try:
                 with open(records_file) as f:
@@ -354,13 +342,11 @@ def validate_digestion_output(
                     for mod in mods:
                         modalities[mod] += 1
 
-                    # Track ZIP placeholders
                     if record.get("needs_extraction") or record.get(
                         "zip_contains_bids"
                     ):
                         has_zip_placeholder = True
 
-                    # Track data quality at dataset level
                     if record.get("nchans") is None or record.get("nchans") == 0:
                         has_missing_nchans = True
                     if (
@@ -385,10 +371,11 @@ def validate_digestion_output(
 
             except json.JSONDecodeError as e:
                 result.add_error(dataset_id, f"Invalid JSON in records file: {e}")
-            except Exception as e:
+            except (OSError, KeyError, ValueError, TypeError) as e:
+                # Same rationale as the dataset-file handler above. Bad
+                # records accumulate; we don't crash the whole digest.
                 result.add_error(dataset_id, f"Error reading records: {e}")
 
-        # Flag empty datasets
         if record_count == 0:
             result.stats["empty_datasets"] += 1
             result.empty_datasets.append(f"{dataset_id} ({source})")
@@ -406,4 +393,94 @@ def validate_digestion_output(
     result.source_distribution = dict(sources)
     result.modality_distribution = dict(modalities)
 
+    return result
+
+
+def validate_pre_digestion(input_dir: Path, verbose: bool = False) -> ValidationResult:
+    """Pre-digestion validation: walk ``manifest.json`` files under
+    ``input_dir`` and flag manifests with no recognised neurophysiology
+    data file (CTF ``.ds`` directories counted as one).
+    """
+    result = ValidationResult()
+
+    if not input_dir.exists():
+        result.add_error("", f"Input directory does not exist: {input_dir}")
+        return result
+
+    dataset_dirs = [
+        d for d in input_dir.iterdir() if d.is_dir() and (d / "manifest.json").exists()
+    ]
+
+    if verbose:
+        print(f"Found {len(dataset_dirs)} manifests to check")
+
+    sources = Counter()
+
+    for dataset_dir in dataset_dirs:
+        dataset_id = dataset_dir.name
+        manifest_path = dataset_dir / "manifest.json"
+
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+            try:
+                manifest_model = ManifestModel.model_validate(manifest)
+            except ValidationError as exc:
+                _add_pydantic_errors(
+                    result, dataset_id=dataset_id, exc=exc, prefix="manifest"
+                )
+                continue
+
+            source = manifest_model.source or "unknown"
+            sources[source] += 1
+            result.stats["datasets_checked"] += 1
+
+            files = manifest_model.files
+
+            data_file_count = 0
+            ctf_ds_dirs = set()
+
+            for f in files:
+                if isinstance(f, str):
+                    filepath = f
+                elif isinstance(f, ManifestFileModel):
+                    filepath = f.path_or_name()
+                else:
+                    filepath = ""
+                filepath_lower = filepath.lower()
+
+                # CTF datasets are directories; count files inside .ds/ once.
+                if ".ds/" in filepath_lower:
+                    ds_idx = filepath_lower.index(".ds/") + 3
+                    ds_path = filepath[:ds_idx]
+                    ctf_ds_dirs.add(ds_path)
+                    continue
+
+                for ext in NEURO_EXTENSIONS:
+                    if filepath_lower.endswith(ext):
+                        data_file_count += 1
+                        break
+
+            data_file_count += len(ctf_ds_dirs)
+            result.stats["records_checked"] += data_file_count
+
+            if data_file_count == 0:
+                result.stats["empty_datasets"] += 1
+                result.empty_datasets.append(f"{dataset_id} ({source})")
+                result.add_warning(
+                    dataset_id,
+                    f"No recognized neurophysiology files in manifest "
+                    f"({len(files)} total files)",
+                )
+
+            if verbose and data_file_count > 0:
+                print(f"  {dataset_id}: {data_file_count} data files")
+
+        except json.JSONDecodeError as e:
+            result.add_error(dataset_id, f"Invalid JSON in manifest: {e}")
+        except (OSError, KeyError, ValueError, TypeError) as e:
+            result.add_error(dataset_id, f"Error reading manifest: {e}")
+
+    result.source_distribution = dict(sources)
     return result

--- a/scripts/ingestions/_validate_config.py
+++ b/scripts/ingestions/_validate_config.py
@@ -1,0 +1,118 @@
+"""Pydantic-settings config for 4_validate_output.py (C7.1).
+
+Applies the C6.5 pattern (Pydantic-settings + thin argparse bridge)
+to the validate stage. 5 CLI flags become declarative fields with
+descriptions; existing exit-code semantics preserved.
+
+The pattern from _inject_config.py:
+1. ``BaseSettings`` model — fields + validators + accessors.
+2. ``load_*_config_from_argv()`` — argparse → kwargs bridge that
+   preserves --help / short-flag ergonomics.
+3. ``main()`` in the stage calls the loader, gets a typed config.
+
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ValidateConfig(BaseSettings):
+    """Validated config for the digest-output validation stage.
+
+    Sources, in precedence order: constructor kwargs → CLI args
+    (via :func:`load_validate_config_from_argv`) → env vars → defaults.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_VALIDATE_",
+        extra="ignore",
+    )
+
+    # I/O
+    input: Path = Field(
+        default=Path("digestion_output"),
+        description=(
+            "Input directory. Default: ``digestion_output``. For "
+            "``--pre-check``, point at ``data/cloned`` instead."
+        ),
+    )
+
+    # Mode toggles
+    pre_check: bool = Field(
+        default=False,
+        description=(
+            "Pre-digestion validation: check manifests have valid "
+            "data files (run BEFORE digest, not after)."
+        ),
+    )
+    verbose: bool = Field(default=False, description="Print per-dataset diagnostics.")
+    strict: bool = Field(
+        default=False,
+        description="Treat warnings as errors (empty datasets fail too).",
+    )
+    # The CLI flag is --json; ``json`` clashes with the stdlib module
+    # name inside main() so we expose it as ``json_output`` in the model
+    # and map back at the CLI layer.
+    json_output: bool = Field(
+        default=False,
+        description="Output the result as a JSON document on stdout.",
+    )
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> ValidateConfig:
+        """The validator can't validate nothing — the input dir has to
+        exist. (No dry-run escape hatch like 5_inject; this stage IS
+        the dry-check.)
+        """
+        if not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+
+def load_validate_config_from_argv(
+    argv: list[str] | None = None,
+) -> ValidateConfig:
+    """Parse argv (or sys.argv) into a validated :class:`ValidateConfig`."""
+    parser = argparse.ArgumentParser(
+        description="Validate digestion output for eegdash compatibility"
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        default=None,
+        help=("Input directory (digestion_output or data/cloned for --pre-check)"),
+    )
+    parser.add_argument(
+        "--pre-check",
+        action="store_true",
+        dest="pre_check",
+        help=("Pre-digestion validation: check manifests have valid data files"),
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print verbose output"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors (empty datasets become errors)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON",
+    )
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None and v is not False}
+    # Re-add False booleans that were explicitly set to False by argparse
+    # (action="store_true" defaults to False — only forward when True).
+    return ValidateConfig(**kwargs)

--- a/scripts/ingestions/profiles/.gitignore
+++ b/scripts/ingestions/profiles/.gitignore
@@ -1,0 +1,16 @@
+# Profile artifacts — large binaries / logs that don't belong in git.
+# The deliverable is E2E-FULL-SCALE-PROFILE.md, which summarises and
+# cross-references everything else.
+#
+# Recreate via the reproducibility section at the bottom of the .md.
+
+*.log
+*.pstats
+*.dot
+*.svg
+stage1/
+stage2/
+stage3/
+stage3-sample/
+stage4/
+nemar-fetch.log

--- a/scripts/ingestions/pyproject.toml
+++ b/scripts/ingestions/pyproject.toml
@@ -1,0 +1,263 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Flat layout with non-package directories alongside the bare modules
+# (profiles/, data/, ...). Disable setuptools auto-discovery
+# and ship the bare modules explicitly so `pip install -e .` works.
+[tool.setuptools]
+py-modules = [
+    "_bids",
+    "_clone_config",
+    "_constants",
+    "_digest_config",
+    "_file_utils",
+    "_fingerprint",
+    "_format_parser_registry",
+    "_github",
+    "_http",
+    "_inject_config",
+    "_inject_plan",
+    "_keywords",
+    "_mef3_parser",
+    "_metadata_cascade",
+    "_montage",
+    "_parser_utils",
+    "_serialize",
+    "_set_parser",
+    "_snirf_parser",
+    "_validate",
+]
+
+[project]
+name = "eegdash-ingestions"
+version = "0.1.0"
+description = "BIDS-dataset ingestion pipeline for the eegdash MongoDB"
+requires-python = ">=3.10"
+license = {text = "BSD-3-Clause"}
+authors = [{name = "Bruno Aristimunha", email = "b.aristimunha@gmail.com"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+dependencies = [
+    "httpx[http2]>=0.27",
+    "tenacity>=8",
+    "pydantic>=2.5",
+    "pydantic-settings>=2",
+    "pandas",
+    "mne-bids>=0.14",
+    "python-dotenv>=1",
+    "pooch>=1.7",  # eegdash.testing.data_path() lazy-fetches test corpus
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=4",
+    "pytest-benchmark>=4",
+    "hypothesis>=6.100",
+    "respx>=0.20",
+    "mutmut>=2.4",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+# ─── Tooling ────────────────────────────────────────────────────────────────
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+extend-exclude = ["1_fetch_sources", "data", "__pycache__", ".cache", "mutants"]
+
+[tool.ruff.lint]
+# Initial selection — keep tight from day 1 so quality only ratchets up.
+# BLE (blind-except) is the headline rule for Phase 3 of the robustness
+# programme: every except: / except Exception: gets reviewed individually.
+select = [
+    "E", "F", "W",   # pycodestyle + pyflakes
+    "I",             # isort
+    "B",             # bugbear
+    "BLE",           # blind-except — Phase 3 target
+    "UP",            # pyupgrade
+    "PT",            # pytest-style
+    "RUF",           # ruff-specific
+    "N",             # pep8-naming
+    "PLC0415",       # import-outside-top-level (PEP 8 — lift lazy imports)
+]
+# D (pydocstyle / numpydoc) is selected per-file once the legacy code has
+# been touched up; turning it on globally on day 1 would generate ~1000
+# warnings on existing code we haven't reviewed yet.
+ignore = [
+    "E501",  # line-too-long — ruff format handles wrap
+    "E402",  # module-level imports after code — used by `# noqa: E402` in mne_bids
+]
+
+[tool.ruff.lint.per-file-ignores]
+# The numbered script files are CLI entrypoints; relax the naming rule
+# (N999: invalid-module-name fires on the leading digit).
+"[0-9]*_*.py" = ["N999"]
+# Test files: relaxed naming + Unicode rules.
+#   D                — tests don't need NumPy docstrings.
+#   N802/N806        — pydantic model class names (DatasetModel, RecordModel)
+#                      are referenced in test names + assigned to local vars.
+#   RUF002/RUF003    — docstrings/comments use × (multiply) and – (en-dash)
+#                      in performance/fixture annotations.
+#   BLE001           — broad except in negative-path test scaffolding.
+"tests/**/*.py" = ["D", "N802", "N806", "RUF002", "RUF003", "BLE001"]
+
+# Legacy-file baseline — these rules will be enforced PHASE BY PHASE as the
+# files are touched. Removing an ignore from this list is part of the
+# evaluation hook for the relevant phase.
+#
+# BLE001 — bare-except / broad-except. 72 violations across 17 files. Phase 3
+# of the robustness programme sweeps these; the per-file ignore is removed
+# as each file is cleaned.
+#
+# Other rules are smaller categories (RUF002/003/005/013, B007, N806, etc.)
+# that we'll tidy mechanically when their owning file is next touched.
+# "2_clone.py"                  — bare-excepts swept in Phase 9 F1 fix (commit 14)
+"3_digest.py"                   = ["E741", "RUF003", "RUF005", "RUF013", "RUF046", "B007", "PLC0415"]  # one pre-existing _vhdr_parser lazy import; sweep when file is next touched
+"_github.py"                    = ["PLC0415"]  # PyGithub lazy import inside try/ImportError
+"_set_parser.py"                = ["PLC0415"]  # scipy.io + h5py lazy optional-dep imports
+"inject_nemar_citations.py"     = ["PLC0415"]  # legacy lazy import — sweep with Phase 3
+# "4_validate_output.py"        — bare-excepts swept Phase 3 (commit 17)
+# "5_inject.py"                 — bare-excepts swept Phase 3 (commit 17)
+# "_bids.py"                    — bare-excepts swept in Phase 3 (commit 2)
+"_file_utils.py"                = ["E741", "RUF003", "RUF005"]  # bare-excepts swept Phase 3 (commit 16)
+# "_github.py"                  — bare-excepts swept in Phase 3 (commit 2). 2 deliberate broad
+#                                  catches remain around PyGithub's heterogeneous wrappings, each
+#                                  marked with an inline noqa: BLE001 + rationale.
+# "_http.py"                    — bare-excepts swept in Phase 3 (commit 2)
+# "_mef3_parser.py"             — bare-excepts swept in Phase 3 (commit 1)
+"_montage.py"                   = ["N806", "RUF002", "RUF003", "RUF013", "RUF059"]  # BLE001 swept Phase 3 (final)
+# "_set_parser.py"              — bare-excepts swept in Phase 3 (commit 1)
+# "_snirf_parser.py"            — bare-excepts swept in Phase 3 (commit 1)
+# "_validate.py"                — bare-excepts swept in Phase 3 (commit 2)
+# "api_helper.py"               — bare-excepts swept Phase 3 (commit 16)
+# "inject_nemar_citations.py"   — swept Phase 3 (commit 15)
+# "patch_nemar_records_storage.py" — swept Phase 3 (commit 15)
+# "patch_nemar_source.py"       — swept Phase 3 (commit 15)
+# "time_openneuro_pipeline.py"  — swept Phase 3 (commit 15)
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "mne",
+    "mne_bids",
+    "eegdash",
+    # Local ingestion modules — bare ``_*.py`` files siblings to this
+    # config. Explicitly listed so isort groups them in the first-party
+    # block instead of guessing.
+    "_bids",
+    "_clone_config",
+    "_constants",
+    "_digest_config",
+    "_file_utils",
+    "_fingerprint",
+    "_format_parser_registry",
+    "_github",
+    "_http",
+    "_inject_config",
+    "_inject_plan",
+    "_keywords",
+    "_mef3_parser",
+    "_metadata_cascade",
+    "_montage",
+    "_parser_utils",
+    "_serialize",
+    "_set_parser",
+    "_snirf_parser",
+    "_validate",
+    "_validate_config",
+    "_vhdr_parser",
+]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.mypy]
+python_version = "3.10"
+# Permissive baseline. Tighten per-module as legacy files are refactored
+# under their own characterisation tests (see
+# Phase 8). Goal: --strict on new files; existing files raised
+# incrementally as they're touched.
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# Aspirational `--strict` per file — start with parsers (Phase 1 target).
+module = [
+    "_set_parser",
+    "_vhdr_parser",
+    "_snirf_parser",
+    "_mef3_parser",
+]
+disallow_untyped_defs = true
+warn_return_any = true
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --tb=short"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "network: marks tests that require network access (deselect with '-m \"not network\"')",
+    "integration: marks tests that hit the live cluster (opt-in via EEGDASH_INTEGRATION_API_URL + EEGDASH_INTEGRATION_ADMIN_TOKEN; deselect with '-m \"not integration\"')",
+]
+# Hypothesis: cap example count for CI speed; raise locally for deep fuzz.
+filterwarnings = [
+    "ignore::DeprecationWarning:hypothesis.*",
+]
+
+[tool.coverage.run]
+source = ["."]
+omit = [
+    "tests/*",
+    "1_fetch_sources/*",
+    "*/conftest.py",
+    "__init__.py",
+    # One-off operational scripts (per ADR 0001 banner). These are run
+    # manually for specific ops tasks (NEMAR citation injection, etc.)
+    # and aren't part of the regular ingest pipeline — including them
+    # in coverage drags the total down without value.
+    "api_helper.py",
+    "inject_nemar_citations.py",
+    "patch_nemar_records_storage.py",
+    "patch_nemar_source.py",
+    "time_openneuro_pipeline.py",
+    # Mutmut runtime config (auto-generated by mutmut; not a test target)
+    "mutmut_config.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    'if __name__ == "__main__":',
+    "if TYPE_CHECKING:",
+]
+show_missing = true
+skip_covered = false
+
+# Mutation testing config (mutmut 2.x — see
+# for why we pinned to 2.x rather than 3.x).
+#
+# Run interactively:
+#   cd scripts/ingestions
+#   mutmut run
+#   mutmut results
+#   mutmut show <id>   # to inspect a surviving mutant
+#
+# Target kill ratio: >= 60 % on _vhdr_parser.py before expanding scope.
+
+[tool.mutmut]
+paths_to_mutate = "_vhdr_parser.py"
+tests_dir = "tests/"
+runner = "python -m pytest tests/parsers/test_vhdr.py tests/parsers/test_property.py -x -q --tb=no --no-header -p no:cacheprovider"

--- a/scripts/ingestions/scripts/find_leaked_creds.sh
+++ b/scripts/ingestions/scripts/find_leaked_creds.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Find leaked credentials in commit messages, file contents, and the
+# index. Exit 1 if any are found; 0 otherwise.
+#
+# Patterns target what's been observed leaking historically:
+#   - EEGDASH_ADMIN_TOKEN=<20+ alphanumerics>
+#   - MONGO_INITDB_ROOT_PASSWORD=<8+ chars>
+#   - 40+ char hex strings (CI_TOKEN shape)
+#
+# Add new patterns at the top; the script reports per-pattern matches.
+
+set -u  # not -e: we want to count matches, not bail on first miss
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  printf '[find_leaked_creds] Not in a git repo — refusing to declare clean.\n' >&2
+  exit 2
+fi
+cd "$git_root" >/dev/null
+
+PATTERNS=(
+  'EEGDASH_ADMIN_TOKEN[[:space:]]*[=:][[:space:]]*"?[A-Za-z0-9]{20,}'
+  'MONGO_INITDB_ROOT_PASSWORD[[:space:]]*[=:][[:space:]]*"?[^[:space:]"]{8,}'
+  'ADMIN_TOKEN[[:space:]]*[=:][[:space:]]*"?[A-Za-z0-9]{20,}'
+  'CI_TOKEN[[:space:]]*[=:][[:space:]]*"?[a-f0-9]{40,}'
+  # Generic AWS-style key shape (no separator)
+  'AKIA[0-9A-Z]{16}'
+)
+
+total=0
+
+scan() {
+  local label="$1" cmd="$2"
+  for pat in "${PATTERNS[@]}"; do
+    matches=$(eval "$cmd" 2>/dev/null | grep -E "$pat" || true)
+    if [[ -n "$matches" ]]; then
+      printf '\n=== %s — pattern: %s ===\n' "$label" "$pat"
+      printf '%s\n' "$matches"
+      lines=$(printf '%s\n' "$matches" | wc -l)
+      total=$((total + lines))
+    fi
+  done
+}
+
+scan "Commit messages" "git log --all --format=%B"
+scan "Tracked file contents" "git grep -I -n '' -- . ':(exclude)*.snirf' ':(exclude)*.tmet' ':(exclude)*.edf' ':(exclude)*.bdf' ':(exclude)*.set' ':(exclude)*.fif' ':(exclude)*.vhdr' ':(exclude)*.cnt' ':(exclude)*.nwb' 2>/dev/null"
+scan "Staged changes"  "git diff --cached"
+
+if [[ $total -gt 0 ]]; then
+  printf '\n[find_leaked_creds] Found %d suspect match(es). Investigate above.\n' "$total" >&2
+  exit 1
+fi
+
+printf '[find_leaked_creds] Clean.\n'
+exit 0

--- a/scripts/ingestions/tests/_helpers/__init__.py
+++ b/scripts/ingestions/tests/_helpers/__init__.py
@@ -1,0 +1,42 @@
+"""Shared test helpers — paths, synthetic fixture builders, factories."""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+from pathlib import Path
+from types import ModuleType
+
+# Stable anchor: ``_helpers/__init__.py`` lives at ``tests/_helpers/``,
+# so ``parents[2]`` is ``scripts/ingestions/`` regardless of how deeply
+# a consumer test file is nested under ``tests/``.
+INGEST_DIR = Path(__file__).resolve().parents[2]
+TESTS_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(filename: str) -> ModuleType:
+    """Load a digit-prefixed ingestion script via ``importlib``.
+
+    Replaces the per-file ``_load_digest()`` / ``_load_inject()`` shims
+    that every consumer used to define. Fresh exec per call (matches the
+    original per-test behaviour — no shared module state).
+    """
+    alias = f"loaded_{Path(filename).stem}"
+    spec = _ilu.spec_from_file_location(alias, INGEST_DIR / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_digest() -> ModuleType:
+    """Load ``3_digest.py``."""
+    return load_module("3_digest.py")
+
+
+def load_inject() -> ModuleType:
+    """Load ``5_inject.py``."""
+    return load_module("5_inject.py")
+
+
+__all__ = ["INGEST_DIR", "TESTS_DIR", "load_digest", "load_inject", "load_module"]

--- a/scripts/ingestions/tests/conftest.py
+++ b/scripts/ingestions/tests/conftest.py
@@ -1,0 +1,68 @@
+"""Pytest configuration and shared fixtures for ingestion tests.
+
+Fixtures defined here are auto-discovered by pytest in every test file
+under ``tests/``. Keep this file small — module-specific fixtures live
+next to the tests that use them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from eegdash.testing import data_path
+
+# Make the ingestion package importable without `pip install -e .` —
+# this is the smallest layer that lets `from _set_parser import …` work
+# from the test files. Once the package is properly installed via the
+# pyproject.toml, this becomes redundant; for now it keeps `pytest`
+# discoverable from any CWD.
+_INGEST_DIR = Path(__file__).resolve().parent.parent
+if str(_INGEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_INGEST_DIR))
+
+# Also make tests/ itself importable so subfolder tests can write
+# `from _helpers.builders import …` without having to spell out
+# `tests._helpers.builders` everywhere.
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+
+# ─── Fixture paths (lazily fetched from eegdash-testing-data) ──────────────
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"  # only inline: records/
+
+
+def _testing_data_root() -> Path:
+    """Resolve the testing-data corpus root, skipping the test on failure."""
+    try:
+        return data_path()
+    except Exception as exc:  # fetch failure → skip cleanly
+        pytest.skip(f"eegdash-testing-data unavailable: {exc}")
+
+
+@pytest.fixture(scope="session")
+def eeg_fixtures_dir() -> Path:
+    """Path to EEG-modality fixtures (EDF/BDF/BV/SET) inside the testing-data corpus."""
+    return _testing_data_root() / "eeg"
+
+
+@pytest.fixture(scope="session")
+def ieeg_fixtures_dir() -> Path:
+    """Path to iEEG-modality fixtures (BrainVision triple, MEF3 header)."""
+    return _testing_data_root() / "ieeg"
+
+
+@pytest.fixture(scope="session")
+def meg_fixtures_dir() -> Path:
+    """Path to MEG-modality fixtures (FIFF samples from MNE-Python BSD-3)."""
+    return _testing_data_root() / "meg"
+
+
+@pytest.fixture(scope="session")
+def digest_snapshots_dir() -> Path:
+    """Directory containing ``digest_snapshots/{inputs,outputs}/ds_snapshot_*``."""
+    return _testing_data_root() / "digest_snapshots"

--- a/scripts/ingestions/tests/test_smoke.py
+++ b/scripts/ingestions/tests/test_smoke.py
@@ -1,0 +1,81 @@
+"""Smoke tests for fixture-corpus presence + license attribution.
+
+A handful of canary checks proving (a) the eegdash-testing-data corpus
+landed in the local cache and (b) every modality/format pair the
+parsers expect is represented. The "does pytest collect at all" test
+that used to live here was a pure tautology and was removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_fixtures_directory_exists(eeg_fixtures_dir: Path) -> None:
+    """The CC0 fixture corpus has been fetched into the cache.
+
+    Without these fixtures, Phase 1 parser tests cannot run. The
+    fixture itself triggers the lazy download from eegdash-testing-data
+    on first use; this test is the canary that the download landed.
+    """
+    assert eeg_fixtures_dir.exists(), (
+        f"fixtures dir missing at {eeg_fixtures_dir} — "
+        "run `python -m eegdash.testing` to fetch the corpus"
+    )
+    edf_files = list(eeg_fixtures_dir.glob("*.edf"))
+    assert len(edf_files) >= 1, "expected at least one .edf fixture"
+
+
+def test_attribution_file_present(eeg_fixtures_dir: Path) -> None:
+    """Fixture provenance must be documented.
+
+    Every fixture binary in the corpus is derived from a CC0 or
+    BSD-licensed source. The attribution file is the contract that
+    keeps this redistributable.
+    """
+    attribution = eeg_fixtures_dir / "LICENSE-ATTRIBUTION.md"
+    assert attribution.exists(), (
+        "eeg/LICENSE-ATTRIBUTION.md must document the source of each "
+        "binary fixture (BIDS dataset accession + license)."
+    )
+    text = attribution.read_text()
+    assert "CC0" in text, "attribution must mention the CC0 license"
+
+
+@pytest.mark.parametrize(
+    ("modality", "suffix"),
+    [
+        ("eeg", ".edf"),
+        ("eeg", ".bdf"),
+        ("eeg", ".vhdr"),
+        ("eeg", ".set"),
+        ("ieeg", ".vhdr"),
+        ("meg", ".fif"),
+    ],
+)
+def test_modality_format_coverage(
+    modality: str,
+    suffix: str,
+    eeg_fixtures_dir: Path,
+    ieeg_fixtures_dir: Path,
+    meg_fixtures_dir: Path,
+) -> None:
+    """At least one fixture exists for each (modality, format) pair.
+
+    This is the matrix that proves the test corpus covers every reader
+    we are expected to test. If a future contributor adds a new reader
+    (CTF, SNIRF, etc.), the matrix grows.
+    """
+    fixtures_root = {
+        "eeg": eeg_fixtures_dir,
+        "ieeg": ieeg_fixtures_dir,
+        "meg": meg_fixtures_dir,
+    }[modality]
+    matches = list(fixtures_root.glob(f"*{suffix}"))
+    assert matches, (
+        f"no {modality}{suffix} fixture in {fixtures_root}. "
+        "Add it to eegdash/eegdash-testing-data and bump the pin in "
+        "eegdash/testing.py."
+    )

--- a/scripts/ingestions/tests/unit/test_find_leaked_creds.py
+++ b/scripts/ingestions/tests/unit/test_find_leaked_creds.py
@@ -1,0 +1,133 @@
+"""Tests for the find_leaked_creds.sh scanner (Task 5)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from _helpers import INGEST_DIR as _INGEST_DIR
+
+SCANNER = _INGEST_DIR / "scripts" / "find_leaked_creds.sh"
+
+
+# Synthesised token used ONLY in a temp git repo for scanner verification.
+# DO NOT CONCATENATE THESE STRINGS — split intentionally so this test
+# fixture file itself doesn't trip the find-leaked-creds scanner under
+# pre-commit. See find_leaked_creds.sh PATTERNS.
+_TOKEN_VAR = "EEGDASH_" + "ADMIN_TOKEN"
+_TOKEN_VAL = "AdminWrite2025" + "SecureTokenABC123"  # 30 alnum chars total
+_PLANTED_SECRET = f"{_TOKEN_VAR}={_TOKEN_VAL}"
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    """Create a tiny git repo with a planted secret in a commit message."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    f = tmp_path / "f.txt"
+    f.write_text("hello\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "f.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "commit",
+            "-q",
+            "-m",
+            f"test commit\n\n{_PLANTED_SECRET}",
+        ],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    return tmp_path
+
+
+def test_scanner_detects_token_in_commit_message(fake_repo):
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=fake_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "EEGDASH_ADMIN_TOKEN" in result.stdout
+    assert result.returncode == 1  # found leaks -> exit 1
+
+
+def test_scanner_clean_repo_exits_0(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "x.txt").write_text("clean\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "x.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "-m", "harmless"],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_scanner_detects_yaml_form_token(tmp_path):
+    """The pattern set must also catch ``KEY: value`` (YAML / docker-compose).
+
+    Real-world driver: the cluster's ``docker-compose.yml`` writes
+    credentials in YAML form, not env-shell form. A scanner that only
+    matches ``=`` would miss them.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    f = tmp_path / "compose-like.yml"
+    # Use split literal so this test file itself doesn't trip the scanner
+    # under pre-commit (see also the existing _TOKEN_VAR pattern).
+    yaml_secret = "ADMIN_TOKEN" + ": AdminWrite2025" + "SecureTokenABC123"
+    f.write_text(f"environment:\n  {yaml_secret}\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "compose-like.yml"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "-m", "add config"],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert "ADMIN_TOKEN" in result.stdout
+    assert result.returncode == 1
+
+
+def test_scanner_outside_git_repo_exits_2(tmp_path):
+    """In a non-git directory, scanner must refuse to claim clean."""
+    # tmp_path is NOT a git repo. Confirm:
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Not in a git repo" in result.stderr

--- a/scripts/ingestions/tests/unit/test_stage_configs.py
+++ b/scripts/ingestions/tests/unit/test_stage_configs.py
@@ -1,0 +1,732 @@
+"""Tests for the Pydantic-settings stage configs (clone / inject / cross-stage invariants)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from pydantic import ValidationError
+
+from _clone_config import (
+    KNOWN_SOURCES,
+    CloneConfig,
+    load_clone_config_from_argv,
+)
+from _digest_config import (
+    DEFAULT_DATASET_TIMEOUT_SECONDS,
+    DigestConfig,
+    load_digest_config_from_argv,
+)
+from _inject_config import (
+    DEFAULT_API_URL,
+    LOCAL_FALLBACK_DATABASES,
+    InjectConfig,
+    _valid_databases_cache,
+    clear_valid_databases_cache,
+    fetch_valid_databases_from_api,
+    load_inject_config_from_argv,
+)
+from _validate_config import (
+    ValidateConfig,
+    load_validate_config_from_argv,
+)
+
+# ─── 1. Clone config ──────────────────────────────────────────────
+
+
+def test_clone_config_defaults(tmp_path: Path):
+    c = CloneConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.output == Path("data/cloned")
+    assert c.sources is None
+    assert c.timeout == 300
+    assert c.workers == 8
+    assert c.limit is None
+    assert c.limit_per_source is None
+    assert c.datasets is None
+    assert c.manifest_only is False
+
+
+def test_clone_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError):
+        CloneConfig(input=tmp_path / "does_not_exist")
+
+
+# ─── Bounds ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("workers", 0, id="workers_below_min"),
+        pytest.param("workers", 9999, id="workers_above_max"),
+        pytest.param("timeout", 0, id="timeout_below_min"),
+        pytest.param("timeout", 60 * 60 * 24, id="timeout_above_6h"),
+        pytest.param("limit", 0, id="limit_below_min"),
+        pytest.param("limit_per_source", 0, id="limit_per_source_below_min"),
+    ],
+)
+def test_clone_config_field_bounds_reject_invalid(
+    tmp_path: Path, field: str, invalid_value: int
+):
+    with pytest.raises(ValidationError):
+        CloneConfig(input=tmp_path, **{field: invalid_value})
+
+
+def test_clone_config_workers_in_range_accepted(tmp_path: Path):
+    c = CloneConfig(input=tmp_path, workers=64)
+    assert c.workers == 64
+
+
+# ─── Sources validation ───────────────────────────────────────────────────
+
+
+def test_clone_config_accepts_known_sources(tmp_path: Path):
+    c = CloneConfig(
+        input=tmp_path,
+        sources=["openneuro", "nemar", "zenodo"],
+    )
+    assert c.sources == ["openneuro", "nemar", "zenodo"]
+
+
+def test_clone_config_rejects_unknown_source(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        CloneConfig(input=tmp_path, sources=["openneuro", "made_up_source"])
+    msg = str(exc.value)
+    assert "made_up_source" in msg
+
+
+@pytest.mark.parametrize("source", sorted(KNOWN_SOURCES))
+def test_clone_config_accepts_known_source(tmp_path: Path, source: str):
+    c = CloneConfig(input=tmp_path, sources=[source])
+    assert c.sources == [source]
+
+
+# ─── CLI parsing ──────────────────────────────────────────────────────────
+
+
+def test_clone_argv_parses_all_flags(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    c = load_clone_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--output",
+            str(out_dir),
+            "--sources",
+            "openneuro",
+            "nemar",
+            "--timeout",
+            "600",
+            "--workers",
+            "4",
+            "--limit",
+            "10",
+            "--limit-per-source",
+            "5",
+            "--datasets",
+            "ds-001",
+            "--manifest-only",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.output == out_dir
+    assert c.sources == ["openneuro", "nemar"]
+    assert c.timeout == 600
+    assert c.workers == 4
+    assert c.limit == 10
+    assert c.limit_per_source == 5
+    assert c.datasets == ["ds-001"]
+    assert c.manifest_only is True
+
+
+def test_clone_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_CLONE_WORKERS=16 → workers via env."""
+    monkeypatch.setenv("EEGDASH_CLONE_WORKERS", "16")
+    c = load_clone_config_from_argv(["--input", str(tmp_path)])
+    assert c.workers == 16
+
+
+def test_clone_argv_validation_error_for_unknown_source_via_argparse(
+    tmp_path: Path,
+):
+    """argparse choices=KNOWN_SOURCES rejects unknown sources via SystemExit before Pydantic."""
+    with pytest.raises(SystemExit):
+        load_clone_config_from_argv(
+            [
+                "--input",
+                str(tmp_path),
+                "--sources",
+                "made_up_source",
+            ]
+        )
+
+
+# ─── 2. Inject config ──────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _prime_valid_databases_cache():
+    """Pre-seed the cache so the field_validator skips real HTTP calls in CI."""
+    clear_valid_databases_cache()
+    _valid_databases_cache[DEFAULT_API_URL] = LOCAL_FALLBACK_DATABASES
+    yield
+    clear_valid_databases_cache()
+
+
+# ─── Defaults + required fields ───────────────────────────────────────────
+
+
+def test_config_requires_database():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(dry_run=True)
+    assert "database" in str(exc.value).lower()
+
+
+def test_config_rejects_invalid_database():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(database="not_a_real_db", dry_run=True)
+    msg = str(exc.value)
+    assert "database" in msg.lower()
+
+
+@pytest.mark.parametrize(
+    "database",
+    [
+        "eegdash",
+        "eegdash_dev",
+        "eegdash_archive",
+        "eegdash_staging",
+        "eegdash_v1",
+    ],
+)
+def test_config_accepts_each_valid_database(database: str):
+    c = InjectConfig(database=database, dry_run=True)
+    assert c.database == database
+
+
+def test_config_defaults():
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.api_url == DEFAULT_API_URL
+    assert c.input == Path("digestion_output")
+    assert c.batch_size == 1000
+    assert c.dry_run is True
+    assert c.only_datasets is False
+    assert c.only_records is False
+    assert c.only_montages is False
+    assert c.skip_montages is False
+    assert c.force is False
+    assert c.skip_validation is False
+    assert c.data_quality_threshold == 10.0
+    assert c.compute_stats is False
+    assert c.datasets is None
+
+
+# ─── Bounds ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("batch_size", 0, id="batch_size_lower"),
+        pytest.param("batch_size", 20_000, id="batch_size_upper"),
+        pytest.param("data_quality_threshold", -1.0, id="dqt_below_zero"),
+        pytest.param("data_quality_threshold", 101.0, id="dqt_above_100"),
+    ],
+)
+def test_inject_config_field_bounds_reject_invalid(field: str, invalid_value):
+    with pytest.raises(ValidationError):
+        InjectConfig(database="eegdash_dev", dry_run=True, **{field: invalid_value})
+
+
+@pytest.mark.parametrize("threshold", [0.0, 50.0, 100.0])
+def test_inject_data_quality_threshold_in_range_accepted(threshold: float):
+    c = InjectConfig(
+        database="eegdash_dev", data_quality_threshold=threshold, dry_run=True
+    )
+    assert c.data_quality_threshold == threshold
+
+
+# ─── Mutually-exclusive only-* flags ──────────────────────────────────────
+
+
+def test_two_only_flags_rejected():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            only_datasets=True,
+            only_records=True,
+            dry_run=True,
+        )
+    assert "mutually exclusive" in str(exc.value).lower()
+
+
+def test_three_only_flags_rejected():
+    with pytest.raises(ValidationError):
+        InjectConfig(
+            database="eegdash_dev",
+            only_datasets=True,
+            only_records=True,
+            only_montages=True,
+            dry_run=True,
+        )
+
+
+def test_each_single_only_flag_accepted():
+    for flag in ("only_datasets", "only_records", "only_montages"):
+        kw = {"database": "eegdash_dev", "dry_run": True, flag: True}
+        c = InjectConfig(**kw)
+        assert getattr(c, flag) is True
+
+
+# ─── only-montages + skip-montages contradict ─────────────────────────────
+
+
+def test_only_and_skip_montages_contradict():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            only_montages=True,
+            skip_montages=True,
+            dry_run=True,
+        )
+    assert "contradict" in str(exc.value).lower()
+
+
+# ─── input must exist (unless dry-run) ────────────────────────────────────
+
+
+def test_missing_input_dir_rejected_when_not_dry_run(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            input=tmp_path / "does_not_exist",
+            dry_run=False,
+        )
+    assert "input" in str(exc.value).lower()
+
+
+def test_missing_input_dir_allowed_in_dry_run(tmp_path: Path):
+    """Dry-run skips the existence check — useful for --help-style runs."""
+    InjectConfig(
+        database="eegdash_dev",
+        input=tmp_path / "does_not_exist",
+        dry_run=True,
+    )
+
+
+def test_existing_input_dir_accepted(tmp_path: Path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    c = InjectConfig(database="eegdash_dev", input=real_dir, dry_run=False)
+    assert c.input == real_dir
+
+
+# ─── Env var fallback for token ───────────────────────────────────────────
+
+
+def test_token_explicit_arg_used_when_provided():
+    c = InjectConfig(database="eegdash_dev", token="explicit", dry_run=True)
+    assert c.token == "explicit"
+
+
+def test_token_reads_from_eegdash_admin_token_env(monkeypatch):
+    """When --token is missing, read EEGDASH_ADMIN_TOKEN (legacy ops-script convention)."""
+    monkeypatch.setenv("EEGDASH_ADMIN_TOKEN", "from_env")
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.token == "from_env"
+
+
+def test_token_none_when_neither_arg_nor_env(monkeypatch):
+    monkeypatch.delenv("EEGDASH_ADMIN_TOKEN", raising=False)
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.token is None
+
+
+# ─── Convenience accessors (want_datasets / want_records / want_montages) ─
+
+
+def test_want_accessors_default_true():
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.want_datasets is True
+    assert c.want_records is True
+    assert c.want_montages is True
+
+
+@pytest.mark.parametrize(
+    ("flag", "want_datasets", "want_records", "want_montages"),
+    [
+        pytest.param("only_datasets", True, False, False, id="only_datasets"),
+        pytest.param("only_records", False, True, False, id="only_records"),
+        pytest.param("only_montages", False, False, True, id="only_montages"),
+    ],
+)
+def test_only_flag_filters_other_paths(
+    flag: str,
+    want_datasets: bool,
+    want_records: bool,
+    want_montages: bool,
+):
+    c = InjectConfig(database="eegdash_dev", dry_run=True, **{flag: True})
+    assert c.want_datasets is want_datasets
+    assert c.want_records is want_records
+    assert c.want_montages is want_montages
+
+
+def test_skip_montages_disables_montage_only():
+    c = InjectConfig(database="eegdash_dev", skip_montages=True, dry_run=True)
+    assert c.want_datasets is True
+    assert c.want_records is True
+    assert c.want_montages is False
+
+
+# ─── CLI parsing ──────────────────────────────────────────────────────────
+
+
+def test_argv_parses_minimum_required():
+    c = load_inject_config_from_argv(["--database", "eegdash_dev", "--dry-run"])
+    assert c.database == "eegdash_dev"
+    assert c.dry_run is True
+
+
+def test_argv_parses_all_string_flags():
+    c = load_inject_config_from_argv(
+        [
+            "--database",
+            "eegdash_dev",
+            "--api-url",
+            "https://test.example.com",
+            "--token",
+            "my-token",
+            "--batch-size",
+            "500",
+            "--dry-run",
+        ]
+    )
+    assert c.api_url == "https://test.example.com"
+    assert c.token == "my-token"
+    assert c.batch_size == 500
+
+
+def test_argv_parses_only_datasets_flag():
+    c = load_inject_config_from_argv(
+        ["--database", "eegdash_dev", "--only-datasets", "--dry-run"]
+    )
+    assert c.only_datasets is True
+    assert c.want_records is False
+
+
+def test_argv_parses_dataset_filter_list():
+    c = load_inject_config_from_argv(
+        [
+            "--database",
+            "eegdash_dev",
+            "--datasets",
+            "ds-001",
+            "ds-002",
+            "ds-003",
+            "--dry-run",
+        ]
+    )
+    assert c.datasets == ["ds-001", "ds-002", "ds-003"]
+
+
+def test_argv_validation_surfaces_via_validation_error():
+    with pytest.raises(ValidationError):
+        load_inject_config_from_argv(
+            [
+                "--database",
+                "eegdash_dev",
+                "--only-datasets",
+                "--only-records",
+                "--dry-run",
+            ]
+        )
+
+
+def test_argv_unknown_flag_rejected_by_argparse():
+    with pytest.raises(SystemExit):
+        load_inject_config_from_argv(
+            ["--database", "eegdash_dev", "--bogus-flag", "--dry-run"]
+        )
+
+
+# ─── fetch_valid_databases_from_api ────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_valid_databases_returns_api_list_on_200():
+    api_url = "https://api.example.test"
+    respx.get(f"{api_url}/admin/valid-databases").mock(
+        return_value=httpx.Response(
+            200, json={"databases": ["eegdash", "eegdash_dev", "eegdash_v2"]}
+        )
+    )
+
+    result = fetch_valid_databases_from_api(api_url, token="dummy")
+
+    assert result == frozenset({"eegdash", "eegdash_dev", "eegdash_v2"})
+
+
+@respx.mock
+def test_fetch_valid_databases_is_cached_per_api_url():
+    """Second call to the same api_url skips the network."""
+    clear_valid_databases_cache()
+    api_url = "https://cache-test.example"
+    route = respx.get(f"{api_url}/admin/valid-databases").mock(
+        return_value=httpx.Response(200, json={"databases": ["eegdash"]})
+    )
+
+    fetch_valid_databases_from_api(api_url, token=None)
+    fetch_valid_databases_from_api(api_url, token=None)
+    fetch_valid_databases_from_api(api_url, token=None)
+
+    assert route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("mock_kwargs", "expected"),
+    [
+        pytest.param(
+            {"return_value": httpx.Response(404, json={"detail": "not found"})},
+            None,
+            id="returns_none_on_404",
+        ),
+        pytest.param(
+            {"side_effect": httpx.ConnectError("boom")},
+            None,
+            id="returns_none_on_network_error",
+        ),
+        pytest.param(
+            {"return_value": httpx.Response(200, json={"unexpected": "shape"})},
+            None,
+            id="returns_none_on_missing_key",
+        ),
+    ],
+)
+@respx.mock
+def test_fetch_valid_databases_returns_none_on_error(mock_kwargs, expected):
+    clear_valid_databases_cache()
+    api_url = "https://error-case.example"
+    respx.get(f"{api_url}/admin/valid-databases").mock(**mock_kwargs)
+    assert fetch_valid_databases_from_api(api_url, token="x") is expected
+
+
+# ─── InjectConfig integration with the API-fetch field validator ──────────
+
+
+@respx.mock
+def test_inject_config_rejects_unknown_database_via_local_fallback(tmp_path):
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_does_not_exist",
+            input=tmp_path,
+            dry_run=True,
+        )
+    assert "valid set" in str(exc.value)
+
+
+@respx.mock
+def test_inject_config_accepts_database_only_in_api_set(tmp_path):
+    """API response extends the valid set beyond LOCAL_FALLBACK_DATABASES."""
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(
+            200,
+            json={"databases": ["eegdash", "eegdash_dev", "eegdash_v99_future"]},
+        )
+    )
+
+    c = InjectConfig(
+        database="eegdash_v99_future",
+        input=tmp_path,
+        dry_run=True,
+    )
+    assert c.database == "eegdash_v99_future"
+
+
+@respx.mock
+def test_inject_config_accepts_local_name_when_api_set_omits_it(tmp_path):
+    """LOCAL_FALLBACK_DATABASES names are accepted even when absent from the API set."""
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(200, json={"databases": ["eegdash", "eegdash_dev"]})
+    )
+
+    c = InjectConfig(
+        database="eegdash_archive",
+        input=tmp_path,
+        dry_run=True,
+    )
+    assert c.database == "eegdash_archive"
+
+
+@respx.mock
+def test_fetch_valid_databases_caches_failure_to_avoid_repeated_network_hits():
+    """Network failure is cached; subsequent calls return None without re-hitting the server."""
+    clear_valid_databases_cache()
+    api_url = "https://failure-cache.example"
+    route = respx.get(f"{api_url}/admin/valid-databases").mock(
+        side_effect=httpx.ConnectError("boom")
+    )
+
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+
+    assert route.call_count == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stage 4 — ValidateConfig
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_validate_config_defaults(tmp_path: Path):
+    c = ValidateConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.pre_check is False
+    assert c.verbose is False
+    assert c.strict is False
+    assert c.json_output is False
+
+
+def test_validate_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        ValidateConfig(input=tmp_path / "does_not_exist")
+    assert "input" in str(exc.value).lower()
+
+
+def test_validate_config_accepts_real_input(tmp_path: Path):
+    c = ValidateConfig(input=tmp_path)
+    assert c.input == tmp_path
+
+
+def test_validate_argv_parses_all_flags(tmp_path: Path):
+    c = load_validate_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--pre-check",
+            "--verbose",
+            "--strict",
+            "--json",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.pre_check is True
+    assert c.verbose is True
+    assert c.strict is True
+    assert c.json_output is True
+
+
+def test_validate_argv_short_flag_for_input(tmp_path: Path):
+    """-i is an alias for --input."""
+    c = load_validate_config_from_argv(["-i", str(tmp_path)])
+    assert c.input == tmp_path
+
+
+def test_validate_argv_short_flag_for_verbose(tmp_path: Path):
+    """-v is an alias for --verbose."""
+    c = load_validate_config_from_argv(["-i", str(tmp_path), "-v"])
+    assert c.verbose is True
+
+
+def test_validate_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_VALIDATE_STRICT=1 → strict via env."""
+    monkeypatch.setenv("EEGDASH_VALIDATE_STRICT", "1")
+    c = load_validate_config_from_argv(["-i", str(tmp_path)])
+    assert c.strict is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stage 3 — DigestConfig
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_digest_config_defaults(tmp_path: Path):
+    c = DigestConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.output == Path("digestion_output")
+    assert c.datasets is None
+    assert c.workers == 1
+    assert c.limit is None
+    assert c.dataset_timeout == float(DEFAULT_DATASET_TIMEOUT_SECONDS)
+
+
+def test_digest_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError):
+        DigestConfig(input=tmp_path / "does_not_exist")
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("workers", 0, id="workers_lower_bound"),
+        pytest.param("workers", 9999, id="workers_upper_bound"),
+        pytest.param("limit", 0, id="limit_lower_bound"),
+        pytest.param("dataset_timeout", 0.0, id="dataset_timeout_zero"),
+        pytest.param("dataset_timeout", -1.0, id="dataset_timeout_negative"),
+        pytest.param(
+            "dataset_timeout",
+            float(60 * 60 * 24),
+            id="dataset_timeout_upper_bound",
+        ),
+    ],
+)
+def test_digest_config_field_bounds_reject_invalid(
+    tmp_path: Path, field: str, invalid_value
+):
+    with pytest.raises(ValidationError):
+        DigestConfig(input=tmp_path, **{field: invalid_value})
+
+
+def test_digest_config_datasets_filter(tmp_path: Path):
+    c = DigestConfig(input=tmp_path, datasets=["ds-001", "ds-002"])
+    assert c.datasets == ["ds-001", "ds-002"]
+
+
+def test_digest_argv_parses_all_flags(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    c = load_digest_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--output",
+            str(out_dir),
+            "--datasets",
+            "ds-001",
+            "ds-002",
+            "--workers",
+            "4",
+            "--limit",
+            "10",
+            "--dataset-timeout",
+            "300",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.output == out_dir
+    assert c.datasets == ["ds-001", "ds-002"]
+    assert c.workers == 4
+    assert c.limit == 10
+    assert c.dataset_timeout == 300.0
+
+
+def test_digest_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_DIGEST_WORKERS=8 → workers=8 via env."""
+    monkeypatch.setenv("EEGDASH_DIGEST_WORKERS", "8")
+    c = load_digest_config_from_argv(["--input", str(tmp_path)])
+    assert c.workers == 8
+
+
+def test_digest_argv_validation_error_surfaces(tmp_path: Path):
+    """Bad CLI → ValidationError, not a vague argparse failure."""
+    with pytest.raises(ValidationError):
+        load_digest_config_from_argv(["--input", str(tmp_path), "--workers", "0"])

--- a/scripts/ingestions/tests/unit/test_validate.py
+++ b/scripts/ingestions/tests/unit/test_validate.py
@@ -1,0 +1,409 @@
+"""Tests for ``_validate.py`` — schema gate (validators + helpers)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from _validate import (
+    DATA_QUALITY_FIELDS,
+    NEURO_EXTENSIONS,
+    RECOMMENDED_DATASET_FIELDS,
+    VALID_SOURCES,
+    VALID_STORAGE_PATTERNS,
+    ValidationResult,
+    validate_dataset,
+    validate_digestion_output,
+    validate_record,
+    validate_storage_url,
+)
+from eegdash.testing import data_file
+
+
+def _minimal_valid_record() -> dict:
+    return {
+        "dataset": "ds002893",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "digested_at": "2026-05-22T12:00:00+00:00",
+        "recording_modality": ["eeg"],
+        "storage": {
+            "base": "s3://openneuro.org/ds002893",
+            "backend": "s3",
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+            "dep_keys": [],
+        },
+    }
+
+
+def _minimal_valid_dataset() -> dict:
+    return {
+        "dataset_id": "ds002893",
+        "source": "openneuro",
+        "ingestion_fingerprint": "abc123def456" + "0" * 20,
+        "name": "Test dataset",
+        "digested_at": "2026-05-22T12:00:00+00:00",
+        "recording_modality": ["eeg"],
+    }
+
+
+# ─── validate_record ──────────────────────────────────────────────────────
+
+
+def test_validate_record_accepts_minimal_valid_record():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.errors == []
+    assert result.stats["storage_errors"] == 0
+
+
+def test_validate_record_flags_storage_url_mismatch():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"]["base"] = "s3://nemar/ds002893"  # wrong source
+
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats["storage_errors"] == 1
+    assert any(e.get("field") == "storage.base" for e in result.errors), (
+        f"no storage.base error in {result.errors}"
+    )
+
+
+def test_validate_record_missing_mandatory_field_raises_pydantic_error():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    del rec["bids_relpath"]
+
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert len(result.errors) >= 1
+    assert any("record" in str(e) for e in result.errors)
+
+
+@pytest.mark.parametrize(
+    ("override", "counter", "expected"),
+    [
+        pytest.param({}, "missing_nchans", 1, id="nchans_missing"),
+        pytest.param({}, "missing_sampling_frequency", 1, id="sfreq_missing"),
+        pytest.param(
+            {"nchans": 0}, "missing_nchans", 1, id="nchans_zero_treated_missing"
+        ),
+        pytest.param(
+            {"nchans": 64, "sampling_frequency": 250.0},
+            "missing_nchans",
+            0,
+            id="nchans_present_not_counted",
+        ),
+        pytest.param(
+            {"nchans": 64, "sampling_frequency": 250.0},
+            "missing_sampling_frequency",
+            0,
+            id="sfreq_present_not_counted",
+        ),
+    ],
+)
+def test_validate_record_missing_field_counters(
+    override: dict, counter: str, expected: int
+):
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec.update(override)
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats[counter] == expected
+
+
+def test_validate_record_first_record_only_emits_recommended_warnings():
+    """Only record_idx == 0 emits recommended-field warnings."""
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds002893", "openneuro", result, record_idx=0)
+    first_warning_count = len(result.warnings)
+    assert first_warning_count > 0
+
+    validate_record(rec, "ds002893", "openneuro", result, record_idx=1)
+    assert len(result.warnings) == first_warning_count
+
+
+def test_validate_record_unknown_source_passes_storage_check():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds-xxx", "brand_new_source", result)
+    assert result.stats["storage_errors"] == 0
+
+
+def test_validate_record_handles_missing_storage_dict():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"] = {}
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats["storage_errors"] == 0
+
+
+# ─── validate_dataset ─────────────────────────────────────────────────────
+
+
+def test_validate_dataset_accepts_minimal_valid_dataset():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    validate_dataset(ds, result)
+    assert result.errors == []
+    assert result.stats["invalid_source"] == 0
+
+
+def test_validate_dataset_warns_on_unknown_source():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    ds["source"] = "made_up_source"
+    validate_dataset(ds, result)
+    assert result.stats["invalid_source"] == 1
+    assert any(w.get("field") == "source" for w in result.warnings), (
+        f"no source warning in {result.warnings}"
+    )
+
+
+def test_validate_dataset_accepts_all_known_sources():
+    for source in VALID_SOURCES:
+        result = ValidationResult()
+        ds = _minimal_valid_dataset()
+        ds["source"] = source
+        validate_dataset(ds, result)
+        assert result.stats["invalid_source"] == 0, (
+            f"{source} should be a valid source but warned"
+        )
+
+
+def test_validate_dataset_warns_on_missing_recommended():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    for field in RECOMMENDED_DATASET_FIELDS:
+        ds.pop(field, None)
+    validate_dataset(ds, result)
+    assert len(result.warnings) >= len(RECOMMENDED_DATASET_FIELDS)
+
+
+def test_validate_dataset_handles_no_dataset_id():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    del ds["dataset_id"]
+    validate_dataset(ds, result)
+    assert len(result.errors) >= 1
+
+
+# ─── validate_digestion_output (entry point) ──────────────────────────────
+
+
+def test_validate_digestion_output_returns_error_for_missing_dir(tmp_path: Path):
+    out = validate_digestion_output(tmp_path / "no_such_dir")
+    assert len(out.errors) >= 1
+    assert any("does not exist" in str(e) for e in out.errors)
+
+
+def test_validate_digestion_output_empty_dir(tmp_path: Path):
+    out = validate_digestion_output(tmp_path)
+    assert out.stats["datasets_checked"] == 0
+    assert out.errors == []
+
+
+def test_validate_digestion_output_walks_dataset_dirs(tmp_path: Path):
+    for ds_id in ("ds001", "ds002"):
+        ds_dir = tmp_path / ds_id
+        ds_dir.mkdir()
+        dataset = _minimal_valid_dataset()
+        dataset["dataset_id"] = ds_id
+        (ds_dir / f"{ds_id}_dataset.json").write_text(json.dumps(dataset))
+        records_doc = {
+            "dataset_id": ds_id,
+            "records": [_minimal_valid_record() | {"dataset": ds_id}],
+        }
+        (ds_dir / f"{ds_id}_records.json").write_text(json.dumps(records_doc))
+
+    out = validate_digestion_output(tmp_path)
+    assert out.stats["datasets_checked"] == 2
+    assert out.stats["records_checked"] == 2
+
+
+def test_validate_digestion_output_surfaces_malformed_json(tmp_path: Path):
+    ds_dir = tmp_path / "ds_bad"
+    ds_dir.mkdir()
+    (ds_dir / "ds_bad_dataset.json").write_text("{ this is not json")
+
+    out = validate_digestion_output(tmp_path)
+    assert any("Invalid JSON" in str(e) for e in out.errors), (
+        f"expected 'Invalid JSON' error, got {out.errors}"
+    )
+
+
+def test_validate_digestion_output_accepts_snapshot_fixture():
+    """End-to-end pin against the committed snapshot fixture."""
+    snapshot_root = data_file("digest_snapshots/outputs")
+    out = validate_digestion_output(snapshot_root)
+    assert out.stats["datasets_checked"] == 3
+    assert out.stats["records_checked"] == 5
+    assert out.errors == [], f"snapshot has errors: {out.errors}"
+
+
+def test_validate_digestion_output_strict_promotes_warnings(tmp_path: Path):
+    """Unknown-source triggers a warning in non-strict mode."""
+    ds_dir = tmp_path / "ds_synth"
+    ds_dir.mkdir()
+    dataset = _minimal_valid_dataset()
+    dataset["dataset_id"] = "ds_synth"
+    dataset["source"] = "made_up_source"
+    (ds_dir / "ds_synth_dataset.json").write_text(json.dumps(dataset))
+
+    non_strict = validate_digestion_output(tmp_path, strict=False)
+    assert non_strict.stats["invalid_source"] == 1
+    assert any(w.get("field") == "source" for w in non_strict.warnings)
+
+
+# ─── Integration: storage URL rejection across all known sources ──────────
+
+
+@pytest.mark.parametrize(
+    ("source", "wrong_url"),
+    [
+        ("openneuro", "s3://nemar/wrong"),
+        ("nemar", "s3://openneuro.org/wrong"),
+        ("zenodo", "https://figshare.com/wrong"),
+        ("figshare", "https://zenodo.org/wrong"),
+        ("osf", "s3://openneuro.org/wrong"),
+        ("scidb", "https://files.osf.io/wrong"),
+        ("datarn", "https://scidb.cn/wrong"),
+        ("gin", "s3://nemar/wrong"),
+    ],
+)
+def test_validate_record_rejects_cross_source_storage_urls(source: str, wrong_url: str):
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"]["base"] = wrong_url
+
+    validate_record(rec, "ds-test", source, result)
+    assert result.stats["storage_errors"] == 1, (
+        f"{source} should have rejected {wrong_url} but didn't"
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "url"),
+    [
+        ("openneuro", "s3://openneuro.org/ds002893"),
+        ("openneuro", "s3://openneuro.org/ds002893/sub-01/eeg/file.edf"),
+        ("nemar", "s3://nemar/nm000176"),
+        ("nemar", "s3://nmdatasets/nm000176"),
+        ("osf", "https://files.osf.io/v1/resources/abc/providers/osfstorage/"),
+        ("figshare", "https://figshare.com/ndownloader/files/12345"),
+        ("figshare", "https://ndownloader.figshare.com/files/12345"),
+        ("figshare", "https://mydomain.figshare.com/articles/12345"),
+        ("zenodo", "https://zenodo.org/record/12345"),
+        ("zenodo", "https://zenodo.org/records/12345"),
+        ("scidb", "https://scidb.cn/dataset/abc"),
+        ("scidb", "https://www.scidb.cn/dataset/abc"),
+        ("datarn", "https://webdav.data.ru.nl/test/path"),
+        ("gin", "https://gin.g-node.org/EEGManyLabs/study"),
+    ],
+)
+def test_storage_url_accepts_canonical_per_source(source: str, url: str):
+    ok, msg = validate_storage_url(source, url)
+    assert ok is True, f"{source=} {url=} → {msg=}"
+    assert msg == ""
+
+
+@pytest.mark.parametrize(
+    ("source", "wrong_url"),
+    [
+        ("nemar", "s3://openneuro.org/nm000176"),
+        ("openneuro", "s3://nemar/ds002893"),
+        ("figshare", "https://zenodo.org/record/12345"),
+        ("zenodo", "https://files.osf.io/v1/abc"),
+        ("openneuro", "https://example.com/ds002893"),
+        ("zenodo", "s3://nemar/12345"),
+    ],
+)
+def test_storage_url_rejects_cross_source_mismatch(source: str, wrong_url: str):
+    ok, msg = validate_storage_url(source, wrong_url)
+    assert ok is False
+    assert source in msg
+    assert wrong_url in msg
+
+
+def test_storage_url_unknown_source_passes_through():
+    ok, msg = validate_storage_url("brand_new_source", "https://example.com/")
+    assert ok is True
+    assert msg == ""
+
+
+def test_storage_url_must_match_at_start():
+    ok, _msg = validate_storage_url("openneuro", "garbage_s3://openneuro.org/ds123")
+    assert ok is False
+
+
+# ─── Constant-set invariants ──────────────────────────────────────────────
+
+
+def test_valid_sources_includes_canonical():
+    expected = {
+        "openneuro",
+        "nemar",
+        "gin",
+        "figshare",
+        "zenodo",
+        "osf",
+        "scidb",
+        "datarn",
+    }
+    assert expected.issubset(VALID_SOURCES)
+
+
+def test_valid_storage_patterns_cover_all_valid_sources_except_hbn():
+    sources_with_patterns = set(VALID_STORAGE_PATTERNS.keys())
+    sources_without_patterns = VALID_SOURCES - sources_with_patterns
+    assert sources_without_patterns <= {"hbn"}
+
+
+def test_neuro_extensions_includes_canonical_formats():
+    expected = {".edf", ".bdf", ".vhdr", ".set", ".fif", ".snirf"}
+    assert expected.issubset(NEURO_EXTENSIONS)
+
+
+def test_data_quality_fields_match_record_schema():
+    assert "nchans" in DATA_QUALITY_FIELDS
+    assert "sampling_frequency" in DATA_QUALITY_FIELDS
+
+
+def test_storage_patterns_compile():
+    for source, pattern in VALID_STORAGE_PATTERNS.items():
+        try:
+            re.compile(pattern)
+        except re.error as e:
+            pytest.fail(f"VALID_STORAGE_PATTERNS[{source!r}] = {pattern!r} fails: {e}")
+
+
+# ─── ValidationResult ──────────────────────────────────────────────────────
+
+
+def test_validation_result_initialises_empty():
+    r = ValidationResult()
+    assert r.errors == []
+    assert r.warnings == []
+    assert r.stats["datasets_checked"] == 0
+    assert r.stats["records_checked"] == 0
+    assert r.stats["storage_errors"] == 0
+
+
+def test_validation_result_stats_keys_are_stable():
+    r = ValidationResult()
+    expected_keys = {
+        "datasets_checked",
+        "records_checked",
+        "storage_errors",
+        "missing_mandatory",
+        "missing_recommended",
+        "empty_datasets",
+        "invalid_source",
+        "zip_placeholders",
+        "missing_nchans",
+        "missing_sampling_frequency",
+    }
+    assert set(r.stats.keys()) == expected_keys


### PR DESCRIPTION
**Stack PR B of 3.** Depends on PR A (test infra).

## Summary
The 4 stage scripts (clone / digest / validate / inject) each carried ~100 lines of argparse boilerplate + ad-hoc post-parse validation. Replaced with a Pydantic-settings BaseSettings per stage:

- `_clone_config.py` — 2_clone.py config
- `_digest_config.py` — 3_digest.py config
- `_validate_config.py` — 4_validate_output.py config
- `_inject_config.py` — 5_inject.py config (env-var aliases + API-valid-databases probe + mutual-exclusion `@model_validator`)

Plus `_validate.py` becomes the canonical home for the validation library; `4_validate_output.py` becomes an 88-line CLI shell that imports from it. Previously the same 5 functions + 6 constants + `ValidationResult` class were duplicated despite `_validate.py`'s docstring claiming to "re-export".

## Test plan
- [x] `test_stage_configs.py` exercises the 4 configs
- [x] `test_validate.py` exercises the validation library
- [ ] Land PR C on top to bring in the stage-script main() changes that consume these configs.