### PR TITLE
Stack 3/4: refactor(library) — helpers + parsers + new Seam modules + unit tests

### DIFF
--- a/.github/workflows/ingestions-bench.yml
+++ b/.github/workflows/ingestions-bench.yml
@@ -1,0 +1,92 @@
+name: Ingestions — Benchmark + Memory
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/ingestions/**'
+      - '.github/workflows/ingestions-bench.yml'
+  push:
+    branches: [main, master]
+    paths:
+      - 'scripts/ingestions/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ingestions-bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # github-action-benchmark needs to push gh-pages history
+  deployments: write
+  pull-requests: write  # to leave PR comments on regression
+
+jobs:
+  benchmark:
+    name: pytest-benchmark + memory gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install ingestion + dev deps (and root eegdash)
+        run: |
+          pip install -e .
+          pip install -e "scripts/ingestions[dev]"
+
+      - name: Cache eegdash-testing-data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/eegdash/testing-data
+          key: eegdash-testing-data-v0.1.0
+      - name: Pre-fetch eegdash-testing-data
+        run: python -m eegdash.testing
+
+      - name: Run memory + bench tests (saves pytest-benchmark JSON)
+        working-directory: scripts/ingestions
+        # The `-m "slow or not slow"` selector includes both the
+        # @pytest.mark.slow memory tests AND the benchmark-decorated
+        # throughput tests in tests/perf/.
+        run: |
+          mkdir -p .benchmarks
+          pytest tests/perf/ \
+            -m "slow or not slow" \
+            --benchmark-json=.benchmarks/output.json \
+            --benchmark-warmup=on \
+            --benchmark-warmup-iterations=2 \
+            -ra --tb=short
+
+      - name: Upload benchmark JSON as workflow artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ingestions-bench-${{ github.sha }}
+          path: scripts/ingestions/.benchmarks/output.json
+          retention-days: 30
+
+      # github-action-benchmark stores results in a gh-pages branch and
+      # leaves a PR comment if the new run regresses by > the threshold.
+      # Only enabled on push to main; PRs see the upload artefact +
+      # the inline assertions in test_perf.py (which already gate
+      # absolute ceilings independently of historic trend).
+      - name: Trend tracking (push to main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: scripts/ingestions/.benchmarks/output.json
+          # Push the historical chart to a parallel gh-pages branch.
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: ingestions-bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Alert if the mean of any single benchmark gets > 1.5x slower
+          # than its historic best on this branch.
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false  # don't block merge; the test_perf.py
+                                # absolute-ceiling assertions are the
+                                # blocking gate.
+          alert-comment-cc-users: '@bruAristimunha'

--- a/.github/workflows/ingestions-lint-and-test.yml
+++ b/.github/workflows/ingestions-lint-and-test.yml
@@ -1,0 +1,152 @@
+name: Ingestions — Lint + Test
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/ingestions/**'
+      - '.github/workflows/ingestions-lint-and-test.yml'
+  push:
+    branches: [main, master]
+    paths:
+      - 'scripts/ingestions/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ingestions-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install ruff
+        run: pip install ruff>=0.4
+      - name: Ruff check
+        run: ruff check scripts/ingestions/
+      - name: Ruff format --check
+        run: ruff format --check scripts/ingestions/
+
+  test:
+    name: Pytest (unit + property + smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install ingestion package + dev deps (and root eegdash)
+        run: |
+          pip install -e .
+          pip install -e "scripts/ingestions[dev]"
+      - name: Cache eegdash-testing-data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/eegdash/testing-data
+          key: eegdash-testing-data-v0.1.0
+      - name: Pre-fetch eegdash-testing-data
+        run: python -m eegdash.testing
+      - name: Run tests with coverage (offline)
+        working-directory: scripts/ingestions
+        # Coverage gate per . Floor RATCHETS up per PR.
+        # History:
+        #   2026-05-22 baseline:  35  (one-off scripts excluded, 36% actual)
+        #   2026-05-22 C1.2:      38  (_serialize 0→93%, _validate 0→20%)
+        #   2026-05-22 C1.5:      40  (_file_utils 24→40% via source-listing)
+        #   2026-05-22 C2.1:      42  (_validate 20→76% via validator tests)
+        #   2026-05-22 C2.2:      44  (_bids 0→99%, _github 0→31%)
+        #   2026-05-22 C2.3:      45  (_parser_utils 32→48%, set parser tests)
+        #   2026-05-22 C2.4:      46  (_montage 17→38% via 37 helper tests)
+        #   2026-05-22 C3.1:      48  (_file_utils 40→54%, _github 31→54%)
+        #   2026-05-22 C3.3:      49  (_snirf 28→78% via synthetic HDF5 fixture)
+        #   2026-05-22 C3.4:      50  (_set 36→65% via synthetic MAT v5 fixture)
+        #   2026-05-22 C4.1:      51  (_http 64→84%, _parser_utils 48→80%)
+        #   2026-05-22 C4.2:      52  (_github 54→85% via PyGithub fast-path mock)
+        #   2026-05-22 C5.1:      53  (_mef3 58→79% via real OpenNeuro .tmet fixture)
+        #   2026-05-22 C6.2:      55  (BIDS sidecar enrichment + inject API tests)
+        #   2026-05-22 C6.2+:     57  (5_inject helpers: load_*, _flatten, _sanitize, filter)
+        #   2026-05-22 C6.5:      58  (_inject_config Pydantic-settings + main() refactor)
+        #   2026-05-22 C7:        59  (_digest_config + _validate_config, same pattern)
+        #   2026-05-22 C8:        60  (_clone_config, completes the 4-stage pattern)
+        #   2026-05-22 Task3:     61  (_metadata_cascade extraction + 13 cascade tests)
+        # Every PR that raises coverage MUST bump this floor in the
+        # same commit so subsequent PRs can't regress.
+        run: |
+          pytest -ra --tb=short \
+            -m "not network and not slow" \
+            --cov=. \
+            --cov-report=term-missing \
+            --cov-report=html \
+            --cov-report=xml \
+            --cov-fail-under=61
+      - name: Append coverage summary to job summary
+        if: always()
+        working-directory: scripts/ingestions
+        run: |
+          {
+            echo "## Coverage summary"
+            echo
+            echo "Floor: 35% (ratchets up per PR; see )"
+            echo
+            echo '```'
+            python -m coverage report --skip-covered 2>/dev/null | tail -40 || echo "no coverage data"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ingestions-coverage
+          path: |
+            scripts/ingestions/htmlcov/
+            scripts/ingestions/coverage.xml
+          retention-days: 14
+
+  e2e_smoke:
+    name: Pipeline E2E (stage 3 → 4 → 5 against snapshot fixtures)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: lint
+    # E2E runs in parallel with the unit test job — both depend on
+    # lint. The smoke is small (the snapshot fixture is ~50 KB) so
+    # the cost is minimal.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install ingestion package + dev deps (and root eegdash)
+        run: |
+          pip install -e .
+          pip install -e "scripts/ingestions[dev]"
+      - name: Cache eegdash-testing-data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/eegdash/testing-data
+          key: eegdash-testing-data-v0.1.0
+      - name: Pre-fetch eegdash-testing-data
+        run: python -m eegdash.testing
+      - name: Run E2E smoke tests (Stage 3 → 4 → 5)
+        # Per . The e2e tests run the snapshot
+        # fixtures through 4_validate_output.py and 5_inject.py
+        # --dry-run as subprocess invocations. Offline (no API calls
+        # in dry-run mode). Verifies the inter-stage contract
+        # documented in PIPELINE-CONTRACT.md.
+        working-directory: scripts/ingestions
+        run: pytest tests/pipeline/test_e2e.py -ra --tb=short
+      - name: Run snapshot tests separately (verbose)
+        # Re-run the snapshot tests with verbose output. They're also
+        # in the main test suite, but isolating them in CI logs makes
+        # byte-drift failures easier to diagnose.
+        working-directory: scripts/ingestions
+        run: pytest tests/digest/test_snapshot.py -v --tb=long

--- a/.github/workflows/ingestions-mutmut-nightly.yml
+++ b/.github/workflows/ingestions-mutmut-nightly.yml
@@ -1,0 +1,163 @@
+name: Ingestions — Mutmut nightly
+
+# Mutation testing as a nightly job (NOT per-PR — each parser takes
+# 10-20 minutes to mutate end-to-end). Tracks kill-ratio over time;
+# alerts when it drops below the configured floor.
+#
+# Per  P0.2.md for the
+# baseline taken in session 4 (69.5% on _vhdr_parser.py with a
+# 10-minute budget).
+
+on:
+  schedule:
+    # 02:17 UTC daily — off the :00/:30 marks to avoid the herd.
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+    inputs:
+      target_file:
+        description: 'Parser to mutate (default: _vhdr_parser.py)'
+        required: false
+        default: '_vhdr_parser.py'
+
+concurrency:
+  group: ingestions-mutmut-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutmut:
+    name: Mutation testing — ${{ matrix.parser }}
+    runs-on: ubuntu-latest
+    # Long timeout because each parser is 10-25 minutes single-threaded.
+    # With ``--simultaneous-mutants 4`` (set in the step below), each
+    # parser should finish in 5-8 minutes.
+    timeout-minutes: 45
+    strategy:
+      # Don't fail-fast — each parser is independent; we want all kill
+      # ratios reported even if one fails.
+      fail-fast: false
+      matrix:
+        parser:
+          - _vhdr_parser.py
+          - _set_parser.py
+          - _snirf_parser.py
+          - _mef3_parser.py
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install ingestion + dev deps
+        run: pip install -e "scripts/ingestions[dev]"
+
+      - name: Pin mutmut to 2.x (3.x has a config-parsing bug)
+        # mutmut 3.x splits ``tests_dir = "tests/"`` letter-by-letter
+        # into pytest args. Documented in findings-phase-4.md.
+        run: pip install 'mutmut<3'
+
+      - name: Override mutmut target + runner
+        working-directory: scripts/ingestions
+        env:
+          # On scheduled runs use the matrix's parser; on
+          # workflow_dispatch use the user-supplied input.
+          TARGET: ${{ github.event_name == 'schedule' && matrix.parser || github.event.inputs.target_file }}
+        run: |
+          # Map parser filename to its parser-specific test file.
+          # Naming convention after the tests-subfolder reorg:
+          #   _vhdr_parser.py → tests/parsers/test_vhdr.py
+          # Strip the leading underscore, the trailing _parser, and ``.py``,
+          # then prefix with ``tests/parsers/test_``.
+          STEM="$(echo "$TARGET" | sed -e 's|^_||' -e 's|_parser\.py$||' -e 's|\.py$||')"
+          PARSER_TEST="tests/parsers/test_${STEM}.py"
+          if [ ! -f "$PARSER_TEST" ]; then
+            echo "FAIL: parser-specific test file not found: $PARSER_TEST"
+            exit 1
+          fi
+          NEW_RUNNER="python -m pytest $PARSER_TEST tests/parsers/test_property.py -x -q --tb=no --no-header -p no:cacheprovider"
+          sed -i "s|paths_to_mutate = .*|paths_to_mutate = \"$TARGET\"|" pyproject.toml
+          sed -i "s|runner = .*|runner = \"$NEW_RUNNER\"|" pyproject.toml
+          echo "Effective mutmut config:"
+          grep -A2 "tool.mutmut" pyproject.toml
+
+      - name: Run mutmut (parallel; ~5-8 min per parser)
+        working-directory: scripts/ingestions
+        # Bounded run with cache enabled (mutmut 2.x caches in
+        # .mutmut-cache and skips already-tested mutants on re-runs).
+        run: |
+          set +e
+          timeout 1800 mutmut run --simultaneous-mutants 4 || true
+          set -e
+          echo "Mutmut run finished."
+
+      - name: Report results
+        working-directory: scripts/ingestions
+        run: |
+          echo "═══════════════════════════════════════════════════════"
+          echo "Mutmut results for ${{ matrix.parser }}"
+          echo "═══════════════════════════════════════════════════════"
+          mutmut results || true
+          echo "═══════════════════════════════════════════════════════"
+
+      - name: Compute kill ratio + check floor (60%)
+        working-directory: scripts/ingestions
+        run: |
+          python <<'PY'
+          # Compute kill ratio from ``mutmut results`` text output.
+          # More robust across mutmut versions than reading the SQLite
+          # cache schema (which changed between 2.x point releases).
+          import re
+          import subprocess
+          import sys
+
+          try:
+              out = subprocess.run(
+                  ["mutmut", "results"],
+                  capture_output=True,
+                  text=True,
+                  check=False,
+                  timeout=60,
+              )
+          except subprocess.TimeoutExpired:
+              print("WARN: mutmut results timed out — skipping ratio check")
+              sys.exit(0)
+
+          text = (out.stdout or "") + (out.stderr or "")
+          # Headings look like ``Survived 🙁 (29)`` / ``Killed (66)``.
+          def _count(label: str) -> int:
+              m = re.search(rf"{label}.*?\((\d+)\)", text, re.IGNORECASE)
+              return int(m.group(1)) if m else 0
+
+          killed = _count("Killed")
+          survived = _count("Survived")
+          tested = killed + survived
+          ratio = (killed / tested * 100) if tested > 0 else 0.0
+
+          print(f"Killed:    {killed}")
+          print(f"Survived:  {survived}")
+          print(f"Tested:    {tested}")
+          print(f"Ratio:     {ratio:.1f}%")
+          print()
+
+          if tested == 0:
+              print("WARN: no mutants tested; mutmut may have errored")
+              sys.exit(0)
+
+          FLOOR = 60.0
+          if ratio < FLOOR:
+              print(f"FAIL: kill ratio {ratio:.1f}% below floor {FLOOR}%")
+              sys.exit(1)
+          print(f"OK: kill ratio {ratio:.1f}% >= floor {FLOOR}%")
+          PY
+
+      - name: Upload mutmut cache as workflow artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutmut-cache-${{ matrix.parser }}-${{ github.run_id }}
+          path: scripts/ingestions/.mutmut-cache
+          retention-days: 30

--- a/.github/workflows/ingestions-schema-dryrun.yml
+++ b/.github/workflows/ingestions-schema-dryrun.yml
@@ -1,0 +1,40 @@
+name: Ingestions — Schema dry-run gate
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/ingestions/5_inject.py'
+      - 'scripts/ingestions/4_validate_output.py'
+      - 'scripts/ingestions/_validate.py'
+      - 'scripts/ingestions/tests/fixtures/records/**'
+      - '.github/workflows/ingestions-schema-dryrun.yml'
+      # Anything that changes the Pydantic schemas referenced by ingest:
+      - 'eegdash/schemas.py'
+
+concurrency:
+  group: ingestions-schema-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  schema:
+    name: Validate fixture records
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install ingestion + eegdash
+        run: |
+          pip install -e .
+          pip install -e "scripts/ingestions[dev]"
+      - name: Cache eegdash-testing-data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/eegdash/testing-data
+          key: eegdash-testing-data-v0.1.0
+      - name: Run schema-preflight tests
+        working-directory: scripts/ingestions
+        run: pytest tests/pipeline/test_schema_preflight.py -ra --tb=short

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,9 @@ repos:
         types: [python]
         files: ^(eegdash|docs|scripts)/
         exclude: (\.ipynb$|docs/source/generated/|docs/_build/|docs/source/conf\.py)
+    -   id: find-leaked-creds
+        name: Block leaked credentials in staged changes
+        entry: bash scripts/ingestions/scripts/find_leaked_creds.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/eegdash/testing.py
+++ b/eegdash/testing.py
@@ -1,0 +1,146 @@
+"""Lazy fetch of the eegdash binary test corpus.
+
+The raw signal fixtures (BDF, EDF, SET, VHDR, SNIRF, FIF, MEF3 ...) live in
+the separate `eegdash/eegdash-testing-data
+<https://github.com/eegdash/eegdash-testing-data>`__ repository, modeled
+after ``mne-testing-data``. The first time a test asks for one we download
+the pinned tarball, verify its SHA-256, and unpack into a per-user cache.
+
+Pin (bump both lines when re-tagging the upstream repo):
+
+* :data:`VERSION` — git tag on ``eegdash-testing-data``
+* :data:`SHA256` — sha256 of the codeload tarball for that tag
+
+Environment overrides
+---------------------
+``EEGDASH_TESTING_DATA_DIR``
+    Cache directory (default: ``~/.cache/eegdash/testing-data``).
+``EEGDASH_SKIP_TESTING_DATA=true``
+    Skip every ``@requires_testing_data`` test; used by air-gapped CI.
+
+Examples
+--------
+>>> from eegdash.testing import data_path  # doctest: +SKIP
+>>> bdf = data_path() / "eeg" / "sub-001_ses-01_task-meditation_eeg.bdf"
+
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+import pooch
+import pytest
+
+VERSION = "0.2.0"
+SHA256 = "8669d60b052b4d7fcc5f929f79f600cec35f8b7c8bdffc1785bc6d09667cd8ca"
+URL = (
+    "https://codeload.github.com/eegdash/eegdash-testing-data/"
+    f"tar.gz/refs/tags/v{VERSION}"
+)
+
+_DEFAULT_CACHE = Path.home() / ".cache" / "eegdash" / "testing-data"
+# GitHub's codeload tarball unpacks into ``<name>-<tag>/`` at the top.
+_ROOT_NAME = f"eegdash-testing-data-{VERSION}"
+_TARBALL_NAME = f"{_ROOT_NAME}.tar.gz"
+
+
+def _cache_dir() -> Path:
+    return Path(os.environ.get("EEGDASH_TESTING_DATA_DIR", _DEFAULT_CACHE))
+
+
+def _skip_requested() -> bool:
+    return os.environ.get("EEGDASH_SKIP_TESTING_DATA", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def has_testing_data() -> bool:
+    """Return True if the corpus is already unpacked in the cache."""
+    root = _cache_dir() / _ROOT_NAME
+    return root.is_dir() and any(root.iterdir())
+
+
+@lru_cache(maxsize=1)
+def data_path() -> Path:
+    """Return the root of the test corpus, fetching on first use.
+
+    Returns
+    -------
+    Path
+        The unpacked ``eegdash-testing-data-{VERSION}/`` directory.
+
+    Raises
+    ------
+    RuntimeError
+        If the download is required but ``EEGDASH_SKIP_TESTING_DATA=true``
+        is set, or if pooch fails to retrieve the tarball.
+
+    """
+    cache = _cache_dir()
+    root = cache / _ROOT_NAME
+    if root.is_dir() and any(root.iterdir()):
+        return root
+
+    if _skip_requested():
+        raise RuntimeError("EEGDASH_SKIP_TESTING_DATA=true — refusing to fetch corpus")
+
+    cache.mkdir(parents=True, exist_ok=True)
+    pooch.retrieve(
+        url=URL,
+        known_hash=f"sha256:{SHA256}",
+        fname=_TARBALL_NAME,
+        path=str(cache),
+        processor=pooch.Untar(extract_dir=str(cache)),
+    )
+    if not (root.is_dir() and any(root.iterdir())):
+        raise RuntimeError(
+            f"pooch reported success but {root} is empty; "
+            "tarball layout may have changed upstream"
+        )
+    return root
+
+
+def data_file(relpath: str) -> Path:
+    """Convenience: ``data_path() / relpath`` as a single call."""
+    return data_path() / relpath
+
+
+def requires_testing_data(func):
+    """Pytest decorator: skip if the corpus is unavailable.
+
+    Skips when ``EEGDASH_SKIP_TESTING_DATA=true`` or the corpus cannot
+    be fetched (e.g. offline CI without a cache hit). The decorator
+    triggers the fetch at collection time so tests that depend on the
+    corpus all share a single download.
+    """
+    reason: str | None
+    if _skip_requested():
+        reason = "EEGDASH_SKIP_TESTING_DATA=true"
+    else:
+        try:
+            data_path()
+            reason = None
+        except Exception as exc:  # noqa: BLE001 — any fetch failure = skip
+            reason = f"eegdash-testing-data unavailable: {exc}"
+
+    return pytest.mark.skipif(reason is not None, reason=reason or "")(func)
+
+
+def _main() -> int:
+    """``python -m eegdash.testing`` — eagerly download the corpus."""
+    try:
+        root = data_path()
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed: {exc}")
+        return 1
+    print(f"ok: {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ tests = [
     'pytest-benchmark',
     'plotly',
     'moabb',
+    # tests/unit_tests/test_annex_key_utils.py + tests/unit_tests/test_digest_parsers.py
+    # import from scripts/ingestions/_file_utils.py + 3_digest.py, which require
+    # these at module top after the PEP-8 import-lift sweep.
+    'tenacity>=8',
+    'pydantic-settings>=2',
 ]
 dev = [
   "pre-commit",
@@ -168,11 +173,24 @@ target-version = "py311"
 
 [tool.ruff.lint]
 ignore-init-module-imports = true
-select = ["E", "W", "F", "D", "I", "NPY201"]
+select = ["E", "W", "F", "D", "I", "NPY201", "PLC0415"]
 ignore = ["E402", "E501", "D100", "D101", "D102", "D103", "D104", "D105", "D107", "D205", "D400", "D415", "D417", "F403", "D401", "E741", "E722", "D419"]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["I"]
+# PLC0415 grace list — legacy lazy imports for optional deps + circular-
+# import guards. Each entry is a candidate for cleanup in a follow-up; the
+# rule still fires on any NEW function-scoped import in untouched files.
+"eegdash/__init__.py" = ["PLC0415"]
+"eegdash/api.py" = ["PLC0415"]
+"eegdash/dataset/base.py" = ["PLC0415"]
+"eegdash/dataset/dataset.py" = ["PLC0415"]
+"eegdash/dataset/io.py" = ["PLC0415"]
+"eegdash/dataset/registry.py" = ["PLC0415"]
+"eegdash/features/extractors.py" = ["PLC0415"]
+"eegdash/features/serialization.py" = ["PLC0415"]
+"eegdash/local_bids.py" = ["PLC0415"]
+"eegdash/viz/identity.py" = ["PLC0415"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["eegdash", "braindecode"]

--- a/scripts/ingestions/.gitignore
+++ b/scripts/ingestions/.gitignore
@@ -1,0 +1,20 @@
+# Mutation-testing working directory (mutmut 3.x scratch space)
+mutants/
+.mutmut-cache
+.mutmut-cache/
+
+# pytest / coverage outputs
+.coverage
+.coverage.*
+htmlcov/
+.pytest_cache/
+__pycache__/
+
+# Hypothesis examples cache
+.hypothesis/
+
+# pytest-benchmark history
+.benchmarks/
+
+# Local sandbox data
+.cache/

--- a/scripts/ingestions/4_validate_output.py
+++ b/scripts/ingestions/4_validate_output.py
@@ -1,576 +1,57 @@
 #!/usr/bin/env python3
-"""Validate digestion output for consistency and correctness.
+"""CLI wrapper around :mod:`_validate` — exit-code semantics + JSON output.
 
-This script checks that digested records and datasets are valid:
-- Storage URLs match the source (no OpenNeuro with OSF URLs!)
-- Required fields are present for eegdash compatibility
-- Datasets have records (not empty)
-- No duplicate records
-- Source is set and valid for all entries
+The validation logic itself lives in :mod:`_validate`. This script is the
+argv-bound entry point: it parses the config, calls either
+:func:`validate_pre_digestion` or :func:`validate_digestion_output`, and
+emits a human-readable summary (or JSON via ``--json``).
 
-Usage:
-    # Post-digestion validation (default)
-    python validate_output.py --input digestion_output
-
-    # Pre-digestion validation (check manifests)
-    python validate_output.py --pre-check --input data/cloned
-
-    # Strict mode - fail on warnings too
-    python validate_output.py --input digestion_output --strict
+See ``python 4_validate_output.py --help``.
 """
 
-import argparse
 import json
-import re
 import sys
-from collections import Counter
-from pathlib import Path
 
 from pydantic import ValidationError
 
-from eegdash.schemas import DatasetModel, ManifestFileModel, ManifestModel, RecordModel
-
-# Valid storage URL patterns per source
-VALID_STORAGE_PATTERNS = {
-    "openneuro": r"^s3://openneuro\.org/ds\d+",
-    "nemar": r"^s3://(nemar|nmdatasets)/",
-    "osf": r"^https://files\.osf\.io/",
-    "figshare": r"^https://(figshare\.com|ndownloader|.*\.figshare\.com)",
-    "zenodo": r"^https://zenodo\.org/",
-    "scidb": r"^https://(www\.)?scidb\.cn/",
-    "datarn": r"^https://webdav\.data\.ru\.nl/",
-    "gin": r"^https://gin\.g-node\.org/",
-}
-
-# Recommended fields (warnings if missing)
-RECOMMENDED_RECORD_FIELDS = ["entities", "datatype", "suffix", "extension"]
-RECOMMENDED_DATASET_FIELDS = [
-    "name",
-    "datatypes",
-    "demographics",
-    "ingestion_fingerprint",
-]
-
-# Data quality fields - these should have values for usable records
-DATA_QUALITY_FIELDS = ["nchans", "sampling_frequency"]
-
-# Valid sources
-VALID_SOURCES = {
-    "openneuro",
-    "nemar",
-    "gin",
-    "figshare",
-    "zenodo",
-    "osf",
-    "scidb",
-    "datarn",
-    "hbn",
-}
-
-# Data file extensions that indicate valid neurophysiology data
-NEURO_EXTENSIONS = {
-    ".edf",
-    ".bdf",
-    ".vhdr",
-    ".set",
-    ".fif",
-    ".ds",
-    ".con",
-    ".sqd",
-    ".pdf",
-    ".mef",
-    ".nwb",
-    ".snirf",
-}
-
-
-class ValidationResult:
-    """Container for validation results."""
-
-    def __init__(self):
-        self.errors = []
-        self.warnings = []
-        self.stats = {
-            "datasets_checked": 0,
-            "records_checked": 0,
-            "storage_errors": 0,
-            "missing_mandatory": 0,
-            "missing_recommended": 0,
-            "empty_datasets": 0,
-            "invalid_source": 0,
-            "zip_placeholders": 0,
-            "missing_nchans": 0,
-            "missing_sampling_frequency": 0,
-        }
-        self.source_distribution = {}
-        self.modality_distribution = {}
-        self.empty_datasets = []
-        self.zip_placeholder_datasets = []
-        self.data_quality_issues = []  # Datasets with missing nchans/sampling_frequency
-
-    def add_error(self, dataset: str, message: str, field: str = None):
-        self.errors.append(
-            {
-                "dataset": dataset,
-                "message": message,
-                "field": field,
-            }
-        )
-
-    def add_warning(self, dataset: str, message: str, field: str = None):
-        self.warnings.append(
-            {
-                "dataset": dataset,
-                "message": message,
-                "field": field,
-            }
-        )
-
-    def is_valid(self) -> bool:
-        return len(self.errors) == 0
-
-    def summary(self) -> str:
-        total_records = self.stats["records_checked"]
-        missing_nchans = self.stats["missing_nchans"]
-        missing_sampling_frequency = self.stats["missing_sampling_frequency"]
-        nchans_pct = (missing_nchans / total_records * 100) if total_records > 0 else 0
-        sampling_frequency_pct = (
-            (missing_sampling_frequency / total_records * 100)
-            if total_records > 0
-            else 0
-        )
-
-        lines = [
-            "=" * 60,
-            "VALIDATION SUMMARY",
-            "=" * 60,
-            f"Datasets checked: {self.stats['datasets_checked']}",
-            f"Records checked: {self.stats['records_checked']}",
-            "",
-            f"Errors: {len(self.errors)}",
-            f"  - Storage URL errors: {self.stats['storage_errors']}",
-            f"  - Missing mandatory fields: {self.stats['missing_mandatory']}",
-            f"  - Invalid source: {self.stats['invalid_source']}",
-            "",
-            f"Warnings: {len(self.warnings)}",
-            f"  - Empty datasets (0 records): {self.stats['empty_datasets']}",
-            f"  - Missing recommended fields: {self.stats['missing_recommended']}",
-            f"  - ZIP placeholders (needs extraction): {self.stats['zip_placeholders']}",
-            "",
-            "Data Quality:",
-            f"  - Records missing nchans: {missing_nchans} ({nchans_pct:.1f}%)",
-            f"  - Records missing sampling_frequency: {missing_sampling_frequency} ({sampling_frequency_pct:.1f}%)",
-        ]
-
-        if self.empty_datasets:
-            lines.append("")
-            lines.append(f"Empty datasets ({len(self.empty_datasets)}):")
-            for ds in self.empty_datasets[:10]:
-                lines.append(f"  - {ds}")
-            if len(self.empty_datasets) > 10:
-                lines.append(f"  ... and {len(self.empty_datasets) - 10} more")
-
-        if self.data_quality_issues:
-            lines.append("")
-            lines.append(
-                f"Data quality issues ({len(self.data_quality_issues)} datasets):"
-            )
-            for issue in self.data_quality_issues[:10]:
-                lines.append(f"  - {issue}")
-            if len(self.data_quality_issues) > 10:
-                lines.append(f"  ... and {len(self.data_quality_issues) - 10} more")
-
-        if self.errors:
-            lines.append("")
-            lines.append("Sample errors (first 10):")
-            for err in self.errors[:10]:
-                field_info = f" [{err['field']}]" if err.get("field") else ""
-                lines.append(f"  [{err['dataset']}]{field_info} {err['message']}")
-
-        if self.warnings and len(self.errors) == 0:
-            lines.append("")
-            lines.append("Sample warnings (first 5):")
-            for warn in self.warnings[:5]:
-                lines.append(f"  [{warn['dataset']}] {warn['message']}")
-
-        lines.append("=" * 60)
-        return "\n".join(lines)
-
-
-def validate_storage_url(source: str, storage_base: str) -> tuple[bool, str]:
-    """Validate that storage URL matches the source."""
-    if source not in VALID_STORAGE_PATTERNS:
-        return True, ""  # Unknown source, can't validate
-
-    pattern = VALID_STORAGE_PATTERNS[source]
-    if re.match(pattern, storage_base):
-        return True, ""
-
-    return (
-        False,
-        f"Storage '{storage_base}' doesn't match expected pattern for {source}",
-    )
-
-
-def _add_pydantic_errors(
-    result: "ValidationResult",
-    *,
-    dataset_id: str,
-    exc: ValidationError,
-    prefix: str | None = None,
-):
-    for err in exc.errors():
-        loc = [str(p) for p in err.get("loc", [])]
-        if prefix:
-            loc = [prefix, *loc]
-        field_path = ".".join(loc) if loc else None
-        result.add_error(dataset_id, err.get("msg", "Invalid value"), field=field_path)
-        if err.get("type") == "missing":
-            result.stats["missing_mandatory"] += 1
-
-
-def validate_record(
-    record: dict,
-    dataset_id: str,
-    source: str,
-    result: ValidationResult,
-    record_idx: int = 0,
-):
-    """Validate a single record for mandatory fields."""
-    try:
-        RecordModel.model_validate(record)
-    except ValidationError as exc:
-        _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="record")
-
-    # Validate storage URL matches source
-    storage = record.get("storage", {})
-    if storage:
-        storage_base = storage.get("base", "")
-        is_valid, error_msg = validate_storage_url(source, storage_base)
-        if not is_valid:
-            result.add_error(dataset_id, error_msg, field="storage.base")
-            result.stats["storage_errors"] += 1
-
-    # Check recommended fields (warnings only, first record only)
-    if record_idx == 0:
-        for field in RECOMMENDED_RECORD_FIELDS:
-            if field not in record or record[field] is None:
-                result.add_warning(
-                    dataset_id,
-                    f"Missing recommended field: {field}",
-                    field=field,
-                )
-                result.stats["missing_recommended"] += 1
-
-    # Check data quality fields (nchans, sampling_frequency) - critical for usability
-    nchans = record.get("nchans")
-    sampling_frequency = record.get("sampling_frequency")
-    if nchans is None or nchans == 0:
-        result.stats["missing_nchans"] += 1
-    if sampling_frequency is None or sampling_frequency == 0:
-        result.stats["missing_sampling_frequency"] += 1
-
-
-def validate_dataset(dataset: dict, result: ValidationResult):
-    """Validate a single dataset document for mandatory fields."""
-    dataset_id = dataset.get("dataset_id", "unknown")
-
-    try:
-        DatasetModel.model_validate(dataset)
-    except ValidationError as exc:
-        _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="dataset")
-
-    # Check source is valid
-    source = dataset.get("source")
-    if source and source not in VALID_SOURCES:
-        result.add_warning(dataset_id, f"Unknown source: {source}", field="source")
-        result.stats["invalid_source"] += 1
-
-    # Check recommended fields
-    for field in RECOMMENDED_DATASET_FIELDS:
-        if field not in dataset or dataset[field] is None:
-            result.add_warning(
-                dataset_id,
-                f"Missing recommended field: {field}",
-                field=field,
-            )
-
-
-def validate_digestion_output(
-    input_dir: Path,
-    verbose: bool = False,
-    strict: bool = False,
-) -> ValidationResult:
-    """Validate all digestion output in a directory.
-
-    Args:
-        input_dir: Directory containing digested datasets
-        verbose: Print progress information
-        strict: Treat warnings as errors
-
-    Returns:
-        ValidationResult with all findings
-
-    """
-    result = ValidationResult()
-
-    if not input_dir.exists():
-        result.add_error("", f"Input directory does not exist: {input_dir}")
-        return result
-
-    dataset_dirs = [d for d in input_dir.iterdir() if d.is_dir()]
-
-    if verbose:
-        print(f"Found {len(dataset_dirs)} dataset directories to validate")
-
-    sources = Counter()
-    modalities = Counter()
-
-    for dataset_dir in dataset_dirs:
-        dataset_id = dataset_dir.name
-        records_file = dataset_dir / f"{dataset_id}_records.json"
-        dataset_file = dataset_dir / f"{dataset_id}_dataset.json"
-
-        source = "unknown"
-        record_count = 0
-
-        # Load dataset first to get source
-        if dataset_file.exists():
-            try:
-                with open(dataset_file) as f:
-                    dataset = json.load(f)
-
-                result.stats["datasets_checked"] += 1
-                validate_dataset(dataset, result)
-                source = dataset.get("source", "unknown")
-                sources[source] += 1
-
-            except json.JSONDecodeError as e:
-                result.add_error(dataset_id, f"Invalid JSON in dataset file: {e}")
-            except Exception as e:
-                result.add_error(dataset_id, f"Error reading dataset: {e}")
-
-        # Validate records
-        if records_file.exists():
-            try:
-                with open(records_file) as f:
-                    data = json.load(f)
-
-                records = data.get("records", [])
-                record_count = len(records)
-                result.stats["records_checked"] += record_count
-
-                has_zip_placeholder = False
-                has_missing_nchans = False
-                has_missing_sampling_frequency = False
-                for idx, record in enumerate(records):
-                    validate_record(record, dataset_id, source, result, idx)
-                    mods = record.get("recording_modality", ["unknown"])
-                    if isinstance(mods, str):
-                        mods = [mods]
-                    for mod in mods:
-                        modalities[mod] += 1
-
-                    # Track ZIP placeholders
-                    if record.get("needs_extraction") or record.get(
-                        "zip_contains_bids"
-                    ):
-                        has_zip_placeholder = True
-
-                    # Track data quality at dataset level
-                    if record.get("nchans") is None or record.get("nchans") == 0:
-                        has_missing_nchans = True
-                    if (
-                        record.get("sampling_frequency") is None
-                        or record.get("sampling_frequency") == 0
-                    ):
-                        has_missing_sampling_frequency = True
-
-                if has_missing_nchans or has_missing_sampling_frequency:
-                    issue_parts = []
-                    if has_missing_nchans:
-                        issue_parts.append("nchans")
-                    if has_missing_sampling_frequency:
-                        issue_parts.append("sampling_frequency")
-                    result.data_quality_issues.append(
-                        f"{dataset_id} ({source}): missing {', '.join(issue_parts)}"
-                    )
-
-                if has_zip_placeholder:
-                    result.stats["zip_placeholders"] += 1
-                    result.zip_placeholder_datasets.append(f"{dataset_id} ({source})")
-
-            except json.JSONDecodeError as e:
-                result.add_error(dataset_id, f"Invalid JSON in records file: {e}")
-            except Exception as e:
-                result.add_error(dataset_id, f"Error reading records: {e}")
-
-        # Flag empty datasets
-        if record_count == 0:
-            result.stats["empty_datasets"] += 1
-            result.empty_datasets.append(f"{dataset_id} ({source})")
-            if strict:
-                result.add_error(
-                    dataset_id,
-                    "Dataset has 0 records - cannot be used in eegdash",
-                )
-            else:
-                result.add_warning(
-                    dataset_id,
-                    "Dataset has 0 records - no usable data files found",
-                )
-
-    result.source_distribution = dict(sources)
-    result.modality_distribution = dict(modalities)
-
-    return result
-
-
-def validate_pre_digestion(input_dir: Path, verbose: bool = False) -> ValidationResult:
-    """Pre-digestion validation: check manifests have valid data files.
-
-    Args:
-        input_dir: Directory containing cloned datasets with manifest.json files
-        verbose: Print progress information
-
-    Returns:
-        ValidationResult with findings
-
-    """
-    result = ValidationResult()
-
-    if not input_dir.exists():
-        result.add_error("", f"Input directory does not exist: {input_dir}")
-        return result
-
-    dataset_dirs = [
-        d for d in input_dir.iterdir() if d.is_dir() and (d / "manifest.json").exists()
-    ]
-
-    if verbose:
-        print(f"Found {len(dataset_dirs)} manifests to check")
-
-    sources = Counter()
-
-    for dataset_dir in dataset_dirs:
-        dataset_id = dataset_dir.name
-        manifest_path = dataset_dir / "manifest.json"
-
-        try:
-            with open(manifest_path) as f:
-                manifest = json.load(f)
-
-            try:
-                manifest_model = ManifestModel.model_validate(manifest)
-            except ValidationError as exc:
-                _add_pydantic_errors(
-                    result, dataset_id=dataset_id, exc=exc, prefix="manifest"
-                )
-                continue
-
-            source = manifest_model.source or "unknown"
-            sources[source] += 1
-            result.stats["datasets_checked"] += 1
-
-            files = manifest_model.files
-
-            # Count potential data files and CTF .ds directories
-            data_file_count = 0
-            ctf_ds_dirs = set()
-
-            for f in files:
-                if isinstance(f, str):
-                    filepath = f
-                elif isinstance(f, ManifestFileModel):
-                    filepath = f.path_or_name()
-                else:
-                    filepath = ""
-                filepath_lower = filepath.lower()
-
-                # Track CTF .ds directories (files inside .ds/ paths)
-                if ".ds/" in filepath_lower:
-                    ds_idx = filepath_lower.index(".ds/") + 3
-                    ds_path = filepath[:ds_idx]
-                    ctf_ds_dirs.add(ds_path)
-                    continue
-
-                # Check if this could be a neurophysiology data file
-                for ext in NEURO_EXTENSIONS:
-                    if filepath_lower.endswith(ext):
-                        data_file_count += 1
-                        break
-
-            # Add CTF .ds directories count
-            data_file_count += len(ctf_ds_dirs)
-            result.stats["records_checked"] += data_file_count
-
-            if data_file_count == 0:
-                result.stats["empty_datasets"] += 1
-                result.empty_datasets.append(f"{dataset_id} ({source})")
-                result.add_warning(
-                    dataset_id,
-                    f"No recognized neurophysiology files in manifest "
-                    f"({len(files)} total files)",
-                )
-
-            if verbose and data_file_count > 0:
-                print(f"  {dataset_id}: {data_file_count} data files")
-
-        except json.JSONDecodeError as e:
-            result.add_error(dataset_id, f"Invalid JSON in manifest: {e}")
-        except Exception as e:
-            result.add_error(dataset_id, f"Error reading manifest: {e}")
-
-    result.source_distribution = dict(sources)
-
-    return result
+from _validate import (  # noqa: F401 — re-export for time_openneuro_pipeline.py subprocess invocation
+    DATA_QUALITY_FIELDS,
+    NEURO_EXTENSIONS,
+    RECOMMENDED_DATASET_FIELDS,
+    RECOMMENDED_RECORD_FIELDS,
+    VALID_SOURCES,
+    VALID_STORAGE_PATTERNS,
+    ValidationResult,
+    _add_pydantic_errors,
+    validate_dataset,
+    validate_digestion_output,
+    validate_pre_digestion,
+    validate_record,
+    validate_storage_url,
+)
+from _validate_config import load_validate_config_from_argv
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Validate digestion output for eegdash compatibility"
-    )
-    parser.add_argument(
-        "--input",
-        "-i",
-        type=Path,
-        default=Path("digestion_output"),
-        help="Input directory (digestion_output or data/cloned for --pre-check)",
-    )
-    parser.add_argument(
-        "--pre-check",
-        action="store_true",
-        help="Pre-digestion validation: check manifests have valid data files",
-    )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Print verbose output",
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Treat warnings as errors (empty datasets become errors)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output results as JSON",
-    )
+    try:
+        cfg = load_validate_config_from_argv()
+    except ValidationError as exc:
+        print("Config error(s):", file=sys.stderr)
+        for err in exc.errors():
+            field = ".".join(str(p) for p in err.get("loc", []))
+            print(f"  {field}: {err.get('msg')}", file=sys.stderr)
+        return 1
 
-    args = parser.parse_args()
-
-    if args.pre_check:
-        result = validate_pre_digestion(args.input, verbose=args.verbose)
+    if cfg.pre_check:
+        result = validate_pre_digestion(cfg.input, verbose=cfg.verbose)
     else:
         result = validate_digestion_output(
-            args.input,
-            verbose=args.verbose,
-            strict=args.strict,
+            cfg.input,
+            verbose=cfg.verbose,
+            strict=cfg.strict,
         )
 
-    if args.json:
+    if cfg.json_output:
         output = {
             "valid": result.is_valid(),
             "stats": result.stats,
@@ -598,9 +79,7 @@ def main():
             ):
                 print(f"  {mod}: {count}")
 
-    # Exit with error code if validation failed
-    # In strict mode, warnings also cause failure
-    if args.strict and result.warnings:
+    if cfg.strict and result.warnings:
         sys.exit(1)
     sys.exit(0 if result.is_valid() else 1)
 

--- a/scripts/ingestions/__init__.py
+++ b/scripts/ingestions/__init__.py
@@ -1,0 +1,11 @@
+"""eegdash ingestion pipeline.
+
+Five-stage pipeline (``1_fetch_sources`` / ``2_clone`` / ``3_digest`` /
+``4_validate_output`` / ``5_inject``) ingesting BIDS EEG/MEG/iEEG datasets
+into the eegdash MongoDB. Shared helpers live in the underscore-prefixed
+sibling modules.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/scripts/ingestions/_bids.py
+++ b/scripts/ingestions/_bids.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import csv
 import re
 from pathlib import Path
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 # Common BIDS indicator files (case-insensitive matching)
 BIDS_REQUIRED_FILES = ["dataset_description.json"]
@@ -45,7 +46,8 @@ def collect_bids_matches(
         dataset_zip_pattern: Regex for BIDS dataset zip files.
         dataset_zip_matcher: "match" or "search" for dataset zip pattern checks.
 
-    Returns:
+    Returns
+    -------
         Dict with required/optional matches and subject/zip file lists.
 
     """
@@ -184,7 +186,10 @@ def count_bad_channels(channels_tsv_path: Path) -> int | None:
             return sum(
                 1 for row in reader if str(row.get(col, "")).strip().lower() == "bad"
             )
-    except Exception:
+    except (OSError, csv.Error, UnicodeDecodeError):
+        # OSError: file disappeared. csv.Error: malformed TSV with
+        # encoding/quote issues. UnicodeDecodeError: TSV with non-UTF-8
+        # bytes (occasionally seen in legacy datasets).
         return None
 
 

--- a/scripts/ingestions/_clone_config.py
+++ b/scripts/ingestions/_clone_config.py
@@ -1,0 +1,151 @@
+"""Pydantic-settings config for 2_clone.py (C8).
+
+Final stage in the C6.5-style config refactor — completes the pattern
+across all 4 main()-style scripts (digest, validate, inject, clone).
+
+The HANDLERS dict in 2_clone.py is treated as the source of truth for
+``--sources`` choices, same as stage 4's _validate.py is for the
+validators that consume it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Source names that 2_clone.py's HANDLERS dict knows how to clone.
+# Kept aligned with HANDLERS — adding a new source there requires adding
+# it here too (or refactoring to import HANDLERS lazily; that's a
+# future round if the list grows).
+KNOWN_SOURCES: frozenset[str] = frozenset(
+    {
+        "openneuro",
+        "nemar",
+        "gin",
+        "figshare",
+        "zenodo",
+        "osf",
+        "scidb",
+        "datarn",
+        "hbn",
+        "neurips25",
+        "unknown",
+    }
+)
+
+
+class CloneConfig(BaseSettings):
+    """Validated config for the clone stage.
+
+    Same pattern as ``InjectConfig`` / ``DigestConfig`` / ``ValidateConfig``.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_CLONE_",
+        extra="ignore",
+    )
+
+    input: Path = Field(
+        default=Path("consolidated"),
+        description=(
+            "Input JSON file or directory containing the consolidated "
+            "per-source listings (output of stage 1)."
+        ),
+    )
+    output: Path = Field(
+        default=Path("data/cloned"),
+        description="Output directory for cloned datasets + manifests.",
+    )
+    sources: list[str] | None = Field(
+        default=None,
+        description=(
+            "Process only specific sources. Default: all sources in "
+            "HANDLERS. Must be a subset of KNOWN_SOURCES."
+        ),
+    )
+    timeout: int = Field(
+        default=300,
+        ge=1,
+        le=60 * 60 * 6,  # 6h ceiling — anything bigger means a hung handler
+        description="Per-dataset handler timeout in seconds (max 6h).",
+    )
+    workers: int = Field(
+        default=8,
+        ge=1,
+        le=128,
+        description="Parallel worker threads (1 = sequential).",
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum datasets to process (total, after limit-per-source).",
+    )
+    limit_per_source: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum datasets per source.",
+    )
+    datasets: list[str] | None = Field(
+        default=None,
+        description="Process only specific dataset IDs.",
+    )
+    manifest_only: bool = Field(
+        default=False,
+        description="Skip git clones; only emit manifests.",
+    )
+
+    @field_validator("sources")
+    @classmethod
+    def _sources_must_be_known(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return value
+        unknown = set(value) - KNOWN_SOURCES
+        if unknown:
+            raise ValueError(
+                f"unknown source(s): {sorted(unknown)}; valid: {sorted(KNOWN_SOURCES)}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> CloneConfig:
+        if not self.input.exists():
+            raise ValueError(f"--input does not exist: {self.input}")
+        return self
+
+
+def load_clone_config_from_argv(
+    argv: list[str] | None = None,
+) -> CloneConfig:
+    """Parse argv (or sys.argv) into a validated :class:`CloneConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Clone or fetch datasets per consolidated source listings "
+            "(stage 2 of the ingest pipeline)."
+        )
+    )
+    parser.add_argument("--input", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        default=None,
+        choices=sorted(KNOWN_SOURCES),
+    )
+    parser.add_argument("--timeout", type=int, default=None)
+    parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--limit-per-source", type=int, default=None, dest="limit_per_source"
+    )
+    parser.add_argument("--datasets", nargs="+", default=None)
+    parser.add_argument("--manifest-only", action="store_true", dest="manifest_only")
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    # Drop False bools (action="store_true" default) AND None values so
+    # the model defaults apply.
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None and v is not False}
+    return CloneConfig(**kwargs)

--- a/scripts/ingestions/_constants.py
+++ b/scripts/ingestions/_constants.py
@@ -54,3 +54,16 @@ MEF3_INTERNAL_EXTENSIONS: set[str] = {
 
 # MEF3 internal directory patterns (inside .mefd)
 MEF3_INTERNAL_DIRS: set[str] = {".timd", ".segd"}
+
+# Dataset IDs explicitly excluded from digestion AND injection. Single
+# source of truth shared by 3_digest.py and 5_inject.py — keep both
+# stages in sync. Add new IDs here, not in either stage.
+EXCLUDED_DATASETS: set[str] = {
+    "test",
+    "ds003380",
+    # OpenNeuro IDs that now redirect to other datasets on openneuro.org.
+    # ds004929 and ds005930 are fNIRS-only (no EEG); ds005407 redirects.
+    "ds004929",
+    "ds005407",
+    "ds005930",
+}

--- a/scripts/ingestions/_digest_config.py
+++ b/scripts/ingestions/_digest_config.py
@@ -1,0 +1,99 @@
+"""Pydantic-settings config for 3_digest.py (C7.2).
+
+Same pattern as ``_inject_config.py`` (C6.5) and ``_validate_config.py``
+(C7.1). Replaces the argparse + ``_positive_float`` custom-type
+boilerplate with declarative bounds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_DATASET_TIMEOUT_SECONDS = 2 * 60  # mirrors 3_digest.py
+
+
+class DigestConfig(BaseSettings):
+    """Validated config for the BIDS digest stage.
+
+    Sources, in precedence order: constructor kwargs → CLI args
+    (via :func:`load_digest_config_from_argv`) → env vars → defaults.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_DIGEST_",
+        extra="ignore",
+    )
+
+    input: Path = Field(
+        default=Path("data/cloned"),
+        description="Directory containing cloned datasets.",
+    )
+    output: Path = Field(
+        default=Path("digestion_output"),
+        description="Output directory for JSON files.",
+    )
+    datasets: list[str] | None = Field(
+        default=None,
+        description="Specific dataset IDs to digest (default: all).",
+    )
+    workers: int = Field(
+        default=1,
+        ge=1,
+        le=128,
+        description="Parallel worker processes (1 = sequential).",
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Stop after digesting N datasets (test-mode short-circuit).",
+    )
+    dataset_timeout: float = Field(
+        default=float(DEFAULT_DATASET_TIMEOUT_SECONDS),
+        gt=0.0,
+        le=60 * 60 * 4.0,  # 4-hour ceiling — anything bigger is a misconfig
+        description=(
+            "Seconds before killing a worker. Default: 120s. Ceiling: 4h "
+            "(beyond that, fix the underlying slowness instead of waiting)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> DigestConfig:
+        if not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+
+def load_digest_config_from_argv(
+    argv: list[str] | None = None,
+) -> DigestConfig:
+    """Parse argv (or sys.argv) into a validated :class:`DigestConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Digest BIDS datasets and generate Dataset + Record JSON for MongoDB."
+        )
+    )
+    parser.add_argument("--input", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--datasets", nargs="+", default=None)
+    parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--dataset-timeout",
+        type=float,
+        default=None,
+        dest="dataset_timeout",
+        help=(
+            "Seconds to allow one dataset before killing its worker "
+            f"(default: {DEFAULT_DATASET_TIMEOUT_SECONDS:g})"
+        ),
+    )
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None}
+    return DigestConfig(**kwargs)

--- a/scripts/ingestions/_file_utils.py
+++ b/scripts/ingestions/_file_utils.py
@@ -17,7 +17,17 @@ import time
 import xml.etree.ElementTree as ET
 from functools import wraps
 from pathlib import Path
+from typing import Any
 from urllib.parse import unquote, urljoin, urlparse
+
+import httpx
+from tenacity import (
+    RetryError,
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from _http import HTTPStatusError, RequestError, request_response
 
@@ -86,7 +96,15 @@ def _fetch_scidb_path(
 
         return files
 
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # External-service listing failure: network blip, HTTP error,
+        # or malformed JSON response. Treat the source as empty.
         return []
 
 
@@ -139,7 +157,15 @@ def _propfind_datarn(url: str, result: list, visited: set, depth: int = 0):
                     }
                 )
 
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # Recoverable external-service failure; we already have partial
+        # `result`/`webdav_url` accumulated. Continue with what we have.
         pass
 
 
@@ -203,34 +229,76 @@ def is_bids_root_file(filename: str) -> bool:
 # =============================================================================
 
 
+def _is_rate_limited_retryable(exc: BaseException) -> bool:
+    """Retry-predicate for ``rate_limited``: 429 + network errors only.
+
+    Used as a tenacity ``retry_if_exception`` callback; defined at
+    module level (rather than nested in ``rate_limited``) to satisfy
+    the no-nested-functions lint rule. Programmer errors
+    (AttributeError, TypeError, etc.) return False and propagate.
+    """
+    if isinstance(exc, HTTPStatusError):
+        return exc.response is not None and exc.response.status_code == 429
+    return isinstance(exc, RequestError)
+
+
 def rate_limited(min_interval: float = 0.5, max_retries: int = 3):
-    """Decorator for rate-limited HTTP requests with retry."""
+    """Decorator for rate-limited HTTP requests with retry on 429/network errors.
+
+    Wraps ``func`` so that:
+    - Calls are spaced at least ``min_interval`` seconds apart.
+    - HTTP 429 (Too Many Requests) and httpx network errors are retried
+      with exponential backoff (factor of 2 between attempts), up to
+      ``max_retries`` total attempts.
+    - Non-429 HTTPStatusError surfaces immediately on the first attempt
+      (404/5xx surface; tenacity-backed callers handle retry themselves
+      via the ``_http`` helper).
+
+    Parameters
+    ----------
+    min_interval : float
+        Minimum seconds between consecutive calls (rate limit). Also
+        used as the base for the exponential backoff between retries.
+    max_retries : int
+        Maximum total attempts (not delta — so ``max_retries=3`` makes
+        up to 3 attempts).
+
+    Notes
+    -----
+    Consolidates a hand-rolled try/except retry loop. Uses ``tenacity``
+    via ``stop_after_attempt`` / ``wait_exponential`` so it shares
+    semantics with ``_http.request_json``. The behaviour change is
+    documented in the test suite.
+    """
     last_call = [0.0]
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Enforce minimum interval between calls
+            # Enforce minimum interval between calls.
             elapsed = time.time() - last_call[0]
             if elapsed < min_interval:
                 time.sleep(min_interval - elapsed)
 
-            for attempt in range(max_retries):
-                try:
-                    result = func(*args, **kwargs)
-                    last_call[0] = time.time()
-                    return result
-                except HTTPStatusError as e:
-                    if e.response is not None and e.response.status_code == 429:
-                        wait = min_interval * (2**attempt)
-                        time.sleep(wait)
-                    elif attempt == max_retries - 1:
-                        raise
-                except RequestError:
-                    if attempt == max_retries - 1:
-                        raise
-                    time.sleep(min_interval * (attempt + 1))
-            return None
+            retrying = Retrying(
+                stop=stop_after_attempt(max_retries),
+                wait=wait_exponential(
+                    multiplier=min_interval, min=min_interval, max=60
+                ),
+                retry=retry_if_exception(_is_rate_limited_retryable),
+            )
+            result: Any = None
+            try:
+                for attempt in retrying:
+                    with attempt:
+                        result = func(*args, **kwargs)
+            except RetryError:
+                # Exhausted retries on a retryable exception path.
+                # Preserve the legacy contract: return None rather than
+                # propagating tenacity's RetryError wrapper.
+                return None
+            last_call[0] = time.time()
+            return result
 
         return wrapper
 
@@ -252,7 +320,8 @@ def peek_zip_contents(url: str, timeout: int = 30) -> list[dict] | None:
         url: Direct download URL for the ZIP file
         timeout: Request timeout in seconds
 
-    Returns:
+    Returns
+    -------
         List of {name, size, compressed_size} dicts, or None on error
 
     """
@@ -350,7 +419,12 @@ def peek_zip_contents(url: str, timeout: int = 30) -> list[dict] | None:
 
         return files if files else None
 
-    except Exception:
+    except (struct.error, UnicodeDecodeError, ValueError, IndexError) as e:
+        # ZIP central-directory parser. struct.error fires on truncated /
+        # garbage bytes; UnicodeDecodeError on filenames in unexpected
+        # encodings; IndexError on offsets past EOF. All recoverable —
+        # caller treats "no peek possible" as "skip the optimisation".
+        logger.debug("peek_zip_contents failed: %s", e)
         return None
 
 
@@ -360,7 +434,16 @@ def peek_zip_contents(url: str, timeout: int = 30) -> list[dict] | None:
 
 
 def list_figshare_files(article_id: int | str, api_key: str = "") -> list[dict]:
-    """List files from a Figshare article."""
+    """List files from a Figshare article.
+
+    .. warning::
+        **Secondary Source.** CI exercises only OpenNeuro and NEMAR;
+        this Adapter is best-effort and may silently drop fields
+        not in the shared schema. Fix opportunistically when
+        exercised; do not invest in depth until promoted in a
+        future sprint. See
+        ADRs/0001-secondary-source-deferral.md``.
+    """
     headers = {"User-Agent": "EEGDash/1.0"}
     if api_key:
         headers["Authorization"] = f"token {api_key}"
@@ -391,12 +474,28 @@ def list_figshare_files(article_id: int | str, api_key: str = "") -> list[dict]:
 
         return result
 
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # External-service listing failure: network blip, HTTP error,
+        # or malformed JSON response. Treat the source as empty.
         return []
 
 
 def list_zenodo_files(record_id: int | str, api_key: str = "") -> list[dict]:
-    """List files from a Zenodo record."""
+    """List files from a Zenodo record.
+
+    .. warning::
+        **Secondary Source.** Same caveats as
+        :func:`list_figshare_files`. Zenodo's per-file ``checksum``
+        field is now picked up by :func:`build_manifest` (was silently
+        dropped before — see
+        ADRs/0001-secondary-source-deferral.md``).
+    """
     headers = {"User-Agent": "EEGDash/1.0"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
@@ -446,12 +545,29 @@ def list_zenodo_files(record_id: int | str, api_key: str = "") -> list[dict]:
 
         return result
 
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # External-service listing failure: network blip, HTTP error,
+        # or malformed JSON response. Treat the source as empty.
         return []
 
 
 def list_osf_files(node_id: str, path: str = "/") -> list[dict]:
-    """Recursively list files from an OSF node."""
+    """Recursively list files from an OSF node.
+
+    .. warning::
+        **Secondary Source.** Same caveats as
+        :func:`list_figshare_files`. Pagination is currently stubbed
+        (line ~593): the helper recurses but does not chase ``next``
+        page links, so OSF nodes with > 100 files may return a
+        partial listing. See
+        ADRs/0001-secondary-source-deferral.md``.
+    """
     url = f"https://api.osf.io/v2/nodes/{node_id}/files/osfstorage{path}"
     headers = {"User-Agent": "EEGDash/1.0"}
 
@@ -500,7 +616,15 @@ def list_osf_files(node_id: str, path: str = "/") -> list[dict]:
                 # Extract path from next URL and recurse
                 pass  # Simplified - OSF pagination rarely needed for single datasets
 
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # Recoverable external-service failure; we already have partial
+        # `result`/`webdav_url` accumulated. Continue with what we have.
         pass
 
     return result
@@ -511,12 +635,20 @@ def list_scidb_files(
 ) -> list[dict]:
     """List files from SciDB using the public file tree API.
 
+    .. warning::
+        **Secondary Source.** Same caveats as
+        :func:`list_figshare_files`. SciDB emits ``md5`` directly and
+        is one of the few Adapters whose checksum survives the
+        manifest pipeline. See
+        ADRs/0001-secondary-source-deferral.md``.
+
     Args:
         dataset_id: The SciDB dataSetId (UUID format)
         version: Dataset version (default: V1)
         max_depth: Maximum recursion depth to prevent infinite loops
 
-    Returns:
+    Returns
+    -------
         List of file info dicts
 
     """
@@ -534,7 +666,15 @@ def list_scidb_files(
 
 
 def list_datarn_files(source_url: str) -> list[dict]:
-    """List files from data.ru.nl using WebDAV PROPFIND."""
+    """List files from data.ru.nl using WebDAV PROPFIND.
+
+    .. warning::
+        **Secondary Source.** Same caveats as
+        :func:`list_figshare_files`. The WebDAV PROPFIND path emits
+        only ``name`` and ``size`` — no checksum, no download URL
+        (constructed by the consumer from the source URL). See
+        ADRs/0001-secondary-source-deferral.md``.
+    """
     # Try to get WebDAV URL from page JSON-LD
     webdav_url = None
 
@@ -549,7 +689,15 @@ def list_datarn_files(source_url: str) -> list[dict]:
                 dist = ld_data.get("distribution", {})
                 if isinstance(dist, dict):
                     webdav_url = dist.get("contentUrl")
-    except Exception:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        # Recoverable external-service failure; we already have partial
+        # `result`/`webdav_url` accumulated. Continue with what we have.
         pass
 
     if not webdav_url:
@@ -714,27 +862,82 @@ def list_git_files(clone_dir: Path) -> list[dict]:
     Includes both regular files and symlinks (even broken ones like git-annex
     pointers).  Resolves git-annex pointer files and symlinks to their real
     data size.
-    """
-    result = []
 
-    for path in clone_dir.rglob("*"):
-        if ".git" in path.parts:
+    Implementation note (perf): walks via :func:`os.scandir` in a single
+    iterative pass and classifies each entry from the cached dirent
+    flags (``DT_REG`` / ``DT_LNK`` / ``DT_DIR``) instead of via
+    ``Path.rglob`` + repeated ``is_file`` / ``is_symlink`` ``stat``
+    syscalls.
+
+    The walker's classification (is_dir / is_file / is_symlink) uses
+    the cached dirent flags from scandir — zero stat syscalls. Per-
+    emitted-file stat cost is unchanged from the prior code:
+    ``get_annex_file_size`` (called once per emitted entry) still does
+    its own Path-based stat probes to disambiguate git-annex pointer
+    files from regular files. The Stage-2 speedup comes from cutting
+    classification syscalls for the (much larger) population of
+    non-emitted intermediate directory entries, not from changing the
+    per-emitted-file cost.
+
+    See ``tests/test_manifest_walk_perf.py`` for the regression guard.
+    """
+    result: list[dict] = []
+    # Pre-resolve to absolute path once so ``os.path.relpath`` is purely
+    # a string operation per entry, avoiding ``Path.__init__`` per file.
+    clone_dir_str = os.fspath(clone_dir)
+    stack: list[str] = [clone_dir_str]
+
+    while stack:
+        cur = stack.pop()
+        try:
+            scanner = os.scandir(cur)
+        except (PermissionError, OSError, FileNotFoundError):
             continue
 
-        if path.is_file():
-            result.append(
-                {
-                    "name": str(path.relative_to(clone_dir)),
-                    "size": get_annex_file_size(path),
-                }
-            )
-        elif path.is_symlink():
-            result.append(
-                {
-                    "name": str(path.relative_to(clone_dir)),
-                    "size": get_annex_file_size(path),
-                }
-            )
+        with scanner:
+            for entry in scanner:
+                # Skip the top-level ".git" tree without ever stat-ing
+                # its contents. Matches the prior ``".git" in path.parts``
+                # guard for any path under the .git subtree, because we
+                # never descend into it.
+                name = entry.name
+                if name == ".git":
+                    continue
+
+                try:
+                    is_symlink = entry.is_symlink()
+                    # ``follow_symlinks=False`` keeps broken symlinks
+                    # classified as non-dir, matching the prior
+                    # ``path.is_file()`` (which followed symlinks but
+                    # would return False for broken pointers).
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                except OSError:
+                    # Dirent went away between readdir and stat. Skip.
+                    continue
+
+                if is_dir and not is_symlink:
+                    stack.append(entry.path)
+                    continue
+
+                # Mirror the prior classifier exactly: emit an entry
+                # when the dirent is a regular file (``is_file`` after
+                # following symlinks) OR when it's a symlink (broken or
+                # otherwise — git-annex pointers).
+                try:
+                    is_file = entry.is_file()
+                except OSError:
+                    is_file = False
+
+                if not (is_file or is_symlink):
+                    continue
+
+                # Size resolution preserves the exact semantics of
+                # ``get_annex_file_size``: annex-keyed pointers → size
+                # parsed from the key, broken symlinks → 0, regular
+                # files → ``stat.st_size``.
+                size = get_annex_file_size(Path(entry.path))
+                rel = os.path.relpath(entry.path, clone_dir_str)
+                result.append({"name": rel, "size": size})
 
     return result
 
@@ -759,7 +962,8 @@ def build_manifest(
         metadata: Optional additional metadata from consolidated files.
                   ALL metadata is preserved to ensure no information loss.
 
-    Returns:
+    Returns
+    -------
         Manifest dict ready to be saved
 
     Note:
@@ -779,8 +983,11 @@ def build_manifest(
         }
         if download_url := f.get("download_url"):
             nf["download_url"] = download_url
-        if md5 := f.get("md5"):
-            nf["md5"] = md5
+        # Some Adapters (Zenodo) emit ``checksum`` instead of ``md5``;
+        # accept either. Without this, Zenodo content hashes were
+        # silently dropped at manifest time. See
+        if checksum := f.get("md5") or f.get("checksum"):
+            nf["md5"] = checksum
 
         # Normalize zip_contents to _zip_contents (expected by digest)
         if zip_contents := f.get("zip_contents"):
@@ -844,7 +1051,8 @@ def list_local_bids_files(local_path: str | Path) -> list[dict]:
     Args:
         local_path: Path to local BIDS dataset directory
 
-    Returns:
+    Returns
+    -------
         List of file dicts with {name, size} for each file
 
     """

--- a/scripts/ingestions/_fingerprint.py
+++ b/scripts/ingestions/_fingerprint.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
-
-
-def _stable_str(value: str) -> str:
-    return value.replace("\0", "")
 
 
 def _hash_entries(entries: Iterable[tuple[str, int]], seed: str = "") -> str:
@@ -17,7 +13,9 @@ def _hash_entries(entries: Iterable[tuple[str, int]], seed: str = "") -> str:
         hasher.update(seed.encode("utf-8", errors="replace"))
         hasher.update(b"\0")
     for path, size in sorted(entries):
-        hasher.update(_stable_str(path).encode("utf-8", errors="replace"))
+        # path.replace("\0", "") strips embedded NULs that would split the
+        # hash domain (NULs are our entry separator).
+        hasher.update(path.replace("\0", "").encode("utf-8", errors="replace"))
         hasher.update(b"\0")
         hasher.update(str(int(size)).encode("ascii", errors="ignore"))
         hasher.update(b"\0")

--- a/scripts/ingestions/_format_parser_registry.py
+++ b/scripts/ingestions/_format_parser_registry.py
@@ -1,0 +1,175 @@
+"""Format metadata parser registry — explicit Seam for binary-header readers.
+
+. Each neuroimaging file format (``.edf`` / ``.bdf`` /
+``.set`` / ``.vhdr`` / ``.snirf`` / ``.mefd``) needs its own binary
+header reader because sidecar JSON may be absent. Before this module
+the 5 parsers shared an implicit contract — same return shape, same
+``None`` semantics, but documented only in their individual docstrings.
+
+This file names the Seam: a :class:`FormatParser` Protocol, a
+:class:`FormatParserResult` TypedDict, and a registry that maps
+extensions to parsers.
+
+The 4 standalone parsers (``_set_parser.py`` / ``_vhdr_parser.py`` /
+``_snirf_parser.py`` / ``_mef3_parser.py``) already conform; this
+module is the seam they share. The MNE-based EDF/BDF parser
+(``_parse_edf_with_mne``) lives here too — it's just an MNE wrapper,
+small enough that a dedicated file would be overkill.
+
+FIF stays special-cased in ``3_digest.py``: ``_parse_fif_with_mne``
+returns ``(dict, is_split_bool)`` rather than just ``dict``. The
+extra flag feeds the split-FIF integrity check downstream and
+doesn't fit the shared shape. Documented as such; do not "regularise"
+it into this registry without changing the downstream check.
+
+See Also
+--------
+  individual parsers (``_vhdr_parser.py`` at 69.5% kill ratio).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, TypedDict
+
+import mne
+from _mef3_parser import parse_mef3_metadata
+from _set_parser import parse_set_metadata
+from _snirf_parser import parse_snirf_metadata
+from _vhdr_parser import parse_vhdr_metadata
+
+
+class FormatParserResult(TypedDict, total=False):
+    """The shape returned by every :class:`FormatParser`.
+
+    All fields optional — a parser fills only what the binary header
+    actually carries. The cascade in
+    ``3_digest.py:_extract_technical_metadata`` reads ``result.get(k)``
+    rather than ``result[k]``, so absence is fine.
+
+    Field semantics:
+
+    sampling_frequency
+        Hz, floating-point. The parser converts whatever the header
+        uses (sampling interval in microseconds for VHDR, sampling
+        rate for EDF / BDF / SET) to a unified Hz.
+    nchans
+        Number of channels. Some headers carry it directly
+        (``NumberOfChannels`` in VHDR); others derive from
+        ``len(ch_names)``.
+    ch_names
+        Channel labels as published in the header. The cascade may
+        override ``nchans`` to ``len(ch_names)`` when both are
+        present and disagree (``channels.tsv`` is authoritative).
+    n_times
+        Number of samples in the recording (NOT seconds). VHDR's
+        header doesn't include this; MNE computes it from the
+        binary companion at read time.
+    n_samples
+        Alias of ``n_times`` used by some older parsers. The
+        cascade accepts either key.
+    """
+
+    sampling_frequency: float
+    nchans: int
+    ch_names: list[str]
+    n_times: int
+    n_samples: int
+
+
+class FormatParser(Protocol):
+    """Callable: ``path -> FormatParserResult | None``.
+
+    Every registered parser must:
+    - Accept a single :class:`pathlib.Path` argument.
+    - Return a (possibly empty) :class:`FormatParserResult` dict or
+      ``None`` when the file can't be parsed (broken, missing, wrong
+      format).
+    - **Never raise** on recoverable parse failures — the cascade
+      relies on ``None`` as the signal. Programmer errors (e.g.,
+      wrong argument type) propagate per Phase 9 F1.
+    - Be safe to call on broken git-annex symlinks (return ``None``).
+
+    The contract is documented here so future parsers (e.g., a
+    BrainVision .ahdr variant, .nirs binary format) can be added
+    consistently.
+    """
+
+    def __call__(self, path: Path) -> FormatParserResult | None: ...
+
+
+def _parse_edf_with_mne(path: Path) -> FormatParserResult | None:
+    """MNE-based parser for EDF / BDF files.
+
+    Reads the file header (``preload=False``) and returns the standard
+    :class:`FormatParserResult` with all 4 fields populated when MNE
+    succeeds. Returns ``None`` on any recoverable MNE failure
+    (RuntimeError on unsupported variants, OSError on filesystem
+    issues, ValueError on truncated header, KeyError on missing
+    required fields).
+
+    Previously inlined inside ``3_digest.py``; moved here in P2.2 so
+    all 5 single-dict parsers live in one Module.
+    """
+    if not path.exists():
+        return None
+    try:
+        resolved = path.resolve()
+        if not resolved.exists():
+            return None
+    except (OSError, RuntimeError):
+        return None
+
+    try:
+        raw = mne.io.read_raw_edf(str(path), preload=False, verbose=False)
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError):
+        return None
+
+    try:
+        result: FormatParserResult = {}
+        sfreq = raw.info.get("sfreq")
+        if sfreq:
+            result["sampling_frequency"] = float(sfreq)
+        ch_names = raw.info.get("ch_names")
+        if ch_names:
+            result["ch_names"] = list(ch_names)
+            result["nchans"] = len(ch_names)
+        if raw.n_times and raw.n_times > 0:
+            result["n_times"] = int(raw.n_times)
+        return result if result else None
+    finally:
+        try:
+            raw.close()
+        except (OSError, AttributeError):
+            pass
+
+
+_REGISTRY: dict[str, FormatParser] = {
+    ".edf": _parse_edf_with_mne,
+    ".bdf": _parse_edf_with_mne,
+    ".set": parse_set_metadata,
+    ".vhdr": parse_vhdr_metadata,
+    ".snirf": parse_snirf_metadata,
+    ".mefd": parse_mef3_metadata,
+}
+
+
+def get_parser_for_extension(ext: str) -> FormatParser | None:
+    """Return the registered :class:`FormatParser` for ``ext`` (lower-cased,
+    leading dot — e.g. ``".edf"``) or ``None`` for unhandled extensions.
+    """
+    return _REGISTRY.get(ext)
+
+
+def registered_extensions() -> tuple[str, ...]:
+    """Sorted tuple of registered extensions."""
+    return tuple(sorted(_REGISTRY))
+
+
+__all__ = [
+    "FormatParser",
+    "FormatParserResult",
+    "_parse_edf_with_mne",
+    "get_parser_for_extension",
+    "registered_extensions",
+]

--- a/scripts/ingestions/_github.py
+++ b/scripts/ingestions/_github.py
@@ -7,7 +7,11 @@ REST API via our `_http` helper to keep scripts runnable in minimal environments
 from __future__ import annotations
 
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
+
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any
@@ -45,7 +49,7 @@ def _pygithub_client(
 ) -> Any | None:
     try:
         from github import Github  # type: ignore[import-not-found]
-    except Exception:
+    except ImportError:
         return None
     return Github(
         login_or_token=token or None,
@@ -83,8 +87,15 @@ def iter_org_repos(
                     "watchers_count": getattr(repo, "watchers_count", None),
                 }
             return
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 — PyGithub raises arbitrary base classes; see note
+            # PyGithub raises a stable set of named exceptions
+            # (GithubException, RateLimitExceededException, BadCredentialsException,
+            # UnknownObjectException, etc.) but ALSO wraps urllib3 / ssl /
+            # socket errors without normalising them. The safe approach
+            # is a broad catch with a logged context — the alternative
+            # (listing every wrapped class) is fragile across pygithub
+            # versions. The noqa documents the deliberate exception.
+            logger.debug("PyGithub fast-path failed, falling back to REST: %s", e)
 
     headers_extra = {"Authorization": f"Bearer {token}"} if token else None
     headers = build_headers(
@@ -163,8 +174,8 @@ def fetch_repo_file_text(
             if not decoded:
                 return None
             return decoded.decode("utf-8", errors="replace")
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 — PyGithub wraps urllib3/socket errors heterogeneously
+            logger.debug("PyGithub file-fetch failed, falling back to raw HTTP: %s", e)
 
     url = f"{GITHUB_RAW_URL}/{organization}/{repo}/{ref}/{path}"
     text, response = request_text(
@@ -233,6 +244,6 @@ def fetch_repo_file_json(
         return None
     try:
         payload = json.loads(text)
-    except Exception:
+    except (json.JSONDecodeError, ValueError):
         return None
     return payload if isinstance(payload, dict) else None

--- a/scripts/ingestions/_http.py
+++ b/scripts/ingestions/_http.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Iterable
+import warnings
+from collections.abc import Iterable
+from typing import Any
 
 import httpx
 
 try:
     from tenacity import (
+        RetryError,
         retry,
         retry_if_exception_type,
         retry_if_result,
@@ -20,13 +23,22 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     _TENACITY_AVAILABLE = False
 
+    class RetryError(Exception):  # type: ignore[no-redef]
+        """Fallback when tenacity is missing; never raised in that case."""
+
+
 try:
     import hishel
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     hishel = None
 
 DEFAULT_USER_AGENT = "EEGDash-DataHarvester/1.0"
-DEFAULT_RETRY_STATUSES = {429, 500, 502, 503, 504}
+# RFC 9110 § 15.5.9: 408 Request Timeout SHOULD be retried by clients
+# (server saw the connection open but did not receive a complete request
+# in time — same root cause as a 504, just observed from the upstream
+# side). Most servers return 504 instead, but including 408 is hygiene
+# and survives upstreams that don't.
+DEFAULT_RETRY_STATUSES = {408, 429, 500, 502, 503, 504}
 DEFAULT_TIMEOUT = 30.0
 
 RequestError = httpx.RequestError
@@ -67,10 +79,15 @@ def _build_transport() -> httpx.BaseTransport:
             try:
                 storage = hishel.FileStorage(base_path=cache_dir)
                 return hishel.CacheTransport(storage=storage)
-            except Exception:
+            except (OSError, PermissionError, ValueError):
+                # OSError covers ENOENT/EACCES on the cache dir; ValueError
+                # covers hishel's "invalid base_path" check. Cache disabled
+                # but the request path still works → silent fall-through.
                 pass
         return hishel.CacheTransport()
-    except Exception:
+    except (OSError, ImportError, AttributeError):
+        # ImportError if hishel is half-installed; AttributeError if its
+        # API changed between releases. Fall back to plain HTTPTransport.
         return httpx.HTTPTransport(retries=0)
 
 
@@ -97,8 +114,31 @@ def close_client() -> None:
         _client = None
 
 
-def make_retry_client(auth_token: str) -> httpx.Client:
-    """Create an HTTP client with auth headers for ingestion injection."""
+def make_authed_client(auth_token: str) -> httpx.Client:
+    """Create an httpx.Client with Bearer auth headers and no retries.
+
+    Retries are injected at the call site by ``request_json`` /
+    ``request_text`` via tenacity (see ``_request_with_retry``). This
+    function only configures the auth header and timeout — the name
+    reflects that.
+
+    Parameters
+    ----------
+    auth_token : str
+        Bearer token to attach as ``Authorization: Bearer <token>``.
+
+    Returns
+    -------
+    httpx.Client
+        Configured client. The caller is responsible for closing it,
+        either explicitly or via the ``with`` statement.
+
+    Notes
+    -----
+    Renamed from ``make_retry_client`` — the old name implied that
+    retries were baked into the client itself, which they are not.
+    The old name remains as a deprecated alias for one release.
+    """
     headers = build_headers(
         extra={
             "Authorization": f"Bearer {auth_token}",
@@ -110,6 +150,26 @@ def make_retry_client(auth_token: str) -> httpx.Client:
         headers=headers,
         timeout=DEFAULT_TIMEOUT,
     )
+
+
+def make_retry_client(auth_token: str) -> httpx.Client:
+    """Deprecated alias for :func:`make_authed_client`.
+
+    .. deprecated:: 0.1
+        ``make_retry_client`` is misleadingly named — the client it
+        returns has ``retries=0``; retries happen at call sites via
+        tenacity. Use :func:`make_authed_client` instead. Will be
+        removed in 0.2.
+    """
+    warnings.warn(
+        "make_retry_client is deprecated; use make_authed_client. "
+        "The returned client does NOT have retries baked in; retries "
+        "are injected by request_json / request_text. "
+        "Will be removed in v0.2.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return make_authed_client(auth_token)
 
 
 def _should_retry_response(
@@ -195,6 +255,7 @@ def request_json(
     retry_set = set(retry_statuses or DEFAULT_RETRY_STATUSES)
     http_client = client or get_client()
 
+    response: httpx.Response | None = None
     try:
         response = _request_with_retry(
             http_client,
@@ -217,6 +278,19 @@ def request_json(
             return response.json(), response
         except ValueError:
             return None, response
+    except RetryError as e:
+        # tenacity raises this when retries exhaust on a RETRY_RESULT
+        # condition (e.g., persistent 5xx — no exception, just a bad
+        # status). The last_attempt's result IS an httpx.Response that
+        # the caller may want to inspect for the final status code.
+        # (Bug found by tests/test_http.py: persistent 503 used to leak
+        # tenacity.RetryError to callers, breaking the documented
+        # "(payload, response)" contract.)
+        try:
+            last_response = e.last_attempt.result()
+        except Exception:  # noqa: BLE001 — last_attempt internals are tenacity-private
+            last_response = None
+        return None, last_response
     except httpx.RequestError:
         if raise_for_request:
             raise

--- a/scripts/ingestions/_inject_config.py
+++ b/scripts/ingestions/_inject_config.py
@@ -1,0 +1,275 @@
+"""Pydantic-settings config for 5_inject.py CLI + env vars."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import httpx
+from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_API_URL = "https://data.eegdash.org"
+
+# Fallback contract; drift is detected when /admin/valid-databases is reachable.
+LOCAL_FALLBACK_DATABASES: frozenset[str] = frozenset(
+    {
+        "eegdash",
+        "eegdash_dev",
+        "eegdash_archive",
+        "eegdash_staging",
+        "eegdash_v1",
+    }
+)
+
+# Per-API-URL cache; cleared by tests via clear_valid_databases_cache().
+_valid_databases_cache: dict[str, frozenset[str]] = {}
+
+
+def fetch_valid_databases_from_api(
+    api_url: str,
+    token: str | None,
+    *,
+    timeout: float = 5.0,
+) -> frozenset[str] | None:
+    """Return the API Gateway's valid_databases set, or None on any failure."""
+    if api_url in _valid_databases_cache:
+        cached = _valid_databases_cache[api_url]
+        return cached if cached else None  # empty frozenset is "API previously failed"
+
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(f"{api_url}/admin/valid-databases", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            valid = frozenset(data["databases"])
+    except (httpx.HTTPError, KeyError, ValueError, TypeError):
+        _valid_databases_cache[api_url] = frozenset()  # sentinel "no api data"
+        return None
+
+    _valid_databases_cache[api_url] = valid
+    return valid
+
+
+def clear_valid_databases_cache() -> None:
+    """Test helper. Resets the per-api_url cache."""
+    _valid_databases_cache.clear()
+
+
+# str alias; accepted values are checked dynamically at validation time.
+DatabaseName = str
+
+
+class InjectConfig(BaseSettings):
+    """Validated injection-pipeline config (kwargs > CLI > env > defaults)."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_INJECT_",
+        extra="ignore",
+    )
+
+    # ─── Required: target database ────────────────────────────────────────
+    database: DatabaseName = Field(
+        description="Target MongoDB database; validated against the API or LOCAL_FALLBACK_DATABASES.",
+    )
+
+    @field_validator("database")
+    @classmethod
+    def _database_must_be_valid(cls, value: str, info) -> str:
+        """Reject databases not in the union of the API set and LOCAL_FALLBACK_DATABASES."""
+        # api_url / token may not yet be validated; fall back to defaults.
+        api_url = info.data.get("api_url") or DEFAULT_API_URL
+        token = info.data.get("token")
+
+        api_set = fetch_valid_databases_from_api(api_url, token)
+        if api_set is None:
+            logging.getLogger(__name__).warning(
+                "Could not reach %s/admin/valid-databases; using "
+                "LOCAL_FALLBACK_DATABASES alone. Database-list drift "
+                "will not be detected this run.",
+                api_url,
+            )
+        valid: frozenset[str] = (api_set or frozenset()) | LOCAL_FALLBACK_DATABASES
+
+        if value not in valid:
+            raise ValueError(
+                f"database={value!r} is not in the valid set "
+                f"({sorted(valid)}); update the API's valid_databases or "
+                f"LOCAL_FALLBACK_DATABASES if you are adding a new one."
+            )
+        return value
+
+    # ─── I/O ─────────────────────────────────────────────────────────────
+    input: Path = Field(
+        default=Path("digestion_output"),
+        description="Directory containing digested datasets.",
+    )
+    api_url: str = Field(
+        default=DEFAULT_API_URL,
+        description="EEGDash API Gateway URL.",
+    )
+
+    # ─── Auth (env-var fallback: EEGDASH_ADMIN_TOKEN) ────────────────────
+    token: str | None = Field(
+        default=None,
+        description="Admin Bearer token (env fallback: EEGDASH_ADMIN_TOKEN).",
+        validation_alias=AliasChoices("token", "EEGDASH_ADMIN_TOKEN"),
+    )
+
+    # ─── Filters ─────────────────────────────────────────────────────────
+    datasets: list[str] | None = Field(
+        default=None,
+        description=(
+            "Specific dataset IDs to inject. Default: all datasets in --input."
+        ),
+    )
+
+    # ─── Behaviour flags ─────────────────────────────────────────────────
+    dry_run: bool = Field(default=False, description="Validate without uploading.")
+    batch_size: int = Field(
+        default=1000,
+        ge=1,
+        le=10_000,
+        description="Max records per API request.",
+    )
+    only_datasets: bool = Field(default=False)
+    only_records: bool = Field(default=False)
+    only_montages: bool = Field(default=False)
+    skip_montages: bool = Field(default=False)
+    force: bool = Field(
+        default=False,
+        description="Inject even if ingestion_fingerprint matches existing.",
+    )
+    skip_validation: bool = Field(
+        default=False,
+        description="Skip validation before injection (not recommended).",
+    )
+    data_quality_threshold: float = Field(
+        default=10.0,
+        ge=0.0,
+        le=100.0,
+        description=(
+            "Max percentage of records with missing nchans/sampling_frequency "
+            "before failing the pre-inject quality gate."
+        ),
+    )
+    compute_stats: bool = Field(
+        default=False,
+        description="Recompute dataset stats after injection.",
+    )
+
+    # ─── Validators ──────────────────────────────────────────────────────
+
+    @model_validator(mode="after")
+    def _only_flags_are_mutually_exclusive(self) -> InjectConfig:
+        """At most one of --only-datasets / --only-records / --only-montages."""
+        only_flags = sum((self.only_datasets, self.only_records, self.only_montages))
+        if only_flags > 1:
+            raise ValueError(
+                "--only-datasets, --only-records, --only-montages are "
+                "mutually exclusive (max one)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _only_and_skip_montages_are_contradictory(self) -> InjectConfig:
+        if self.only_montages and self.skip_montages:
+            raise ValueError(
+                "--only-montages and --skip-montages contradict each other"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _input_dir_must_exist_unless_dry_run(self) -> InjectConfig:
+        """Require the input directory to exist, unless dry_run skips actual I/O."""
+        if not self.dry_run and not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+    # ─── Convenience accessors ───────────────────────────────────────────
+
+    @property
+    def want_datasets(self) -> bool:
+        return not self.only_records and not self.only_montages
+
+    @property
+    def want_records(self) -> bool:
+        return not self.only_datasets and not self.only_montages
+
+    @property
+    def want_montages(self) -> bool:
+        if self.only_datasets or self.only_records:
+            return False
+        if self.skip_montages:
+            return False
+        return True
+
+
+def load_inject_config_from_argv(argv: list[str] | None = None) -> InjectConfig:
+    """Parse argv (or sys.argv) into a validated :class:`InjectConfig`."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject digested datasets and records into MongoDB via "
+            "the EEGDash API Gateway."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Directory containing digested datasets (default: digestion_output/).",
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        required=True,
+        help=(
+            "Target MongoDB database: eegdash | eegdash_dev | eegdash_archive | "
+            "eegdash_staging | eegdash_v1."
+        ),
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        default=None,
+        dest="api_url",
+        help=f"EEGDash API URL (default: {DEFAULT_API_URL}).",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Admin token (env fallback: EEGDASH_ADMIN_TOKEN).",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=None,
+        help="Specific dataset IDs to inject (default: all).",
+    )
+    parser.add_argument("--dry-run", action="store_true", dest="dry_run")
+    parser.add_argument("--batch-size", type=int, default=None, dest="batch_size")
+    parser.add_argument("--only-datasets", action="store_true", dest="only_datasets")
+    parser.add_argument("--only-records", action="store_true", dest="only_records")
+    parser.add_argument("--only-montages", action="store_true", dest="only_montages")
+    parser.add_argument("--skip-montages", action="store_true", dest="skip_montages")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--skip-validation", action="store_true", dest="skip_validation"
+    )
+    parser.add_argument(
+        "--data-quality-threshold",
+        type=float,
+        default=None,
+        dest="data_quality_threshold",
+    )
+    parser.add_argument("--compute-stats", action="store_true", dest="compute_stats")
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    # Omit None so Field defaults take effect.
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None}
+    return InjectConfig(**kwargs)

--- a/scripts/ingestions/_inject_plan.py
+++ b/scripts/ingestions/_inject_plan.py
@@ -1,0 +1,306 @@
+"""Build the Stage 5 Injection Plan from a Digest Corpus."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from _constants import EXCLUDED_DATASETS
+from _fingerprint import fingerprint_from_records
+from _http import get_client, request_json
+
+
+@dataclass
+class InjectionPlan:
+    """Structured write plan produced from a Digest Corpus."""
+
+    dataset_dirs: list[Path] = field(default_factory=list)
+    datasets: list[dict] = field(default_factory=list)
+    records: list[dict] = field(default_factory=list)
+    montages: list[dict] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
+    skipped_ids: list[str] = field(default_factory=list)
+    changed_ids: list[str] = field(default_factory=list)
+    duplicate_montage_sightings: int = 0
+
+
+def find_digested_datasets(
+    input_dir: Path, datasets: list[str] | None = None
+) -> list[Path]:
+    """Find all dataset directories in the Digest Corpus."""
+    dataset_dirs = []
+
+    for dataset_dir in sorted(input_dir.iterdir()):
+        if not dataset_dir.is_dir():
+            continue
+
+        dataset_id = dataset_dir.name
+
+        if (
+            dataset_id.startswith(".")
+            or dataset_id.startswith("_")
+            or dataset_id in EXCLUDED_DATASETS
+        ):
+            continue
+
+        if datasets and dataset_id not in datasets:
+            continue
+
+        dataset_file = dataset_dir / f"{dataset_id}_dataset.json"
+        records_file = dataset_dir / f"{dataset_id}_records.json"
+
+        if dataset_file.exists() or records_file.exists():
+            dataset_dirs.append(dataset_dir)
+
+    return dataset_dirs
+
+
+def load_dataset(dataset_dir: Path) -> dict | None:
+    """Load a Dataset document from a directory."""
+    dataset_id = dataset_dir.name
+    dataset_file = dataset_dir / f"{dataset_id}_dataset.json"
+
+    if not dataset_file.exists():
+        return None
+
+    with open(dataset_file) as f:
+        return json.load(f)
+
+
+def load_records(dataset_dir: Path) -> list[dict]:
+    """Load records from a directory; supports new schema and legacy formats."""
+    dataset_id = dataset_dir.name
+
+    def _prepare(records: list) -> list[dict]:
+        out = []
+        for r in records:
+            r = _flatten_entities(r)
+            r.setdefault("dataset", dataset_id)
+            out.append(r)
+        return out
+
+    records_file = dataset_dir / f"{dataset_id}_records.json"
+    if records_file.exists():
+        with open(records_file) as f:
+            data = json.load(f)
+        if isinstance(data, dict) and "records" in data:
+            records = data["records"]
+        elif isinstance(data, list):
+            records = data
+        else:
+            records = []
+        return _prepare(records)
+
+    for legacy_name in [f"{dataset_id}_core.json", f"{dataset_id}_minimal.json"]:
+        legacy_file = dataset_dir / legacy_name
+        if legacy_file.exists():
+            with open(legacy_file) as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                records = data
+            elif isinstance(data, dict) and "records" in data:
+                records = data["records"]
+            else:
+                records = []
+            return _prepare(records)
+
+    return []
+
+
+def load_montages(dataset_dir: Path) -> list[dict]:
+    """Load Montage documents from a dataset's digest directory."""
+    dataset_id = dataset_dir.name
+    montages_file = dataset_dir / f"{dataset_id}_montages.json"
+    try:
+        with open(montages_file) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return []
+
+    if isinstance(data, dict) and "montages" in data:
+        return data.get("montages") or []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _flatten_entities(record: dict) -> dict:
+    """Flatten BIDS entities to top-level fields for Gateway compatibility."""
+    result = record.copy()
+    entities = result.pop("entities", {})
+    if entities:
+        for key in ("subject", "task", "session", "run"):
+            if key in entities and key not in result:
+                result[key] = entities[key]
+    return result
+
+
+def fetch_existing_dataset(
+    api_url: str,
+    database: str,
+    dataset_id: str,
+):
+    """Fetch existing dataset metadata from the API; returns None if missing or ambiguous."""
+    url = f"{api_url}/api/{database}/datasets/{dataset_id}"
+    data, response = request_json("get", url, timeout=30, client=get_client())
+    if response is None:
+        return None
+    if response.status_code == 404:
+        return None
+    if response.status_code != 200 or data is None:
+        return None
+    payload = data.get("data")
+    if not payload:
+        # 200 with missing/empty data is ambiguous; don't claim 'new'.
+        return None
+    return payload
+
+
+def _ensure_fingerprint(dataset_id: str, dataset: dict | None, records: list[dict]):
+    """Ensure ingestion_fingerprint is set; honours any fingerprint already stamped by digest stage."""
+    if dataset is None:
+        dataset = {"dataset_id": dataset_id}
+    if dataset.get("ingestion_fingerprint"):
+        return dataset
+    if records:
+        dataset["ingestion_fingerprint"] = fingerprint_from_records(
+            dataset_id,
+            dataset.get("source", "unknown"),
+            records,
+        )
+    return dataset
+
+
+def filter_changed_datasets(
+    dataset_ids: list[str],
+    datasets_by_id: dict[str, dict],
+    records_by_id: dict[str, list[dict]],
+    api_url: str,
+    database: str,
+):
+    """Return dataset IDs that are new or updated, plus skipped IDs."""
+    changed_ids: list[str] = []
+    skipped_ids: list[str] = []
+
+    for dataset_id in dataset_ids:
+        dataset = datasets_by_id.get(dataset_id)
+        records = records_by_id.get(dataset_id, [])
+        dataset = _ensure_fingerprint(dataset_id, dataset, records)
+        datasets_by_id[dataset_id] = dataset
+
+        existing = fetch_existing_dataset(api_url, database, dataset_id)
+        existing_fp = (existing or {}).get("ingestion_fingerprint")
+        current_fp = dataset.get("ingestion_fingerprint")
+
+        if not existing:
+            changed_ids.append(dataset_id)
+            continue
+        if existing_fp and current_fp and existing_fp == current_fp:
+            skipped_ids.append(dataset_id)
+            continue
+        changed_ids.append(dataset_id)
+
+    return changed_ids, skipped_ids
+
+
+def build_injection_plan(
+    dataset_dirs: list[Path],
+    *,
+    want_datasets: bool,
+    want_records: bool,
+    want_montages: bool,
+    force: bool,
+    only_montages: bool,
+    api_url: str,
+    database: str,
+    progress: Callable[[Iterable[Path]], Iterable[Path]] | None = None,
+) -> InjectionPlan:
+    """Load a Digest Corpus and decide which documents Stage 5 should write."""
+    iter_dirs = progress(dataset_dirs) if progress else dataset_dirs
+
+    all_datasets = []
+    all_records = []
+    all_montages_by_hash: dict[str, dict] = {}
+    montage_dataset_sources: dict[str, set[str]] = {}
+    dataset_docs: dict[str, dict] = {}
+    errors: list[dict[str, str]] = []
+
+    for dataset_dir in iter_dirs:
+        dataset_id = dataset_dir.name
+
+        try:
+            records = load_records(dataset_dir)
+            if want_records and records:
+                all_records.extend(records)
+
+            # Always load dataset doc even when records is empty (metadata-only seeds).
+            dataset = load_dataset(dataset_dir)
+            if dataset:
+                dataset_docs[dataset_id] = dataset
+                if want_datasets:
+                    all_datasets.append(dataset)
+
+            if want_montages:
+                for montage in load_montages(dataset_dir):
+                    montage_hash = montage.get("hash")
+                    if not montage_hash:
+                        continue
+                    if montage_hash not in all_montages_by_hash:
+                        all_montages_by_hash[montage_hash] = montage
+                    montage_dataset_sources.setdefault(montage_hash, set()).add(
+                        dataset_id
+                    )
+
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            errors.append({"dataset": dataset_id, "error": str(e)})
+            print(f"  Error loading {dataset_id}: {e}", file=sys.stderr)
+
+    all_montages = list(all_montages_by_hash.values())
+    duplicate_sightings = sum(
+        max(0, len(sources) - 1) for sources in montage_dataset_sources.values()
+    )
+
+    datasets_by_id = {ds_id: ds for ds_id, ds in dataset_docs.items() if ds_id and ds}
+    records_by_id: dict[str, list[dict]] = {}
+    for record in all_records:
+        dataset_id = record.get("dataset")
+        if not dataset_id:
+            continue
+        records_by_id.setdefault(dataset_id, []).append(record)
+
+    dataset_ids = sorted(set(datasets_by_id) | set(records_by_id))
+
+    for dataset_id in dataset_ids:
+        dataset = datasets_by_id.get(dataset_id)
+        records = records_by_id.get(dataset_id, [])
+        datasets_by_id[dataset_id] = _ensure_fingerprint(dataset_id, dataset, records)
+
+    changed_ids = dataset_ids
+    skipped_ids: list[str] = []
+    if not force and not only_montages:
+        changed_ids, skipped_ids = filter_changed_datasets(
+            dataset_ids,
+            datasets_by_id,
+            records_by_id,
+            api_url,
+            database,
+        )
+        changed_set = set(changed_ids)
+        all_datasets = [
+            datasets_by_id[ds_id] for ds_id in changed_ids if ds_id in datasets_by_id
+        ]
+        all_records = [r for r in all_records if r.get("dataset") in changed_set]
+
+    return InjectionPlan(
+        dataset_dirs=dataset_dirs,
+        datasets=all_datasets,
+        records=all_records,
+        montages=all_montages,
+        errors=errors,
+        skipped_ids=skipped_ids,
+        changed_ids=changed_ids,
+        duplicate_montage_sightings=duplicate_sightings,
+    )

--- a/scripts/ingestions/_mef3_parser.py
+++ b/scripts/ingestions/_mef3_parser.py
@@ -8,11 +8,14 @@ Reference: https://github.com/msel-source/meflib
 
 from __future__ import annotations
 
+import logging
 import struct
 from pathlib import Path
 from typing import Any
 
 from _parser_utils import validate_file_path
+
+logger = logging.getLogger(__name__)
 
 
 def parse_mef3_metadata(mefd_path: Path | str) -> dict[str, Any] | None:
@@ -146,15 +149,34 @@ def _extract_sfreq_from_timd(timd_dir: Path) -> float | None:
     # The sampling frequency is stored as a double at a specific offset
     try:
         return _parse_tmet_sampling_frequency(tmet_file)
-    except Exception:
+    except (OSError, struct.error, ValueError) as e:
+        # OSError covers file-not-found / permission. struct.error fires
+        # when the .tmet is truncated below the header offset. ValueError
+        # protects against pathological data passing the size check but
+        # holding NaN or infinity. All recoverable.
+        logger.debug("Could not parse .tmet at %s: %s", tmet_file, e)
         return None
 
 
 def _parse_tmet_sampling_frequency(tmet_path: Path) -> float | None:
     """Parse sampling frequency from MEF3 .tmet file.
 
-    MEF3 .tmet files contain time series metadata in a binary format.
-    The sampling frequency is stored as a double-precision float.
+    MEF3 .tmet files contain time series metadata in a binary format
+    documented at https://github.com/msel-source/meflib_3p0. The
+    sampling frequency is stored as a little-endian double in the
+    time-series metadata section, AFTER the 1024-byte universal header.
+
+    The exact offset depends on the structure version + padding
+    choices the encoder made. Production MEF 3.0 files written by the
+    Mayo Foundation tooling place it at offset 8720 (verified against
+    OpenNeuro ds003708's CC0 fixture); older / synthetic files have
+    been observed at 272, 280, 1272, 1280, 1288.
+
+    Rather than guess at a fixed offset, this implementation scans
+    every 8-byte-aligned position past the universal header and
+    accepts the first value within the sanity range (0.1 - 1_000_000 Hz)
+    that's also an integer multiple of 0.5 Hz (a near-universal
+    convention for clinical recording rates: 256/512/1024/2048/etc).
 
     Parameters
     ----------
@@ -169,34 +191,45 @@ def _parse_tmet_sampling_frequency(tmet_path: Path) -> float | None:
     """
     try:
         with open(tmet_path, "rb") as f:
-            # MEF3 .tmet file structure (simplified):
-            # - Universal header (1024 bytes)
-            # - Time series metadata section header
-            # - Sampling frequency is at offset 272 in the metadata section
-            # (after the 1024-byte universal header)
-
-            # Read the file
             data = f.read()
 
             if len(data) < 1300:  # Minimum size for valid .tmet
                 return None
 
-            # Try to find sampling frequency
-            # In MEF3 format, sampling_frequency is a double at specific offset
-            # Offset varies by MEF version, try common locations
+            # Fast-path: try the historically-observed offsets first
+            # so non-MEF-3.0 / synthetic test files keep working.
+            for offset in (1272, 1280, 1288, 272, 280):
+                if offset + 8 > len(data):
+                    continue
+                try:
+                    sfreq = struct.unpack("<d", data[offset : offset + 8])[0]
+                except struct.error:
+                    continue
+                if 0.1 < sfreq < 1_000_000:
+                    return sfreq
 
-            # MEF 3.0 layout: sampling_frequency at offset 1024 + 248 = 1272
-            for offset in [1272, 1280, 1288, 272, 280]:
-                if offset + 8 <= len(data):
-                    try:
-                        sfreq = struct.unpack("<d", data[offset : offset + 8])[0]
-                        # Sanity check - sampling frequency should be reasonable
-                        if 0.1 < sfreq < 1000000:
-                            return sfreq
-                    except struct.error:
-                        continue
+            # Slow-path: scan every 8-byte-aligned position past the
+            # universal header. Pick the first half-Hz multiple in the
+            # sanity range — that filters out random doubles that happen
+            # to fall in 100-1000 (e.g., MD5 hash bytes interpreted as
+            # doubles).
+            for offset in range(1024, len(data) - 8, 8):
+                try:
+                    sfreq = struct.unpack("<d", data[offset : offset + 8])[0]
+                except struct.error:
+                    continue
+                if not (0.1 < sfreq < 1_000_000):
+                    continue
+                # Half-Hz multiple filter — production clinical / research
+                # recording rates are all integer or half-integer Hz.
+                if (sfreq * 2.0) != int(sfreq * 2.0):
+                    continue
+                return sfreq
 
             return None
 
-    except Exception:
+    except (OSError, struct.error) as e:
+        # OSError = file disappeared or unreadable; struct.error = the
+        # binary layout doesn't match any of the offset hypotheses above.
+        logger.debug("Failed to unpack .tmet %s: %s", tmet_path, e)
         return None

--- a/scripts/ingestions/_metadata_cascade.py
+++ b/scripts/ingestions/_metadata_cascade.py
@@ -1,0 +1,503 @@
+"""Technical-metadata cascade for the BIDS digest pipeline.
+
+Resolves ``(sampling_frequency, nchans, ntimes, ch_names)`` plus a
+per-field provenance dict by trying up to five sources in order with
+first-writer-wins semantics: MneBidsStep → ModalitySidecarStep →
+ChannelsTsvStep → BinaryParserStep → MneFallbackStep.
+
+Public surface: :class:`MetadataCascade.run` takes a
+:class:`CascadeContext` and returns a :class:`CascadeResult`.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+import pandas as pd
+
+import mne
+from _format_parser_registry import get_parser_for_extension
+
+# Provenance source names persisted into ``_metadata_provenance``; values are
+# snapshot-tested for byte-level stability — do not rename.
+PROV_MNE_BIDS = "mne_bids"
+PROV_MODALITY_SIDECAR = "modality_sidecar"
+PROV_CHANNELS_TSV = "channels_tsv"
+PROV_BINARY_PARSER = "binary_parser"
+PROV_MNE_FALLBACK = "mne_fallback"
+
+_METADATA_FIELDS: tuple[str, ...] = (
+    "sampling_frequency",
+    "nchans",
+    "ntimes",
+    "ch_names",
+)
+
+
+# ─── BIDS sidecar helpers ─────────────────────────────────────────────────
+
+
+# Per-modality JSON sidecar suffixes. MEG before EEG so a co-recorded
+# MEG+EEG study finds the MEG sidecar first (authoritative for n_megchans).
+_MODALITY_SIDECAR_SUFFIXES = (
+    "_meg.json",
+    "_eeg.json",
+    "_ieeg.json",
+    "_nirs.json",
+)
+
+_BIDS_CHANNEL_COUNT_FIELDS: tuple[str, ...] = (
+    "MEGChannelCount",
+    "EEGChannelCount",
+    "EOGChannelCount",
+    "ECGChannelCount",
+    "EMGChannelCount",
+    "MiscChannelCount",
+    "TriggerChannelCount",
+    "iEEGChannelCount",
+    "SEEGChannelCount",
+    "ECOGChannelCount",
+    "NIRSChannelCount",
+    "ACCELChannelCount",
+)
+
+
+def sum_bids_channel_counts(sidecar_data: dict[str, Any]) -> int | None:
+    """Sum all known BIDS ``*ChannelCount`` fields; return ``None`` when zero."""
+    total = sum(sidecar_data.get(field, 0) or 0 for field in _BIDS_CHANNEL_COUNT_FIELDS)
+    return total if total > 0 else None
+
+
+def _build_bids_search_paths(
+    bids_file_path: Path, bids_root: Path
+) -> tuple[list[str], list[Path]]:
+    """Return base-name variants and ancestor directories for a BIDS inheritance walk."""
+    stem = bids_file_path.stem
+    parts = stem.split("_")
+
+    base_names_to_try: list[str] = []
+    full_base = "_".join(parts[:-1]) if len(parts) > 1 else stem
+    base_names_to_try.append(full_base)
+
+    if "_run-" in full_base:
+        without_run = "_".join(p for p in parts[:-1] if not p.startswith("run-"))
+        base_names_to_try.append(without_run)
+
+    if "_acq-" in full_base:
+        without_acq_run = "_".join(
+            p
+            for p in parts[:-1]
+            if not p.startswith("run-") and not p.startswith("acq-")
+        )
+        base_names_to_try.append(without_acq_run)
+
+    task_part = next((p for p in parts if p.startswith("task-")), None)
+    if task_part and task_part not in base_names_to_try:
+        base_names_to_try.append(task_part)
+
+    parent_dir = bids_file_path.parent
+    dirs_to_try: list[Path] = [parent_dir]
+    current = parent_dir
+    while current != bids_root and current.parent != current:
+        current = current.parent
+        dirs_to_try.append(current)
+        if current == bids_root:
+            break
+
+    return base_names_to_try, dirs_to_try
+
+
+def extract_sfreq_nchans_from_modality_sidecar(
+    bids_file_path: Path,
+    bids_root: Path,
+    sampling_frequency: float | None,
+    nchans: int | None,
+) -> tuple[float | None, int | None]:
+    """Fill missing sfreq/nchans from a modality JSON sidecar using BIDS inheritance."""
+    if sampling_frequency and nchans:
+        return sampling_frequency, nchans
+
+    base_names_to_try, dirs_to_try = _build_bids_search_paths(bids_file_path, bids_root)
+
+    for search_dir in dirs_to_try:
+        if sampling_frequency and nchans:
+            break
+        for base_name in base_names_to_try:
+            if sampling_frequency and nchans:
+                break
+            for sidecar_suffix in _MODALITY_SIDECAR_SUFFIXES:
+                sidecar_path = search_dir / f"{base_name}{sidecar_suffix}"
+                if not sidecar_path.exists():
+                    continue
+                try:
+                    with open(sidecar_path) as f:
+                        sidecar_data = json.load(f)
+                except (OSError, json.JSONDecodeError, ValueError, TypeError):
+                    # Unreadable or malformed sidecar — try next candidate.
+                    continue
+                if not sampling_frequency and "SamplingFrequency" in sidecar_data:
+                    try:
+                        sampling_frequency = float(sidecar_data["SamplingFrequency"])
+                    except (TypeError, ValueError):
+                        pass
+                if not nchans:
+                    summed = sum_bids_channel_counts(sidecar_data)
+                    if summed is not None:
+                        nchans = summed
+                break  # only consult one sidecar variant per (dir, base)
+
+    return sampling_frequency, nchans
+
+
+def extract_sfreq_nchans_from_channels_tsv(
+    bids_file_path: Path,
+    bids_root: Path,
+    sampling_frequency: float | None,
+    nchans: int | None,
+) -> tuple[float | None, int | None]:
+    """Fill missing sfreq/nchans from a ``*_channels.tsv`` using BIDS inheritance."""
+    if sampling_frequency and nchans:
+        return sampling_frequency, nchans
+
+    base_names_to_try, dirs_to_try = _build_bids_search_paths(bids_file_path, bids_root)
+
+    for search_dir in dirs_to_try:
+        if sampling_frequency and nchans:
+            break
+        for base_name in base_names_to_try:
+            if sampling_frequency and nchans:
+                break
+            channels_path = search_dir / f"{base_name}_channels.tsv"
+            if not channels_path.exists():
+                continue
+            try:
+                channels_df = pd.read_csv(
+                    channels_path,
+                    sep="\t",
+                    dtype="string",
+                    keep_default_na=False,
+                )
+            except (
+                pd.errors.ParserError,
+                pd.errors.EmptyDataError,
+                OSError,
+                UnicodeDecodeError,
+                ValueError,
+                KeyError,
+            ):
+                # channels.tsv malformed; try next search dir.
+                continue
+            if not nchans:
+                nchans = len(channels_df)
+            if not sampling_frequency:
+                for col in ("sampling_frequency", "SamplingFrequency"):
+                    if col not in channels_df.columns:
+                        continue
+                    for val in channels_df[col]:
+                        try:
+                            sfreq_val = float(val)
+                        except (TypeError, ValueError):
+                            continue
+                        if sfreq_val > 0:
+                            sampling_frequency = sfreq_val
+                            break
+                    if sampling_frequency:
+                        break
+            break  # one channels.tsv per (dir, base) is authoritative
+
+    return sampling_frequency, nchans
+
+
+# ─── FIF metadata helper ──────────────────────────────────────────────────
+
+
+def _parse_fif_with_mne(fif_path: Path) -> tuple[dict[str, Any] | None, bool]:
+    """Parse FIF metadata via MNE; ``on_split_missing="warn"`` lets git-annex hash-named files yield header data."""
+    # Broken git-annex symlinks resolve to non-existent targets.
+    if not fif_path.exists():
+        return None, False
+    try:
+        resolved = fif_path.resolve()
+        if not resolved.exists():
+            return None, False
+    except (OSError, RuntimeError):
+        return None, False
+
+    try:
+        is_split = False
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            raw = mne.io.read_raw_fif(
+                str(fif_path),
+                preload=False,
+                on_split_missing="warn",
+                verbose=False,
+            )
+        for w in caught:
+            if "split" in str(w.message).lower():
+                is_split = True
+                break
+
+        try:
+            result: dict[str, Any] = {}
+
+            sfreq = raw.info.get("sfreq")
+            if sfreq:
+                result["sampling_frequency"] = float(sfreq)
+
+            ch_names = raw.info.get("ch_names")
+            if ch_names:
+                result["ch_names"] = list(ch_names)
+                result["nchans"] = len(ch_names)
+
+            if raw.n_times and raw.n_times > 0:
+                result["n_times"] = int(raw.n_times)
+
+            return (result if result else None), is_split
+        finally:
+            try:
+                raw.close()
+            except (OSError, AttributeError):
+                pass
+
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError, AttributeError):
+        # AttributeError: mne >=1.12 raises this from _fiff/open.py:151
+        # when reading a malformed FIF (tag is None → tag.kind crashes).
+        return None, False
+
+
+# ─── Dataclasses ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class CascadeContext:
+    """Input bundle for one cascade run; derived fields populated in ``__post_init__``."""
+
+    bids_dataset: Any
+    bids_file: str
+
+    # Derived in __post_init__.
+    bids_file_path: Path = field(init=False)
+    bids_root: Path = field(init=False)
+    ext: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.bids_file_path = Path(self.bids_file)
+        self.bids_root = Path(self.bids_dataset.bidsdir)
+        self.ext = self.bids_file_path.suffix.lower()
+
+
+@dataclass
+class CascadeResult:
+    """Accumulated output of one cascade run; ``provenance[field]`` is the first source that filled it, or ``None``."""
+
+    sampling_frequency: float | None = None
+    nchans: int | None = None
+    ntimes: int | None = None
+    ch_names: list[str] | None = None
+    fif_is_split: bool = False
+    fif_continuations_ok: bool = True
+    provenance: dict[str, str | None] = field(
+        default_factory=lambda: {f: None for f in _METADATA_FIELDS}
+    )
+
+    def stamp(self, source: str, field_name: str, old: Any, new: Any) -> None:
+        """Record ``source`` as the provenance for ``field_name`` on first write."""
+        if old is None and new is not None and self.provenance[field_name] is None:
+            self.provenance[field_name] = source
+
+
+# ─── Step Protocol + concrete implementations ─────────────────────────────
+
+
+class CascadeStep(Protocol):
+    """Protocol for cascade steps; each mutates ``result`` in-place."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None: ...
+
+
+class MneBidsStep:
+    """Step 1: ``EEGBIDSDataset`` attribute getters (mne_bids backend)."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None:
+        bd = ctx.bids_dataset
+        try:
+            sf = bd.get_bids_file_attribute("sfreq", ctx.bids_file)
+            nc = bd.get_bids_file_attribute("nchans", ctx.bids_file)
+            nt = bd.get_bids_file_attribute("ntimes", ctx.bids_file)
+        except (FileNotFoundError, OSError):
+            # Broken git-annex symlink on the BIDS sidecar JSON.
+            sf = nc = nt = None
+
+        if sf:
+            result.sampling_frequency = float(sf)
+            result.provenance["sampling_frequency"] = PROV_MNE_BIDS
+        if nc:
+            result.nchans = int(nc)
+            result.provenance["nchans"] = PROV_MNE_BIDS
+        if nt:
+            result.ntimes = int(nt)
+            result.provenance["ntimes"] = PROV_MNE_BIDS
+
+        # channel_labels reads channels.tsv via mne_bids — same provenance bucket.
+        try:
+            ch_names = bd.channel_labels(ctx.bids_file)
+        except (FileNotFoundError, OSError, ValueError, KeyError, AttributeError):
+            ch_names = None
+        if ch_names:
+            result.ch_names = ch_names
+            result.provenance["ch_names"] = PROV_MNE_BIDS
+            # channel_labels count is more complete than sidecar *ChannelCount sums;
+            # overwrite the value but only claim provenance if not yet stamped.
+            if result.provenance["nchans"] is None:
+                result.provenance["nchans"] = PROV_MNE_BIDS
+            result.nchans = len(ch_names)
+
+
+class ModalitySidecarStep:
+    """Step 2: modality JSON sidecar with BIDS-inheritance walk."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None:
+        sf_before = result.sampling_frequency
+        n_before = result.nchans
+        sf, nc = extract_sfreq_nchans_from_modality_sidecar(
+            ctx.bids_file_path, ctx.bids_root, sf_before, n_before
+        )
+        result.sampling_frequency = sf
+        result.nchans = nc
+        result.stamp(PROV_MODALITY_SIDECAR, "sampling_frequency", sf_before, sf)
+        result.stamp(PROV_MODALITY_SIDECAR, "nchans", n_before, nc)
+
+
+class ChannelsTsvStep:
+    """Step 3: ``channels.tsv`` with BIDS-inheritance walk."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None:
+        sf_before = result.sampling_frequency
+        n_before = result.nchans
+        sf, nc = extract_sfreq_nchans_from_channels_tsv(
+            ctx.bids_file_path, ctx.bids_root, sf_before, n_before
+        )
+        result.sampling_frequency = sf
+        result.nchans = nc
+        result.stamp(PROV_CHANNELS_TSV, "sampling_frequency", sf_before, sf)
+        result.stamp(PROV_CHANNELS_TSV, "nchans", n_before, nc)
+
+
+class BinaryParserStep:
+    """Step 4: per-extension binary parser via the format registry."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None:
+        parser = get_parser_for_extension(ctx.ext)
+        if parser is None:
+            return
+
+        # Skip when all four fields are already populated.
+        if (
+            result.sampling_frequency
+            and result.nchans
+            and result.ntimes
+            and result.ch_names
+        ):
+            return
+
+        md = parser(ctx.bids_file_path)
+        if not md:
+            return
+
+        sf_before = result.sampling_frequency
+        n_before = result.nchans
+        nt_before = result.ntimes
+        ch_before = result.ch_names
+
+        result.sampling_frequency = sf_before or md.get("sampling_frequency")
+        result.nchans = n_before or md.get("nchans")
+        result.ntimes = nt_before or md.get("n_times") or md.get("n_samples")
+        result.ch_names = ch_before or md.get("ch_names")
+
+        for fname, old, new in (
+            ("sampling_frequency", sf_before, result.sampling_frequency),
+            ("nchans", n_before, result.nchans),
+            ("ntimes", nt_before, result.ntimes),
+            ("ch_names", ch_before, result.ch_names),
+        ):
+            result.stamp(PROV_BINARY_PARSER, fname, old, new)
+
+
+class MneFallbackStep:
+    """Step 5: MNE fallbacks for VHDR ntimes and FIF metadata + split detection."""
+
+    def fill(self, ctx: CascadeContext, result: CascadeResult) -> None:
+        # --- VHDR: try MNE for n_times specifically (needs binary companion). ---
+        if ctx.ext == ".vhdr" and not result.ntimes:
+            raw = None
+            try:
+                raw = mne.io.read_raw_brainvision(
+                    str(ctx.bids_file_path), preload=False, verbose=False
+                )
+                if raw.n_times and raw.n_times > 0:
+                    result.ntimes = int(raw.n_times)
+                    if result.provenance["ntimes"] is None:
+                        result.provenance["ntimes"] = PROV_MNE_FALLBACK
+            except (OSError, ValueError, RuntimeError, KeyError):
+                # Missing companion file, malformed header, or unsupported variant.
+                pass
+            finally:
+                if raw is not None:
+                    try:
+                        raw.close()
+                    except (OSError, AttributeError):
+                        pass
+
+        # --- FIF: full-record fallback + split detection. ---
+        if ctx.ext == ".fif" and (
+            not result.sampling_frequency or not result.nchans or not result.ntimes
+        ):
+            fif_metadata, fif_is_split = _parse_fif_with_mne(ctx.bids_file_path)
+            result.fif_is_split = fif_is_split
+            if fif_metadata:
+                sf_before = result.sampling_frequency
+                n_before = result.nchans
+                nt_before = result.ntimes
+                ch_before = result.ch_names
+
+                result.sampling_frequency = sf_before or fif_metadata.get(
+                    "sampling_frequency"
+                )
+                result.nchans = n_before or fif_metadata.get("nchans")
+                result.ntimes = nt_before or fif_metadata.get("n_times")
+                result.ch_names = ch_before or fif_metadata.get("ch_names")
+
+                for fname, old, new in (
+                    ("sampling_frequency", sf_before, result.sampling_frequency),
+                    ("nchans", n_before, result.nchans),
+                    ("ntimes", nt_before, result.ntimes),
+                    ("ch_names", ch_before, result.ch_names),
+                ):
+                    result.stamp(PROV_MNE_FALLBACK, fname, old, new)
+
+
+# ─── Cascade runner ───────────────────────────────────────────────────────
+
+
+class MetadataCascade:
+    """Runs cascade steps in order; first writer per field wins. Inject ``steps`` in tests."""
+
+    def __init__(self, steps: tuple[CascadeStep, ...] | None = None) -> None:
+        self.steps = steps or (
+            MneBidsStep(),
+            ModalitySidecarStep(),
+            ChannelsTsvStep(),
+            BinaryParserStep(),
+            MneFallbackStep(),
+        )
+
+    def run(self, ctx: CascadeContext) -> CascadeResult:
+        result = CascadeResult()
+        for step in self.steps:
+            step.fill(ctx, result)
+        return result

--- a/scripts/ingestions/_montage.py
+++ b/scripts/ingestions/_montage.py
@@ -65,12 +65,30 @@ import hashlib
 import json
 import logging
 import re
+import struct
+import tempfile
 import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import pandas as pd
+
+try:
+    import mne
+except ImportError:  # pragma: no cover - optional dependency
+    mne = None  # type: ignore[assignment]
+
+from _file_utils import _read_annex_pointer_text, parse_annex_size
+from _parser_utils import (
+    build_s3_url,
+    extract_dataset_info,
+    fetch_bytes_from_s3,
+    head_content_length,
+    is_broken_symlink,
+)
 
 LOGGER = logging.getLogger("digest.montage")
 
@@ -83,7 +101,7 @@ _COORDSYS_PREFIXES = ("EEG", "iEEG", "MEG", "EMG", "NIRS")
 
 
 def _round_mm(v: float) -> int:
-    return int(round(v * 1000))
+    return round(v * 1000)
 
 
 def _hash_sensors(modality: str, sensors: list[dict[str, Any]]) -> str:
@@ -93,16 +111,19 @@ def _hash_sensors(modality: str, sensors: list[dict[str, Any]]) -> str:
     cap from aliasing on name + position (vanishingly unlikely, but free
     to prevent).
     """
-    canonical = [modality] + sorted(
-        (
-            s.get("name", ""),
-            _round_mm(s.get("x", 0.0)),
-            _round_mm(s.get("y", 0.0)),
-            _round_mm(s.get("z", 0.0)),
-            s.get("type", ""),
-        )
-        for s in sensors
-    )
+    canonical = [
+        modality,
+        *sorted(
+            (
+                s.get("name", ""),
+                _round_mm(s.get("x", 0.0)),
+                _round_mm(s.get("y", 0.0)),
+                _round_mm(s.get("z", 0.0)),
+                s.get("type", ""),
+            )
+            for s in sensors
+        ),
+    ]
     payload = repr(canonical).encode("utf-8")
     return hashlib.sha1(payload).hexdigest()[:16]
 
@@ -235,7 +256,10 @@ def _extract_tsv_layout(
         return None
     try:
         sensors = _parse_sensor_tsv(tsv, extras=extras)
-    except Exception as exc:  # noqa: BLE001
+    except (OSError, ValueError, KeyError, UnicodeDecodeError) as exc:
+        # _parse_sensor_tsv hits filesystem and pandas. ValueError covers
+        # NaN/Inf coord rejection; KeyError covers missing required
+        # columns; UnicodeDecodeError covers non-UTF8 TSV files.
         LOGGER.warning("[layout.%s] parse error on %s: %s", modality, tsv, exc)
         return None
     if len(sensors) < min_sensors:
@@ -265,22 +289,91 @@ def _extract_tsv_layout(
 # ---------------------------------------------------------------------------
 
 
-def extract_eeg_layout(
-    data_file: Path, bids_root: Path
-) -> tuple[str, dict[str, Any]] | None:
-    """Scalp EEG: parse ``*_electrodes.tsv`` → hash-identified doc.
+# extract_eeg_layout removed (Phase 8 P2.1). EEG's "TSV first, then
+# template-match fallback" logic is now expressed by
+# ``_TSV_MODALITY_CONFIGS["eeg"]`` having ``template_fallback=True``;
+# :func:`_extract_layout_for_config` runs the cascade.
 
-    When no ``*_electrodes.tsv`` sidecar was published for the dataset,
-    fall back to matching ``*_channels.tsv`` names against MNE's
-    built-in standard montages and emit a template-derived layout. The
-    fallback doc is tagged ``source: "template-matched"`` so downstream
-    consumers can tell subject-specific positions apart from canonical
-    vendor-cap positions.
+
+@dataclass(frozen=True)
+class _ModalityConfig:
+    """Per-modality parametrization of :func:`_extract_tsv_layout`.
+
+    The 4 TSV-based modalities (EEG, iEEG, EMG, fNIRS) differ only in
+    these knobs; collecting them as a dataclass makes "what varies per
+    modality" a single named place instead of 4 functions with bespoke
+    kwarg patterns.
+
+    Per the implicit Seam between the 4 TSV-based
+    extractors becomes explicit: each modality is a named config, the
+    dispatcher reads from a dict, ``_extract_tsv_layout`` is called once.
     """
-    direct = _extract_tsv_layout(data_file, bids_root, modality="eeg")
+
+    modality: str
+    tsv_pattern: str = "*_electrodes.tsv"
+    extras: tuple[str, ...] = ("type", "material", "impedance")
+    min_sensors: int = 4
+    coord_suffix: str = "_electrodes.tsv"
+    # EEG-only: when *_electrodes.tsv is absent, fall back to
+    # matching channel-name list against MNE's standard montages.
+    template_fallback: bool = False
+
+
+_TSV_MODALITY_CONFIGS: dict[str, _ModalityConfig] = {
+    "eeg": _ModalityConfig(
+        modality="eeg",
+        template_fallback=True,
+    ),
+    "ieeg": _ModalityConfig(
+        modality="ieeg",
+        extras=("type", "hemisphere", "material", "impedance", "group", "size"),
+        min_sensors=1,
+    ),
+    "emg": _ModalityConfig(
+        modality="emg",
+        extras=("type", "material", "impedance", "coordinate_system", "group"),
+        min_sensors=2,
+    ),
+    "nirs": _ModalityConfig(
+        modality="nirs",
+        tsv_pattern="*_optodes.tsv",
+        extras=("type", "template_x", "template_y", "template_z"),
+        min_sensors=2,
+        coord_suffix="_optodes.tsv",
+    ),
+}
+
+
+def _extract_layout_for_config(
+    data_file: Path, bids_root: Path, config: _ModalityConfig
+) -> tuple[str, dict[str, Any]] | None:
+    """Run the TSV-based pipeline for one ``_ModalityConfig``.
+
+    Phase 8 P2.1 — replaces 4 thin ``extract_<modality>_layout``
+    wrapper functions with one config-driven helper. The dispatcher
+    in :func:`extract_layout` selects the right config by datatype
+    name and calls this helper.
+
+    For configs with ``template_fallback=True`` (EEG only today), the
+    helper tries ``_extract_tsv_layout`` first, then falls back to
+    template-matching when no ``*_electrodes.tsv`` is published.
+    """
+    direct = _extract_tsv_layout(
+        data_file,
+        bids_root,
+        modality=config.modality,
+        tsv_pattern=config.tsv_pattern,
+        extras=config.extras,
+        min_sensors=config.min_sensors,
+        coord_suffix=config.coord_suffix,
+    )
     if direct is not None:
         return direct
-    return _extract_template_from_channels(data_file, bids_root, modality="eeg")
+    if config.template_fallback:
+        return _extract_template_from_channels(
+            data_file, bids_root, modality=config.modality
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -345,20 +438,28 @@ def _load_mne_templates() -> dict[str, dict[str, tuple[float, float, float]]]:
         cache: dict[str, dict[str, tuple[float, float, float]]] = {}
 
         # Pool 1 — MNE built-ins. These land keyed by MNE's canonical name.
-        try:
-            import mne  # type: ignore
-
-            for name in mne.channels.get_builtin_montages():
+        if mne is None:
+            LOGGER.warning("[template] mne not installed; pool 1 empty")
+        else:
+            try:
+                builtin_names = mne.channels.get_builtin_montages()
+            except AttributeError as exc:
+                # AttributeError: a future MNE refactor removed
+                # get_builtin_montages.
+                LOGGER.warning("[template] MNE API change (%s); pool 1 empty", exc)
+                builtin_names = []
+            for name in builtin_names:
                 try:
                     m = mne.channels.make_standard_montage(name)
                     cache[name] = {
                         k.upper(): (float(v[0]), float(v[1]), float(v[2]))
                         for k, v in m.get_positions()["ch_pos"].items()
                     }
-                except Exception:  # noqa: BLE001 — skip anything MNE can't build here
+                except (ValueError, KeyError, TypeError, AttributeError):
+                    # MNE can raise on a misnamed standard montage or an
+                    # unexpected positions dict shape. Skip that template;
+                    # the other 50+ will still populate.
                     continue
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("[template] MNE import failed (%s); pool 1 empty", exc)
 
         # Pool 2 — the electrode-explorer extras. montages.json stores each
         # position in meters already (xyz is centred on the fitted head
@@ -438,7 +539,16 @@ def _parse_channels_tsv_for_eeg(path: Path) -> list[str]:
     """
     try:
         df = pd.read_csv(path, sep="\t", dtype=str, na_values=["n/a", "N/A", ""])
-    except Exception:
+    except (
+        OSError,
+        pd.errors.ParserError,
+        pd.errors.EmptyDataError,
+        UnicodeDecodeError,
+        ValueError,
+    ):
+        # channels.tsv absent, malformed, non-UTF8, or empty. Empty
+        # channel list lets the caller fall back to inferring from the
+        # binary header.
         return []
     if "name" not in df.columns:
         return []
@@ -568,22 +678,10 @@ def _extract_template_from_channels(
 # ---------------------------------------------------------------------------
 
 
-def extract_ieeg_layout(
-    data_file: Path, bids_root: Path
-) -> tuple[str, dict[str, Any]] | None:
-    """Intracranial EEG: positions in brain space (no radius sanity).
-
-    The 2D sphere viewer can't render these today, but cataloguing the
-    hash still deduplicates identical grids across subjects for future
-    glass-brain viewers.
-    """
-    return _extract_tsv_layout(
-        data_file,
-        bids_root,
-        modality="ieeg",
-        extras=("type", "hemisphere", "material", "impedance", "group", "size"),
-        min_sensors=1,
-    )
+# extract_ieeg_layout removed (Phase 8 P2.1) — its body was a thin
+# wrapper over ``_extract_tsv_layout``. The kwargs now live in
+# ``_TSV_MODALITY_CONFIGS["ieeg"]`` and the dispatcher in
+# :func:`extract_layout` invokes ``_extract_layout_for_config``.
 
 
 # ---------------------------------------------------------------------------
@@ -632,11 +730,6 @@ def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str 
     populate just the metadata prefix, and let MNE seek-but-not-read
     the raw-data tail (it's zeros, which MNE skips).
     """
-    import struct  # noqa: PLC0415
-    import tempfile  # noqa: PLC0415
-
-    from _parser_utils import fetch_bytes_from_s3  # noqa: PLC0415
-
     # Try progressively larger buffers. 306-channel Neuromag files end
     # their MEAS_INFO around 3-8 MB; 4 MB covers most, 16 MB is a safe
     # backstop for dense HPI + isotrak + long comments.
@@ -697,7 +790,9 @@ def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str 
                 total / (1024 * 1024),
             )
             return tmp.name
-        except Exception as exc:  # noqa: BLE001
+        except (OSError, ValueError) as exc:
+            # Filesystem failure on the tempfile write, or malformed
+            # input bytes triggering the truncation logic.
             LOGGER.debug("[layout.meg] streaming stitch %s failed: %s", url, exc)
             try:
                 Path(tmp.name).unlink()
@@ -712,6 +807,31 @@ def _fetch_fif_metadata_streaming(data_file: Path, url: str, total: int) -> str 
         url,
     )
     return None
+
+
+def _resolve_fif_total_size(data_file: Path, url: str) -> int | None:
+    """Discover the FIF total size, preferring the annex symlink over a HEAD.
+
+    OpenNeuro / NEMAR FIF files are git-annex-managed; the size is
+    encoded in the symlink target (``MD5E-s{size}--{hash}.fif``).
+    Reading the symlink avoids the HTTPS HEAD round-trip that
+    dominated the MEG digest profile before pooling landed.
+
+    Falls back to :func:`head_content_length` when:
+      - the file isn't an annex symlink (Zenodo / Figshare raw URLs);
+      - the annex key doesn't follow the MD5E/SHA256E size convention;
+      - the parsed size is zero (impossible for a real FIF — treat
+        as malformed key and probe the wire).
+
+    Returns ``None`` if both paths fail; caller treats that as a
+    transient network failure.
+    """
+    text = _read_annex_pointer_text(data_file)
+    if text is not None and "/annex/" in text:
+        annex_size = parse_annex_size(text)
+        if annex_size is not None and annex_size > 0:
+            return annex_size
+    return head_content_length(url, timeout=30.0)
 
 
 def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
@@ -748,13 +868,8 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
     Returns ``None`` when the file lacks a usable directory (streaming-
     only FIF) or the fetch fails.
     """
-    import struct  # noqa: PLC0415
-    import tempfile  # noqa: PLC0415
-
-    from _parser_utils import fetch_bytes_from_s3, head_content_length  # noqa: PLC0415
-
-    # 1. Total size
-    total = head_content_length(url, timeout=30.0)
+    # 1. Total size — prefer the annex symlink key over a HEAD round-trip.
+    total = _resolve_fif_total_size(data_file, url)
     if total is None or total <= 0:
         return None
 
@@ -847,7 +962,9 @@ def _fetch_fif_metadata_via_directory(data_file: Path, url: str) -> str | None:
             len(merged),
         )
         return tmp.name
-    except Exception as exc:  # noqa: BLE001
+    except (OSError, ValueError, KeyError) as exc:
+        # Range-request stitch: OSError on tempfile write, ValueError on
+        # truncation arithmetic, KeyError on malformed range metadata.
         LOGGER.debug("[layout.meg] range stitch %s failed: %s", url, exc)
         try:
             Path(tmp.name).unlink()
@@ -874,11 +991,7 @@ def extract_meg_layout(
     ``_fetch_fif_metadata_via_directory``: only metadata tags come
     over the wire (~7 MB for a 2 GB recording).
     """
-    # Import MNE lazily so this module's other entry points keep working
-    # even when MNE isn't installed (rare, but possible in minimal envs).
-    try:
-        import mne
-    except ImportError:
+    if mne is None:
         LOGGER.warning("[layout.meg] mne not available; skipping %s", data_file)
         return None
 
@@ -906,7 +1019,16 @@ def extract_meg_layout(
             else:
                 LOGGER.info("[layout.meg] unrecognized MEG format: %s", data_file)
                 return None
-        except Exception as direct_exc:  # noqa: BLE001
+        except (
+            OSError,
+            ValueError,
+            RuntimeError,
+            KeyError,
+            AttributeError,
+        ) as direct_exc:
+            # MNE raises RuntimeError on unsupported format variant,
+            # ValueError on truncated/malformed header, OSError on file
+            # not found / permission, KeyError on missing required field.
             LOGGER.debug(
                 "[layout.meg] direct read %s failed: %s", data_file, direct_exc
             )
@@ -916,11 +1038,6 @@ def extract_meg_layout(
             # investigated yet.
             if suffix != ".fif":
                 return None
-            from _parser_utils import (  # noqa: PLC0415
-                build_s3_url,
-                extract_dataset_info,
-                is_broken_symlink,
-            )
 
             # Only chase S3 for files that really are broken annex pointers.
             if not is_broken_symlink(data_file) and data_file.exists():
@@ -943,7 +1060,9 @@ def extract_meg_layout(
                 return None
             try:
                 info = mne.io.read_info(tmp_path, verbose="error")
-            except Exception as partial_exc:  # noqa: BLE001
+            except (OSError, ValueError, RuntimeError, KeyError) as partial_exc:
+                # Same MNE failure classes; the reconstructed FIF stub
+                # may still be malformed for various reasons.
                 LOGGER.info(
                     "[layout.meg] %s: directory-reconstructed FIF still "
                     "unparsable (%s)",
@@ -955,7 +1074,9 @@ def extract_meg_layout(
         if raw is not None:
             try:
                 raw.close()
-            except Exception:
+            except (OSError, AttributeError):
+                # OSError: already-closed. AttributeError: not an MNE
+                # Raw (defensive guard).
                 pass
         if tmp_path:
             try:
@@ -1032,31 +1153,11 @@ def extract_meg_layout(
 # ---------------------------------------------------------------------------
 
 
-def extract_emg_layout(
-    data_file: Path, bids_root: Path
-) -> tuple[str, dict[str, Any]] | None:
-    """Surface EMG: parse ``*_electrodes.tsv`` with body-landmark frames.
-
-    EMG differs from the scalp modalities in three ways worth knowing:
-
-    1. **Anatomical coordinate systems** — positions live in body-part
-       frames (e.g. HySER's ``ExtensorDistal`` / ``forearm``), not on a
-       head sphere. Hash dedupes across subjects; the 2D sphere viewer
-       can't render.
-    2. **Non-length units** — ``EMGCoordinateUnits`` is often
-       ``"percent"`` (normalised to anatomical landmarks). Preserved
-       verbatim; viewers that need mm must supply calibration.
-    3. **Per-row coordinate system** — one TSV can mix frames via the
-       optional ``coordinate_system`` column (HySER: 4 muscles × 64
-       electrodes in one file). Preserved on each sensor.
-    """
-    return _extract_tsv_layout(
-        data_file,
-        bids_root,
-        modality="emg",
-        extras=("type", "material", "impedance", "coordinate_system", "group"),
-        min_sensors=2,
-    )
+# extract_emg_layout removed (Phase 8 P2.1). EMG kwargs documented:
+# anatomical coord systems (HySER ExtensorDistal etc.), per-row
+# coordinate_system column, often percent units. All preserved in
+# ``_TSV_MODALITY_CONFIGS["emg"]``. See the config above for the
+# extras tuple including ``coordinate_system`` and ``group``.
 
 
 # ---------------------------------------------------------------------------
@@ -1064,39 +1165,15 @@ def extract_emg_layout(
 # ---------------------------------------------------------------------------
 
 
-def extract_fnirs_layout(
-    data_file: Path, bids_root: Path
-) -> tuple[str, dict[str, Any]] | None:
-    """fNIRS: parse ``*_optodes.tsv`` for source/detector positions.
-
-    ``*_channels.tsv`` declares source+detector pairings per measurement
-    channel; we don't decode the pairing here (keeps hash stable across
-    upstream channel-name churn). The optode ``type`` column is kept so
-    the viewer can distinguish sources from detectors.
-    """
-    return _extract_tsv_layout(
-        data_file,
-        bids_root,
-        modality="nirs",
-        tsv_pattern="*_optodes.tsv",
-        extras=("type", "template_x", "template_y", "template_z"),
-        min_sensors=2,
-        coord_suffix="_optodes.tsv",
-    )
+# extract_fnirs_layout removed (Phase 8 P2.1). fNIRS reads
+# ``*_optodes.tsv`` (not _electrodes.tsv) — that's the only thing
+# that distinguishes it from the other TSV modalities. See
+# ``_TSV_MODALITY_CONFIGS["nirs"]`` for the per-modality kwargs.
 
 
 # ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
-
-_DISPATCH = {
-    "eeg": extract_eeg_layout,
-    "ieeg": extract_ieeg_layout,
-    "meg": extract_meg_layout,
-    "emg": extract_emg_layout,
-    "nirs": extract_fnirs_layout,
-    "fnirs": extract_fnirs_layout,  # some older datasets use this token
-}
 
 
 def extract_layout(
@@ -1106,10 +1183,24 @@ def extract_layout(
 ) -> tuple[str, dict[str, Any]] | None:
     """Dispatch to the right per-modality extractor.
 
-    Returns ``None`` for unsupported datatypes (EMG, beh, etc.) so the
+    Phase 8 P2.1 — the dispatch now reads from
+    :data:`_TSV_MODALITY_CONFIGS` for the 4 TSV-based modalities
+    (EEG, iEEG, EMG, fNIRS). MEG remains a special case (sensor
+    positions in the FIF header, not a sidecar — ~190 LOC of header
+    streaming logic in :func:`extract_meg_layout`).
+
+    Returns ``None`` for unsupported datatypes (beh, etc.) so the
     caller can simply record ``layout_hash = None`` and move on.
+
+    Note: ``"fnirs"`` is accepted as an alias for ``"nirs"`` — some
+    older datasets use it as the datatype name.
     """
-    fn = _DISPATCH.get((datatype or "").lower())
-    if fn is None:
+    dt = (datatype or "").lower()
+    if dt == "meg":
+        return extract_meg_layout(data_file, bids_root)
+    if dt == "fnirs":  # alias for nirs in some older datasets
+        dt = "nirs"
+    config = _TSV_MODALITY_CONFIGS.get(dt)
+    if config is None:
         return None
-    return fn(data_file, bids_root)
+    return _extract_layout_for_config(data_file, bids_root, config)

--- a/scripts/ingestions/_parser_utils.py
+++ b/scripts/ingestions/_parser_utils.py
@@ -3,18 +3,146 @@
 This module provides shared functionality for validating file paths,
 reading files with encoding fallback, and fetching from S3 for
 git-annex symlinks.
+
+HTTP path note (2026-05-22, hardened post-review)
+-------------------------------------------------
+The three S3 helpers (``fetch_bytes_from_s3``, ``head_content_length``,
+``fetch_from_s3``) used to call ``urllib.request.urlopen`` directly.
+The Stage-3 profile run of 2026-05-22 showed that the MEG montage
+extractor calls ``head_content_length`` ~100x per dataset, and that
+91% of the digest wall-clock went to TLS handshake / connect / read
+for those serialised, unpooled requests.
+
+This module lazy-initialises a single shared :class:`httpx.Client`
+per process (``_http_client()``), keeping connections alive across
+calls to the same host. After the post-perf code-review the
+implementation also:
+
+* Acquires the same lock for read/return AND for close, so concurrent
+  ``reset_http_client_for_testing()`` callers cannot return a freshly-
+  closed client to a sibling thread.
+* Catches ``RuntimeError`` (httpx raises it on use-after-close) in
+  addition to ``httpx.HTTPError`` — keeps the documented
+  "returns None on any network or protocol failure" contract.
+* Registers the atexit hook exactly once per interpreter via a
+  module-level flag — avoids unbounded handler accumulation when
+  tests call ``reset_http_client_for_testing()`` between rounds.
+* Registers an ``os.register_at_fork`` child-side reset so a Linux
+  fork (default mp start-method) cannot inherit live sockets from
+  the parent.
+* Uses ``client.stream("GET", ...)`` for the byte-range path so a
+  server that ignores ``Range`` (returning 200 with the full body)
+  is bounded to ``max_bytes`` and the pool slot is released
+  immediately.
+
+Tests use ``respx`` to mock the httpx transport at the transport
+layer (same library + decorator as ``_inject_config.py``; pooling
+semantics differ — that module uses per-call ``with httpx.Client(...)``).
 """
 
 from __future__ import annotations
 
+import atexit
 import logging
+import os
 import re
-import urllib.request
+import threading
 from pathlib import Path
-from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 
+import httpx
+
 logger = logging.getLogger(__name__)
+
+
+# ─── Pooled httpx client (shared across all S3 helpers) ───────────────────
+
+# httpx.Client is thread-safe for synchronous use (per docs). The
+# Stage-2 clone uses ThreadPoolExecutor → one client is fine. The
+# Stage-3 digest uses ``mp.get_context()`` (which defaults to fork on
+# Linux) → child processes inherit the parent's client; we register
+# an at-fork hook that resets the child-side client to None so a
+# warmed parent pool doesn't share sockets across fork.
+
+_HTTP_CLIENT: httpx.Client | None = None
+_HTTP_CLIENT_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False  # register the atexit hook exactly once
+
+
+def _http_client() -> httpx.Client:
+    """Return the lazily-initialised shared HTTP client.
+
+    Pooled keep-alive connections (default httpx settings) eliminate the
+    per-request TLS handshake overhead. The full body of the function
+    runs under ``_HTTP_CLIENT_LOCK`` so a concurrent
+    ``reset_http_client_for_testing()`` cannot null/close the cached
+    instance between the read and the return.
+    """
+    global _HTTP_CLIENT, _ATEXIT_REGISTERED
+    with _HTTP_CLIENT_LOCK:
+        if _HTTP_CLIENT is None:
+            _HTTP_CLIENT = httpx.Client(
+                timeout=httpx.Timeout(30.0),
+                limits=httpx.Limits(
+                    max_keepalive_connections=20,
+                    max_connections=40,
+                    keepalive_expiry=60.0,
+                ),
+                follow_redirects=True,
+                http2=True,  # multiplex concurrent HEADs over one connection
+            )
+            if not _ATEXIT_REGISTERED:
+                atexit.register(_close_http_client)
+                _ATEXIT_REGISTERED = True
+        return _HTTP_CLIENT
+
+
+def _close_http_client() -> None:
+    """Test helper + atexit hook to release the pooled client.
+
+    Acquires the same lock the readers use so a concurrent
+    ``_http_client()`` caller cannot observe a half-state where
+    ``_HTTP_CLIENT`` is non-None but ``client.close()`` has run.
+    """
+    global _HTTP_CLIENT
+    with _HTTP_CLIENT_LOCK:
+        client = _HTTP_CLIENT
+        _HTTP_CLIENT = None
+    if client is not None:
+        try:
+            client.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Error closing httpx client at shutdown: %s", exc)
+
+
+def _reset_http_client_after_fork_child() -> None:
+    """``os.register_at_fork`` child-side hook.
+
+    A forked child inherits the parent's ``_HTTP_CLIENT`` reference
+    but the underlying TCP / TLS sockets are also shared (file
+    descriptors). If both parent and child use the same socket the
+    HTTP frame stream interleaves. We drop the inherited client
+    reference WITHOUT calling ``close()`` (closing in the child
+    would tear down the parent's sockets too).
+    """
+    global _HTTP_CLIENT, _ATEXIT_REGISTERED
+    _HTTP_CLIENT = None
+    _ATEXIT_REGISTERED = False
+
+
+try:  # ``os.register_at_fork`` only exists on POSIX
+    os.register_at_fork(after_in_child=_reset_http_client_after_fork_child)
+except AttributeError:  # pragma: no cover — Windows
+    pass
+
+
+def reset_http_client_for_testing() -> None:
+    """Drop the cached client so the next call rebuilds it.
+
+    Tests that use respx may want to inspect call counts on a fresh
+    transport; this resets the singleton so respx hooks land cleanly.
+    """
+    _close_http_client()
 
 
 def is_broken_symlink(path: Path) -> bool:
@@ -121,7 +249,7 @@ def fetch_bytes_from_s3(
     max_bytes: int = 262144,
     timeout: float = 30.0,
 ) -> bytes | None:
-    """Range-fetch ``max_bytes`` starting at ``start`` from an S3 object.
+    """Range-fetch up to ``max_bytes`` starting at ``start`` from an S3 object.
 
     Used to pull MEG FIF / KIT SQD headers without downloading the full
     multi-GB recording. S3 always supports ``Range: bytes=start-end`` —
@@ -130,55 +258,79 @@ def fetch_bytes_from_s3(
     → ``FIFFB_MEAS_INFO`` → channel info blocks, usually well under
     256 KB even for 500-channel recordings.
 
+    Uses the shared :func:`_http_client` and ``client.stream`` so a
+    server that ignores ``Range`` and returns 200 with the full body
+    is bounded — the returned slice is at most ``max_bytes`` and the
+    pooled connection is released as soon as we hit the cap. (Older
+    revisions returned the full body and held the pool slot for the
+    duration; the post-review hardening caps the read.)
+
     Returns the raw byte slice on success, ``None`` on any network or
     protocol failure (caller decides whether to retry with a larger
     ``max_bytes``).
     """
     end = int(start) + int(max_bytes) - 1
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Range": f"bytes={int(start)}-{end}",
-            "Accept": "*/*",
-        },
-    )
+    headers = {
+        "Range": f"bytes={int(start)}-{end}",
+        "Accept": "*/*",
+    }
     logger.debug("Range-fetching bytes=%d-%d from %s", start, end, url)
+    # Stream the response so a server that ignores Range and returns
+    # 200 with the full body cannot OOM the worker or hold the pooled
+    # connection for an arbitrarily large download — we cap at
+    # ``max_bytes`` and release the slot immediately.
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            # Servers that don't honour Range return 200 with the full
-            # body; accept both but log when we got more than asked.
-            data = resp.read()
-            if len(data) > max_bytes:
-                logger.debug(
-                    "server ignored Range; got %d bytes (asked %d) from %s",
-                    len(data),
-                    max_bytes,
-                    url,
-                )
-            return data
-    except HTTPError as e:
-        logger.debug("HTTP error range-fetching %s: %s", url, e)
-        return None
-    except URLError as e:
-        logger.debug("URL error range-fetching %s: %s", url, e)
-        return None
-    except (TimeoutError, OSError) as e:
-        logger.debug("Network error range-fetching %s: %s", url, e)
+        with _http_client().stream(
+            "GET", url, headers=headers, timeout=timeout
+        ) as resp:
+            resp.raise_for_status()
+            chunks: list[bytes] = []
+            received = 0
+            cap = int(max_bytes) + 1  # +1 so we can detect over-cap reads
+            for chunk in resp.iter_bytes():
+                if not chunk:
+                    continue
+                chunks.append(chunk)
+                received += len(chunk)
+                if received >= cap:
+                    logger.debug(
+                        "server ignored Range; truncating at %d bytes from %s",
+                        max_bytes,
+                        url,
+                    )
+                    break
+            data = b"".join(chunks)
+        if len(data) > max_bytes:
+            data = data[:max_bytes]
+        return data
+    except (httpx.HTTPError, RuntimeError) as e:
+        # RuntimeError covers httpx's "client has been closed" race
+        # (see _close_http_client). HTTPError covers transport,
+        # timeout, status, and decode errors.
+        logger.debug("HTTP/network error range-fetching %s: %s", url, e)
         return None
 
 
 def head_content_length(url: str, *, timeout: float = 30.0) -> int | None:
     """Issue a HEAD request and return ``Content-Length`` as int.
 
+    Uses the shared :func:`_http_client` (pooled keep-alive). The
+    Stage-3 profile of 2026-05-22 showed this function is called ~100x
+    per MEG dataset (one per FIF montage source); each call previously
+    opened a fresh TLS connection. Sharing one client across calls
+    yields the ~5x speedup the profile report quotes.
+
     Returns ``None`` on any network failure or when the header is absent.
     """
     try:
-        with urllib.request.urlopen(
-            urllib.request.Request(url, method="HEAD"), timeout=timeout
-        ) as resp:
-            raw = resp.headers.get("Content-Length")
-            return int(raw) if raw is not None else None
-    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as exc:
+        resp = _http_client().head(url, timeout=timeout)
+        resp.raise_for_status()
+        raw = resp.headers.get("Content-Length")
+        return int(raw) if raw is not None else None
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        # RuntimeError covers httpx's "client has been closed" race
+        # (see _close_http_client). HTTPError covers transport,
+        # timeout, status. ValueError covers the int() parse.
         logger.debug("HEAD %s failed: %s", url, exc)
         return None
 
@@ -189,6 +341,9 @@ def fetch_from_s3(
     encodings: tuple[str, ...] = ("utf-8", "latin-1", "cp1252"),
 ) -> str | None:
     """Fetch text content from an S3 URL.
+
+    Uses the shared :func:`_http_client` (pooled keep-alive). Tries each
+    encoding in order; returns the first that decodes the body cleanly.
 
     Parameters
     ----------
@@ -202,36 +357,83 @@ def fetch_from_s3(
     Returns
     -------
     str | None
-        File content as string, or None if fetch fails.
-
+        File content as string, or None if fetch or decode fails.
     """
     logger.debug("Fetching from S3: %s", url)
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as response:
-            content_bytes = response.read()
+        resp = _http_client().get(url, timeout=timeout)
+        resp.raise_for_status()
+        content_bytes = resp.content
+    except (httpx.HTTPError, RuntimeError) as e:
+        # RuntimeError covers httpx's "client has been closed" race
+        # (see _close_http_client).
+        logger.debug("HTTP/network error fetching from S3: %s - %s", url, e)
+        return None
 
-            # Try each encoding
-            for encoding in encodings:
-                try:
-                    content = content_bytes.decode(encoding)
-                    logger.debug(
-                        "Successfully fetched %d bytes from S3", len(content_bytes)
-                    )
-                    return content
-                except UnicodeDecodeError:
-                    continue
+    for encoding in encodings:
+        try:
+            content = content_bytes.decode(encoding)
+            logger.debug("Successfully fetched %d bytes from S3", len(content_bytes))
+            return content
+        except UnicodeDecodeError:
+            continue
 
-            logger.warning("Failed to decode S3 content with any encoding: %s", url)
-            return None
-    except HTTPError as e:
-        logger.debug("HTTP error fetching from S3: %s - %s", url, e)
-        return None
-    except URLError as e:
-        logger.debug("URL error fetching from S3: %s - %s", url, e)
-        return None
-    except (TimeoutError, OSError) as e:
-        logger.debug("Network error fetching from S3: %s - %s", url, e)
-        return None
+    logger.warning("Failed to decode S3 content with any encoding: %s", url)
+    return None
+
+
+def path_is_within_root(path: Path | str, root: Path | str) -> bool:
+    """Return True if ``path`` resolves inside ``root``.
+
+    Defense-in-depth helper for path-traversal containment. Resolves
+    both arguments to absolute paths and tests that the result of
+    ``path`` is a sub-path of ``root``. Symlinks are followed, so a
+    symlink-out-of-tree fails the check.
+
+    Parameters
+    ----------
+    path : Path or str
+        Candidate file or directory path.
+    root : Path or str
+        Trusted root directory that ``path`` must remain inside.
+
+    Returns
+    -------
+    bool
+        True if ``path`` is structurally contained in ``root`` AND both
+        resolve without OS-level error. False otherwise — including
+        when either side cannot be resolved (e.g. permission denied on
+        an ancestor directory).
+
+    Notes
+    -----
+    Internal trust model: paths from a manifest the pipeline itself
+    built are already trusted; this helper
+    exists so a future code path that accepts a user-supplied sidecar
+    reference (BIDS ``IntendedFor``, ``.vhdr`` ``DataFile=``, etc.) can
+    cheaply gate it.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> root = Path("/data/ds002893").resolve()
+    >>> path_is_within_root(root / "sub-01" / "eeg" / "x.set", root)
+    True
+    >>> path_is_within_root(root / ".." / "ds_other" / "x.set", root)
+    False
+    """
+    try:
+        p = Path(path).resolve()
+        r = Path(root).resolve()
+    except (OSError, RuntimeError):
+        return False
+    try:
+        # is_relative_to landed in 3.9 — we target 3.10+ per pyproject.
+        return p.is_relative_to(r)
+    except (AttributeError, ValueError):
+        # AttributeError: not reachable under py3.9+; defensive.
+        # ValueError: shouldn't fire here but matches the docs contract.
+        return False
 
 
 def validate_file_path(path: Path) -> bool:

--- a/scripts/ingestions/_serialize.py
+++ b/scripts/ingestions/_serialize.py
@@ -63,7 +63,8 @@ def extract_subjects_count(description: str | None) -> int:
     Args:
         description: Text description that may contain subject count info
 
-    Returns:
+    Returns
+    -------
         Extracted subject count, or 0 if not found
 
     """
@@ -95,7 +96,8 @@ def extract_surname(author_name: str) -> str | None:
     Args:
         author_name: Author name in various formats
 
-    Returns:
+    Returns
+    -------
         Extracted surname or None if extraction fails
 
     """
@@ -156,7 +158,8 @@ def extract_year(date_string: str | None) -> str | None:
     Args:
         date_string: Date string in various formats
 
-    Returns:
+    Returns
+    -------
         Four-digit year string or None
 
     """
@@ -179,7 +182,8 @@ def generate_dataset_id(
 ) -> str:
     """Generate a dataset ID in SurnameYEAR format.
 
-    Examples:
+    Examples
+    --------
     - ["John Smith"], "2024-01-15" -> "Smith2024"
     - ["Alice Johnson", "Bob Brown"], "2023" -> "Johnson2023"
     - No authors, "2024" with fallback="12345" -> "figshare_12345"
@@ -191,7 +195,8 @@ def generate_dataset_id(
         fallback_id: Fallback ID to use if SurnameYEAR cannot be generated
         index: Optional index to append for disambiguation (e.g., "Smith2024_2")
 
-    Returns:
+    Returns
+    -------
         Dataset ID in SurnameYEAR format or source_fallback format
 
     """
@@ -236,7 +241,8 @@ def deduplicate_dataset_ids(datasets: list[dict[str, Any]]) -> list[dict[str, An
     Args:
         datasets: List of dataset dictionaries with dataset_id field
 
-    Returns:
+    Returns
+    -------
         List with deduplicated dataset_id values
 
     """
@@ -283,7 +289,8 @@ def normalize_dataset(dataset: dict[str, Any]) -> dict[str, Any]:
     Args:
         dataset: Dataset dictionary to normalize
 
-    Returns:
+    Returns
+    -------
         Normalized dataset dictionary
 
     """

--- a/scripts/ingestions/_set_parser.py
+++ b/scripts/ingestions/_set_parser.py
@@ -16,7 +16,20 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from _parser_utils import validate_file_path
+
 logger = logging.getLogger(__name__)
+
+# scipy's MatReadError isn't in the public io namespace, but it's the
+# canonical class raised for truncated/corrupt MAT files. Importing it
+# lazily so an environment without scipy still loads this module —
+# falling back to a no-op base class so the `except` below is harmless.
+try:
+    from scipy.io.matlab._miobase import MatReadError as _MatReadError
+except ImportError:  # pragma: no cover — scipy unavailable
+
+    class _MatReadError(Exception):
+        pass
 
 
 def parse_set_metadata(set_path: Path | str) -> dict[str, Any] | None:
@@ -51,7 +64,11 @@ def parse_set_metadata(set_path: Path | str) -> dict[str, Any] | None:
     """
     set_path = Path(set_path)
 
-    if not set_path.exists():
+    # Use the shared validate_file_path so .set files behind broken
+    # git-annex symlinks are handled consistently
+    # with the other parsers (previously this just called .exists()
+    # which returns True for broken symlinks pointing into git-annex).
+    if not validate_file_path(set_path):
         return None
 
     result: dict[str, Any] = {}
@@ -123,7 +140,12 @@ def parse_set_metadata(set_path: Path | str) -> dict[str, Any] | None:
                         # Update nchans if not set
                         if "nchans" not in result:
                             result["nchans"] = len(ch_names)
-                except Exception as e:
+                except (AttributeError, IndexError, TypeError, ValueError) as e:
+                    # .chanlocs is an arbitrary MATLAB structure — any of
+                    # these mean the labels field isn't shaped like we
+                    # expect. Recoverable: we just skip channel-name
+                    # extraction and let downstream callers fall back to
+                    # synthesised names.
                     logger.debug("Could not extract channel names: %s", e)
 
             # Check for external data file reference
@@ -144,8 +166,24 @@ def parse_set_metadata(set_path: Path | str) -> dict[str, Any] | None:
 
     except ImportError:
         logger.debug("scipy not available for .set parsing")
-    except Exception as e:
+    except (
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+        IndexError,
+        NotImplementedError,
+    ) as e:
+        # `scipy.io.loadmat` raises NotImplementedError on MAT-v7.3 (HDF5)
+        # files, which is the trigger for our h5py fallback below. The
+        # other classes cover: OSError (file not found / unreadable),
+        # ValueError (truncated or wrong magic), KeyError (missing 'EEG'
+        # struct in the .set), TypeError (unexpected MATLAB field shape).
         logger.debug("scipy.io.loadmat failed: %s", e)
+    except _MatReadError as e:
+        # MatReadError is scipy's own class. Imported lazily below the
+        # try so the import isn't required when scipy is missing.
+        logger.debug("scipy.io.loadmat: corrupted MAT file: %s", e)
 
     # Try h5py for HDF5-based .set files (newer EEGLAB format)
     try:
@@ -183,7 +221,12 @@ def parse_set_metadata(set_path: Path | str) -> dict[str, Any] | None:
 
     except ImportError:
         logger.debug("h5py not available for .set parsing")
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
+        # h5py raises OSError for "not an HDF5 file" (which happens on
+        # every MAT-v5 .set), ValueError for malformed datasets, and
+        # KeyError when navigating an unexpected struct layout. None
+        # of these are programmer bugs — log and fall through to the
+        # 'return None or partial result' tail.
         logger.debug("h5py parsing failed: %s", e)
 
     return None if not result else result

--- a/scripts/ingestions/_snirf_parser.py
+++ b/scripts/ingestions/_snirf_parser.py
@@ -8,17 +8,30 @@ Reference: https://github.com/fNIRS/snirf
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
+try:
+    import h5py
+except ImportError:  # pragma: no cover - optional dependency
+    h5py = None  # type: ignore[assignment]
+
+try:
+    from mne.io import read_raw_snirf
+except ImportError:  # pragma: no cover - optional dependency
+    read_raw_snirf = None  # type: ignore[assignment]
+
 from _parser_utils import validate_file_path
+
+logger = logging.getLogger(__name__)
 
 
 def parse_snirf_metadata(snirf_path: Path | str) -> dict[str, Any] | None:
     """Parse metadata from SNIRF file using MNE.
 
-    Extracts sampling frequency, number of channels, and channel names
-    from a SNIRF file.
+    Extracts sampling frequency, number of channels, channel names,
+    and recording length from a SNIRF file.
 
     Parameters
     ----------
@@ -32,8 +45,16 @@ def parse_snirf_metadata(snirf_path: Path | str) -> dict[str, Any] | None:
         - sampling_frequency: float (in Hz)
         - nchans: int
         - ch_names: list[str]
+        - n_times: int (sample count along the time axis)
         Returns None if file cannot be parsed.
 
+    Notes
+    -----
+     (C5.1 pattern): ``n_times`` was added after
+    a real OpenNeuro fixture (ds007554) surfaced the gap. The synthetic
+    h5py fixture validated the parser against itself; the real one
+    revealed that ``raw.n_times`` (MNE) / ``len(time)`` (h5py fallback)
+    were never read.
     """
     snirf_path = Path(snirf_path)
 
@@ -41,9 +62,10 @@ def parse_snirf_metadata(snirf_path: Path | str) -> dict[str, Any] | None:
     if not validate_file_path(snirf_path):
         return None
 
-    try:
-        from mne.io import read_raw_snirf  # noqa: PLC0415 (optional dependency)
+    if read_raw_snirf is None:
+        return _parse_snirf_with_h5py(snirf_path)
 
+    try:
         # Read SNIRF file with MNE (preload=False to avoid loading data)
         raw = read_raw_snirf(str(snirf_path), preload=False, verbose=False)
         try:
@@ -58,7 +80,15 @@ def parse_snirf_metadata(snirf_path: Path | str) -> dict[str, Any] | None:
             ch_names = raw.info.get("ch_names")
             if ch_names:
                 result["ch_names"] = list(ch_names)
-                result["nchans"] = int(len(ch_names))
+                result["nchans"] = len(ch_names)
+
+            # Extract recording length.
+            # ``raw.n_times`` is always populated on a successfully-read
+            # MNE Raw — but defensive-guard against subclasses where it
+            # could be 0 or missing (e.g. truncated SNIRF stubs).
+            n_times = getattr(raw, "n_times", None)
+            if n_times and n_times > 0:
+                result["n_times"] = int(n_times)
 
             if not result:
                 return None
@@ -67,14 +97,18 @@ def parse_snirf_metadata(snirf_path: Path | str) -> dict[str, Any] | None:
         finally:
             try:
                 raw.close()
-            except Exception:
+            except (OSError, AttributeError):
+                # OSError from already-closed file; AttributeError if `raw`
+                # wasn't a real MNE object (unlikely but defensive).
                 pass
 
-    except ImportError:
-        # MNE not available, try fallback h5py parser
-        return _parse_snirf_with_h5py(snirf_path)
-    except Exception:
-        # MNE failed, try fallback
+    except (OSError, ValueError, KeyError, RuntimeError) as e:
+        # MNE's SNIRF reader raises RuntimeError on unsupported variants,
+        # OSError on file-system issues, ValueError on schema mismatch,
+        # KeyError on missing fields. All recoverable; the h5py fallback
+        # catches a different subset, so retrying via the fallback is
+        # cheap and worth doing.
+        logger.debug("MNE SNIRF parse failed for %s: %s — trying h5py", snirf_path, e)
         return _parse_snirf_with_h5py(snirf_path)
 
 
@@ -92,9 +126,7 @@ def _parse_snirf_with_h5py(snirf_path: Path) -> dict[str, Any] | None:
         Parsed metadata or None.
 
     """
-    try:
-        import h5py  # noqa: PLC0415 (optional dependency)
-    except ImportError:
+    if h5py is None:
         return None
 
     result: dict[str, Any] = {}
@@ -111,13 +143,18 @@ def _parse_snirf_with_h5py(snirf_path: Path) -> dict[str, Any] | None:
             if nirs_group is None:
                 return None
 
-            # Extract sampling frequency from time vector
+            # Extract sampling frequency from time vector. Also record
+            # ``n_times`` — the
+            # time vector length IS the sample count along the time axis.
             for data_key in nirs_group.keys():
                 if data_key.startswith("data"):
                     data_group = nirs_group[data_key]
                     if "time" in data_group:
                         time_data = data_group["time"][:]
-                        if len(time_data) > 1:
+                        n_time_points = len(time_data)
+                        if n_time_points > 0:
+                            result["n_times"] = int(n_time_points)
+                        if n_time_points > 1:
                             dt = float(time_data[1] - time_data[0])
                             if dt > 0:
                                 result["sampling_frequency"] = float(1.0 / dt)
@@ -176,7 +213,11 @@ def _parse_snirf_with_h5py(snirf_path: Path) -> dict[str, Any] | None:
             if ch_names:
                 result["ch_names"] = ch_names
 
-    except Exception:
+    except (OSError, ValueError, KeyError, AttributeError) as e:
+        # OSError = not a valid HDF5; KeyError = expected dataset path
+        # missing (different SNIRF version); ValueError/AttributeError =
+        # unexpected element shape. All are recoverable parse failures.
+        logger.debug("h5py SNIRF parse failed for %s: %s", snirf_path, e)
         return None
 
     if not result:

--- a/scripts/ingestions/_validate.py
+++ b/scripts/ingestions/_validate.py
@@ -1,7 +1,6 @@
-"""Validation utilities for injection scripts.
+"""Validation utilities for the ingestion pipeline.
 
-This module re-exports the validation functions from 4_validate_output.py
-for use in other ingestion scripts.
+``4_validate_output.py`` is a thin CLI wrapper that imports from here.
 """
 
 import json
@@ -11,7 +10,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from eegdash.schemas import DatasetModel, RecordModel
+from eegdash.schemas import DatasetModel, ManifestFileModel, ManifestModel, RecordModel
 
 # Valid storage URL patterns per source
 VALID_STORAGE_PATTERNS = {
@@ -89,9 +88,9 @@ class ValidationResult:
         self.modality_distribution = {}
         self.empty_datasets = []
         self.zip_placeholder_datasets = []
-        self.data_quality_issues = []  # Datasets with missing nchans/sampling_frequency
+        self.data_quality_issues = []
 
-    def add_error(self, dataset: str, message: str, field: str = None):
+    def add_error(self, dataset: str, message: str, field: str | None = None):
         self.errors.append(
             {
                 "dataset": dataset,
@@ -100,7 +99,7 @@ class ValidationResult:
             }
         )
 
-    def add_warning(self, dataset: str, message: str, field: str = None):
+    def add_warning(self, dataset: str, message: str, field: str | None = None):
         self.warnings.append(
             {
                 "dataset": dataset,
@@ -225,7 +224,6 @@ def validate_record(
     except ValidationError as exc:
         _add_pydantic_errors(result, dataset_id=dataset_id, exc=exc, prefix="record")
 
-    # Validate storage URL matches source
     storage = record.get("storage", {})
     if storage:
         storage_base = storage.get("base", "")
@@ -234,7 +232,6 @@ def validate_record(
             result.add_error(dataset_id, error_msg, field="storage.base")
             result.stats["storage_errors"] += 1
 
-    # Check recommended fields (warnings only, first record only)
     if record_idx == 0:
         for field in RECOMMENDED_RECORD_FIELDS:
             if field not in record or record[field] is None:
@@ -245,7 +242,6 @@ def validate_record(
                 )
                 result.stats["missing_recommended"] += 1
 
-    # Check data quality fields (nchans, sampling_frequency) - critical for usability
     nchans = record.get("nchans")
     sampling_frequency = record.get("sampling_frequency")
     if nchans is None or nchans == 0:
@@ -284,17 +280,7 @@ def validate_digestion_output(
     verbose: bool = False,
     strict: bool = False,
 ) -> ValidationResult:
-    """Validate all digestion output in a directory.
-
-    Args:
-        input_dir: Directory containing digested datasets
-        verbose: Print progress information
-        strict: Treat warnings as errors
-
-    Returns:
-        ValidationResult with all findings
-
-    """
+    """Validate all digestion output in a directory."""
     result = ValidationResult()
 
     if not input_dir.exists():
@@ -317,7 +303,6 @@ def validate_digestion_output(
         source = "unknown"
         record_count = 0
 
-        # Load dataset first to get source
         if dataset_file.exists():
             try:
                 with open(dataset_file) as f:
@@ -330,10 +315,13 @@ def validate_digestion_output(
 
             except json.JSONDecodeError as e:
                 result.add_error(dataset_id, f"Invalid JSON in dataset file: {e}")
-            except Exception as e:
+            except (OSError, KeyError, ValueError, TypeError) as e:
+                # OSError: file disappeared / permission. KeyError: missing
+                # 'datasets' or other expected fields. ValueError/TypeError:
+                # validate_dataset received an unexpected shape. All
+                # accumulate into result.errors rather than crashing.
                 result.add_error(dataset_id, f"Error reading dataset: {e}")
 
-        # Validate records
         if records_file.exists():
             try:
                 with open(records_file) as f:
@@ -354,13 +342,11 @@ def validate_digestion_output(
                     for mod in mods:
                         modalities[mod] += 1
 
-                    # Track ZIP placeholders
                     if record.get("needs_extraction") or record.get(
                         "zip_contains_bids"
                     ):
                         has_zip_placeholder = True
 
-                    # Track data quality at dataset level
                     if record.get("nchans") is None or record.get("nchans") == 0:
                         has_missing_nchans = True
                     if (
@@ -385,10 +371,11 @@ def validate_digestion_output(
 
             except json.JSONDecodeError as e:
                 result.add_error(dataset_id, f"Invalid JSON in records file: {e}")
-            except Exception as e:
+            except (OSError, KeyError, ValueError, TypeError) as e:
+                # Same rationale as the dataset-file handler above. Bad
+                # records accumulate; we don't crash the whole digest.
                 result.add_error(dataset_id, f"Error reading records: {e}")
 
-        # Flag empty datasets
         if record_count == 0:
             result.stats["empty_datasets"] += 1
             result.empty_datasets.append(f"{dataset_id} ({source})")
@@ -406,4 +393,94 @@ def validate_digestion_output(
     result.source_distribution = dict(sources)
     result.modality_distribution = dict(modalities)
 
+    return result
+
+
+def validate_pre_digestion(input_dir: Path, verbose: bool = False) -> ValidationResult:
+    """Pre-digestion validation: walk ``manifest.json`` files under
+    ``input_dir`` and flag manifests with no recognised neurophysiology
+    data file (CTF ``.ds`` directories counted as one).
+    """
+    result = ValidationResult()
+
+    if not input_dir.exists():
+        result.add_error("", f"Input directory does not exist: {input_dir}")
+        return result
+
+    dataset_dirs = [
+        d for d in input_dir.iterdir() if d.is_dir() and (d / "manifest.json").exists()
+    ]
+
+    if verbose:
+        print(f"Found {len(dataset_dirs)} manifests to check")
+
+    sources = Counter()
+
+    for dataset_dir in dataset_dirs:
+        dataset_id = dataset_dir.name
+        manifest_path = dataset_dir / "manifest.json"
+
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+            try:
+                manifest_model = ManifestModel.model_validate(manifest)
+            except ValidationError as exc:
+                _add_pydantic_errors(
+                    result, dataset_id=dataset_id, exc=exc, prefix="manifest"
+                )
+                continue
+
+            source = manifest_model.source or "unknown"
+            sources[source] += 1
+            result.stats["datasets_checked"] += 1
+
+            files = manifest_model.files
+
+            data_file_count = 0
+            ctf_ds_dirs = set()
+
+            for f in files:
+                if isinstance(f, str):
+                    filepath = f
+                elif isinstance(f, ManifestFileModel):
+                    filepath = f.path_or_name()
+                else:
+                    filepath = ""
+                filepath_lower = filepath.lower()
+
+                # CTF datasets are directories; count files inside .ds/ once.
+                if ".ds/" in filepath_lower:
+                    ds_idx = filepath_lower.index(".ds/") + 3
+                    ds_path = filepath[:ds_idx]
+                    ctf_ds_dirs.add(ds_path)
+                    continue
+
+                for ext in NEURO_EXTENSIONS:
+                    if filepath_lower.endswith(ext):
+                        data_file_count += 1
+                        break
+
+            data_file_count += len(ctf_ds_dirs)
+            result.stats["records_checked"] += data_file_count
+
+            if data_file_count == 0:
+                result.stats["empty_datasets"] += 1
+                result.empty_datasets.append(f"{dataset_id} ({source})")
+                result.add_warning(
+                    dataset_id,
+                    f"No recognized neurophysiology files in manifest "
+                    f"({len(files)} total files)",
+                )
+
+            if verbose and data_file_count > 0:
+                print(f"  {dataset_id}: {data_file_count} data files")
+
+        except json.JSONDecodeError as e:
+            result.add_error(dataset_id, f"Invalid JSON in manifest: {e}")
+        except (OSError, KeyError, ValueError, TypeError) as e:
+            result.add_error(dataset_id, f"Error reading manifest: {e}")
+
+    result.source_distribution = dict(sources)
     return result

--- a/scripts/ingestions/_validate_config.py
+++ b/scripts/ingestions/_validate_config.py
@@ -1,0 +1,118 @@
+"""Pydantic-settings config for 4_validate_output.py (C7.1).
+
+Applies the C6.5 pattern (Pydantic-settings + thin argparse bridge)
+to the validate stage. 5 CLI flags become declarative fields with
+descriptions; existing exit-code semantics preserved.
+
+The pattern from _inject_config.py:
+1. ``BaseSettings`` model — fields + validators + accessors.
+2. ``load_*_config_from_argv()`` — argparse → kwargs bridge that
+   preserves --help / short-flag ergonomics.
+3. ``main()`` in the stage calls the loader, gets a typed config.
+
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ValidateConfig(BaseSettings):
+    """Validated config for the digest-output validation stage.
+
+    Sources, in precedence order: constructor kwargs → CLI args
+    (via :func:`load_validate_config_from_argv`) → env vars → defaults.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="EEGDASH_VALIDATE_",
+        extra="ignore",
+    )
+
+    # I/O
+    input: Path = Field(
+        default=Path("digestion_output"),
+        description=(
+            "Input directory. Default: ``digestion_output``. For "
+            "``--pre-check``, point at ``data/cloned`` instead."
+        ),
+    )
+
+    # Mode toggles
+    pre_check: bool = Field(
+        default=False,
+        description=(
+            "Pre-digestion validation: check manifests have valid "
+            "data files (run BEFORE digest, not after)."
+        ),
+    )
+    verbose: bool = Field(default=False, description="Print per-dataset diagnostics.")
+    strict: bool = Field(
+        default=False,
+        description="Treat warnings as errors (empty datasets fail too).",
+    )
+    # The CLI flag is --json; ``json`` clashes with the stdlib module
+    # name inside main() so we expose it as ``json_output`` in the model
+    # and map back at the CLI layer.
+    json_output: bool = Field(
+        default=False,
+        description="Output the result as a JSON document on stdout.",
+    )
+
+    @model_validator(mode="after")
+    def _input_must_exist(self) -> ValidateConfig:
+        """The validator can't validate nothing — the input dir has to
+        exist. (No dry-run escape hatch like 5_inject; this stage IS
+        the dry-check.)
+        """
+        if not self.input.exists():
+            raise ValueError(f"--input directory does not exist: {self.input}")
+        return self
+
+
+def load_validate_config_from_argv(
+    argv: list[str] | None = None,
+) -> ValidateConfig:
+    """Parse argv (or sys.argv) into a validated :class:`ValidateConfig`."""
+    parser = argparse.ArgumentParser(
+        description="Validate digestion output for eegdash compatibility"
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        default=None,
+        help=("Input directory (digestion_output or data/cloned for --pre-check)"),
+    )
+    parser.add_argument(
+        "--pre-check",
+        action="store_true",
+        dest="pre_check",
+        help=("Pre-digestion validation: check manifests have valid data files"),
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print verbose output"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors (empty datasets become errors)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON",
+    )
+
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    kwargs = {k: v for k, v in vars(ns).items() if v is not None and v is not False}
+    # Re-add False booleans that were explicitly set to False by argparse
+    # (action="store_true" defaults to False — only forward when True).
+    return ValidateConfig(**kwargs)

--- a/scripts/ingestions/_vhdr_parser.py
+++ b/scripts/ingestions/_vhdr_parser.py
@@ -19,7 +19,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from _parser_utils import is_broken_symlink, read_with_encoding_fallback
+from _parser_utils import (
+    is_broken_symlink,
+    path_is_within_root,
+    read_with_encoding_fallback,
+)
 
 # Add eegdash to path if not already importable
 _project_root = Path(__file__).parent.parent.parent
@@ -184,7 +188,11 @@ def extract_vhdr_references(vhdr_path: Path | str) -> dict[str, str | None]:
     if content is None:
         return result
 
-    # Extract DataFile reference
+    # Extract DataFile reference. Path-traversal hardening: a malicious
+    # .vhdr could set DataFile=../../../etc/passwd. We accept
+    # the field but only mark *_exists=True if the resolved sibling
+    # stays inside the .vhdr's parent directory.
+    parent_dir = vhdr_path.parent
     datafile_match = re.search(
         r"^\s*DataFile\s*=\s*(.+?)\s*$",
         content,
@@ -192,10 +200,12 @@ def extract_vhdr_references(vhdr_path: Path | str) -> dict[str, str | None]:
     )
     if datafile_match:
         result["datafile"] = datafile_match.group(1).strip()
-        data_path = vhdr_path.parent / result["datafile"]
-        result["datafile_exists"] = data_path.exists()
+        data_path = parent_dir / result["datafile"]
+        result["datafile_exists"] = (
+            path_is_within_root(data_path, parent_dir) and data_path.exists()
+        )
 
-    # Extract MarkerFile reference
+    # Extract MarkerFile reference (same containment check)
     markerfile_match = re.search(
         r"^\s*MarkerFile\s*=\s*(.+?)\s*$",
         content,
@@ -203,8 +213,10 @@ def extract_vhdr_references(vhdr_path: Path | str) -> dict[str, str | None]:
     )
     if markerfile_match:
         result["markerfile"] = markerfile_match.group(1).strip()
-        marker_path = vhdr_path.parent / result["markerfile"]
-        result["markerfile_exists"] = marker_path.exists()
+        marker_path = parent_dir / result["markerfile"]
+        result["markerfile_exists"] = (
+            path_is_within_root(marker_path, parent_dir) and marker_path.exists()
+        )
 
     return result
 

--- a/scripts/ingestions/api_helper.py
+++ b/scripts/ingestions/api_helper.py
@@ -27,6 +27,7 @@ import os
 import sys
 from typing import Any
 
+import httpx
 import requests
 
 
@@ -377,7 +378,15 @@ Environment Variables:
             print(f"\nTotal: {len(datasets)} datasets")
             return 0
 
-    except Exception as e:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        ValueError,
+        OSError,
+    ) as e:
+        # CLI top-level: recoverable failures become a 1-exit with a
+        # printed error. Programmer errors propagate (no traceback hiding).
         print(f"Error: {e}", file=sys.stderr)
         return 1
 

--- a/scripts/ingestions/dev/audit_helper_usage.py
+++ b/scripts/ingestions/dev/audit_helper_usage.py
@@ -1,0 +1,117 @@
+"""AST-based audit of how often each private helper is used.
+
+A *private helper* is any module-level ``def _foo(…)`` (single-underscore
+prefix, not dunder). For each one we count the references *within the same
+file* (private helpers shouldn't be imported across files, but we still
+inspect siblings as a sanity check).
+
+The output highlights candidates for inlining:
+
+* **0 callers** → unused, delete.
+* **1 caller**  → consider inlining (small functions only).
+* **2+ callers** → keep as a helper.
+
+Run::
+
+    python scripts/ingestions/dev/audit_helper_usage.py [path ...]
+
+Default scope mirrors ``audit_local_imports.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+DEFAULT_ROOTS = ("eegdash", "scripts/ingestions")
+SKIP_DIRS = {"__pycache__", ".cache", "tests", "mutants", "data", "1_fetch_sources"}
+
+
+def _iter_py(roots: Iterable[Path]) -> Iterable[Path]:
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file() and root.suffix == ".py":
+            yield root
+            continue
+        for p in root.rglob("*.py"):
+            if any(part in SKIP_DIRS for part in p.parts):
+                continue
+            yield p
+
+
+def _private_helpers(tree: ast.AST) -> list[tuple[str, int, int]]:
+    """Return ``[(name, lineno, body_len_lines), ...]`` for top-level ``_foo``."""
+    out: list[tuple[str, int, int]] = []
+    if not isinstance(tree, ast.Module):
+        return out
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if not node.name.startswith("_") or node.name.startswith("__"):
+            continue
+        body_len = (node.end_lineno or node.lineno) - node.lineno
+        out.append((node.name, node.lineno, body_len))
+    return out
+
+
+def _count_uses(tree: ast.AST, name: str) -> int:
+    """Count Name references to ``name`` *outside* its own definition body."""
+    own_def: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    if isinstance(tree, ast.Module):
+        for node in tree.body:
+            if (
+                isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+                and node.name == name
+            ):
+                own_def = node
+                break
+    own_ids = set(map(id, ast.walk(own_def))) if own_def is not None else set()
+
+    n = 0
+    for node in ast.walk(tree):
+        if id(node) in own_ids:
+            continue
+        if isinstance(node, ast.Name) and node.id == name:
+            n += 1
+        elif isinstance(node, ast.Attribute) and node.attr == name:
+            n += 1
+    return n
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    roots = [REPO / a for a in argv] if argv else [REPO / r for r in DEFAULT_ROOTS]
+    rows: list[tuple[str, str, int, int, int]] = []
+    for py in sorted(_iter_py(roots)):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for name, lineno, body_len in _private_helpers(tree):
+            uses = _count_uses(tree, name)
+            rows.append((str(py.relative_to(REPO)), name, lineno, body_len, uses))
+
+    rows.sort(key=lambda r: (r[4], r[3]))
+    print(f"{'file':<60} {'helper':<35} {'L':>5} {'body':>5} {'uses':>5}")
+    print("-" * 115)
+    n_unused = n_single = 0
+    for rel, name, lineno, body_len, uses in rows:
+        marker = " *" if uses == 0 else ("  ~" if uses == 1 else "")
+        print(f"{rel:<60} {name:<35} {lineno:>5} {body_len:>5} {uses:>5}{marker}")
+        if uses == 0:
+            n_unused += 1
+        elif uses == 1:
+            n_single += 1
+    print()
+    print(
+        f"# {len(rows)} private helpers; {n_unused} unused (*), {n_single} single-use (~)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingestions/dev/audit_local_imports.py
+++ b/scripts/ingestions/dev/audit_local_imports.py
@@ -1,0 +1,77 @@
+"""AST-based audit of function-scoped imports in the PR diff.
+
+Reports every ``import``/``from … import …`` statement that lives inside a
+function body (i.e. would trip ruff's preview rule ``PLC0415``,
+``import-outside-top-level``). Used as a one-shot inventory while the
+codebase converges on PEP 8 module-level imports.
+
+Usage::
+
+    python scripts/ingestions/dev/audit_local_imports.py [path ...]
+
+Default scope: ``eegdash/`` + ``scripts/ingestions/`` (skipping tests/,
+data/, and *.bak*).
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+DEFAULT_ROOTS = ("eegdash", "scripts/ingestions")
+SKIP_DIRS = {"__pycache__", ".cache", "tests", "mutants", "data", "1_fetch_sources"}
+
+
+def _iter_py(roots: Iterable[Path]) -> Iterable[Path]:
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file() and root.suffix == ".py":
+            yield root
+            continue
+        for p in root.rglob("*.py"):
+            if any(part in SKIP_DIRS for part in p.parts):
+                continue
+            yield p
+
+
+def _local_imports(path: Path) -> list[tuple[int, str]]:
+    """Return ``[(lineno, statement_text), ...]`` for nested imports in ``path``."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        print(f"# skip {path}: {exc}", file=sys.stderr)
+        return []
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for sub in ast.walk(node):
+            if sub is node:
+                continue
+            if isinstance(sub, ast.Import | ast.ImportFrom):
+                hits.append((sub.lineno, ast.unparse(sub)))
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    roots = [REPO / a for a in argv] if argv else [REPO / r for r in DEFAULT_ROOTS]
+    total = 0
+    for py in sorted(_iter_py(roots)):
+        hits = _local_imports(py)
+        if not hits:
+            continue
+        rel = py.relative_to(REPO)
+        for lineno, text in hits:
+            print(f"{rel}:{lineno}: {text}")
+            total += 1
+    print(f"\n# {total} function-scoped imports found")
+    return 0 if total == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingestions/dev/audit_pr_functions.py
+++ b/scripts/ingestions/dev/audit_pr_functions.py
@@ -1,0 +1,214 @@
+"""Inventory + usage audit of every function introduced by PR #354.
+
+Extracts each function whose definition is on a PR-added line (vs
+``origin/develop``), then counts how many distinct call-sites reference
+it across the whole codebase (PR-touched files + the rest of ``eegdash/``
++ ``scripts/ingestions/`` minus tests/, plus tests/ as a separate count
+so we can tell "only used in its own test" apart from "used in prod").
+
+Output is two CSV-like tables on stdout:
+
+* ``functions``: file,name,lineno,body_lines,is_private,is_method,prod_uses,test_uses,total_uses
+* ``candidates``: same row but only where prod_uses+test_uses ≤ 1
+  (delete / inline candidates).
+
+Run::
+
+    python scripts/ingestions/dev/audit_pr_functions.py [--base origin/develop]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+PROD_GLOBS = ("eegdash/**/*.py", "scripts/ingestions/**/*.py")
+TEST_PATH_MARKERS = ("/tests/", "/test_", "test_")
+
+
+def _changed_files(base: str) -> list[Path]:
+    out = subprocess.check_output(
+        ["git", "diff", base, "--name-only", "--", "*.py"], cwd=REPO, text=True
+    )
+    return [REPO / line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _added_line_set(base: str, file: Path) -> set[int]:
+    """Return the set of *new* HEAD line numbers added by the PR diff."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", base, "--", str(file.relative_to(REPO))],
+            cwd=REPO,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return set()
+    added: set[int] = set()
+    cur = 0
+    for line in out.splitlines():
+        if line.startswith("@@"):
+            # @@ -a,b +c,d @@
+            try:
+                plus = line.split("+", 1)[1].split(" ", 1)[0]
+                cur = int(plus.split(",")[0])
+            except (IndexError, ValueError):
+                cur = 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added.add(cur)
+            cur += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        elif line.startswith(" "):
+            cur += 1
+    return added
+
+
+def _pr_funcs(file: Path, base: str) -> list[tuple[str, int, int, bool, bool]]:
+    """Return ``[(name, lineno, body_len, is_private, is_method), ...]``
+    for every function whose ``def`` line was added by the PR.
+    """
+    try:
+        tree = ast.parse(file.read_text(encoding="utf-8"))
+    except (SyntaxError, OSError):
+        return []
+    added = _added_line_set(base, file)
+    out: list[tuple[str, int, int, bool, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.lineno not in added:
+            continue
+        name = node.name
+        end = node.end_lineno or node.lineno
+        is_priv = name.startswith("_") and not name.startswith("__")
+        is_method = False
+        # parents aren't tracked by ast.walk; approximate by checking if
+        # the function is the descendant of a ClassDef (we'll just look at
+        # col_offset > 0 + the module body to detect)
+        # Simpler heuristic: col_offset > 0 means nested or method.
+        is_method = node.col_offset > 0
+        out.append((name, node.lineno, end - node.lineno, is_priv, is_method))
+    return out
+
+
+def _scan_files(roots: Iterable[str]) -> list[Path]:
+    seen: set[Path] = set()
+    for glob in roots:
+        for p in REPO.glob(glob):
+            if p.is_file() and "__pycache__" not in p.parts:
+                seen.add(p)
+    return sorted(seen)
+
+
+def _index_references(
+    files: list[Path],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Parse every file once and build {name -> count} dicts split into
+    (prod, test). Names are Name.id, Attribute.attr, and Constant.value (str).
+    """
+    prod: dict[str, int] = defaultdict(int)
+    test: dict[str, int] = defaultdict(int)
+    for f in files:
+        bucket = test if any(m in str(f) for m in TEST_PATH_MARKERS) else prod
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name):
+                bucket[node.id] += 1
+            elif isinstance(node, ast.Attribute):
+                bucket[node.attr] += 1
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                bucket[node.value] += 1
+    return prod, test
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--base", default="origin/develop")
+    p.add_argument("--threshold", type=int, default=1)
+    args = p.parse_args()
+
+    pr_files = [f for f in _changed_files(args.base) if f.exists()]
+    all_files = _scan_files(PROD_GLOBS)
+
+    rows: list[tuple[str, str, int, int, bool, bool, int, int]] = []
+    # Track function NAMES that are reused across multiple files; if a
+    # name is defined in N files and used in M, we want to attribute the
+    # uses to each defining file separately (but since uses don't carry
+    # source-file metadata, the count is global). That's fine for an
+    # audit: name reuse across files is itself a finding.
+    seen: dict[str, list[tuple[str, int]]] = defaultdict(list)
+
+    for f in pr_files:
+        for name, lineno, body, is_priv, is_method in _pr_funcs(f, args.base):
+            seen[name].append((str(f.relative_to(REPO)), lineno))
+
+    prod_idx, test_idx = _index_references(all_files)
+    name_uses: dict[str, tuple[int, int]] = {
+        name: (prod_idx.get(name, 0), test_idx.get(name, 0)) for name in seen
+    }
+
+    for f in pr_files:
+        for name, lineno, body, is_priv, is_method in _pr_funcs(f, args.base):
+            prod, test = name_uses[name]
+            # Subtract one prod use per defining occurrence (the def-site
+            # would be counted as a Name in some contexts e.g. decorator
+            # references). Defensive: keep at >= 0.
+            rows.append(
+                (
+                    str(f.relative_to(REPO)),
+                    name,
+                    lineno,
+                    body,
+                    is_priv,
+                    is_method,
+                    max(prod, 0),
+                    max(test, 0),
+                )
+            )
+
+    rows.sort(key=lambda r: (r[6] + r[7], r[3]))
+
+    print("file,name,lineno,body,priv,method,prod_uses,test_uses,total")
+    for rel, name, lineno, body, is_priv, is_method, prod, test in rows:
+        total = prod + test
+        print(
+            f"{rel},{name},{lineno},{body},{int(is_priv)},{int(is_method)},"
+            f"{prod},{test},{total}"
+        )
+
+    print()
+    print("# Summary")
+    n_total = len(rows)
+    n_zero = sum(1 for r in rows if r[6] + r[7] == 0)
+    n_one = sum(1 for r in rows if r[6] + r[7] == 1)
+    n_two_plus = sum(1 for r in rows if r[6] + r[7] >= 2)
+    n_test_only = sum(1 for r in rows if r[6] == 0 and r[7] > 0)
+    print(f"# {n_total} PR-introduced functions")
+    print(f"# {n_zero} unused (0 callers)")
+    print(f"# {n_one} single-use (1 caller)")
+    print(f"# {n_test_only} only-tested (no prod caller, only test caller)")
+    print(f"# {n_two_plus} multi-use (≥2 callers)")
+
+    # Name-collisions across multiple files
+    multi = {n: locs for n, locs in seen.items() if len(locs) > 1}
+    if multi:
+        print()
+        print("# Name collisions (same function name in ≥2 PR-introduced files)")
+        for name, locs in sorted(multi.items()):
+            print(f"# {name}: {len(locs)} defs")
+            for loc, lineno in locs:
+                print(f"#   {loc}:{lineno}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingestions/digest_telemetry.py
+++ b/scripts/ingestions/digest_telemetry.py
@@ -1,0 +1,157 @@
+"""Structured per-Record / per-Dataset event stream for the digest pipeline.
+
+Emits four event kinds: ``dataset_started``, ``dataset_finished``,
+``record_built`` (carries ``metadata_provenance``), and ``record_failed``.
+Events are queryable via ``jq`` / ``pandas.read_json(lines=True)``.
+Use :func:`configure_telemetry` at orchestrator start-up or set
+``$EEGDASH_TELEMETRY_PATH`` to enable :class:`NDJSONEmitter`; the
+default :class:`NullEmitter` is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TelemetryEvent:
+    """Frozen dataclass representing one event in the digest event stream."""
+
+    event_kind: str
+    dataset_id: str
+    payload: dict[str, Any]
+    record_id: str | None = None
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable representation (field order is stable)."""
+        return {
+            "timestamp": self.timestamp,
+            "event_kind": self.event_kind,
+            "dataset_id": self.dataset_id,
+            "record_id": self.record_id,
+            "payload": self.payload,
+        }
+
+
+class TelemetryEmitter(ABC):
+    """Where events go. Implementations decide the backend (file / DB / null)."""
+
+    @abstractmethod
+    def emit(self, event: TelemetryEvent) -> None:
+        """Record one event; must not raise on best-effort errors."""
+
+    def close(self) -> None:  # noqa: B027 — intentional default no-op
+        """Optional cleanup hook; override in subclasses with open handles."""
+
+
+class NullEmitter(TelemetryEmitter):
+    """No-op default emitter; zero I/O overhead."""
+
+    def emit(self, event: TelemetryEvent) -> None:
+        return None
+
+
+class NDJSONEmitter(TelemetryEmitter):
+    """Append one JSON line per event to a file; thread-safe, append-mode."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # Append mode so re-runs accumulate; lock is per-instance (new emitter per subprocess).
+        self._fh = open(self.path, "a", encoding="utf-8")
+        self._lock = threading.Lock()
+
+    def emit(self, event: TelemetryEvent) -> None:
+        try:
+            line = json.dumps(event.to_dict(), separators=(",", ":"))
+        except (TypeError, ValueError) as e:
+            # Best-effort: a malformed payload shouldn't crash digest.
+            logger.warning(
+                "telemetry: failed to serialize %s event: %s",
+                event.event_kind,
+                e,
+            )
+            return
+        with self._lock:
+            self._fh.write(line + "\n")
+            self._fh.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._fh.close()
+            except OSError:
+                pass
+
+
+# ─── Process-global emitter ───────────────────────────────────────────
+
+
+_EMITTER: TelemetryEmitter = NullEmitter()
+_EMITTER_LOCK = threading.Lock()
+
+
+def get_emitter() -> TelemetryEmitter:
+    """Return the process-global emitter (defaults to :class:`NullEmitter`)."""
+    return _EMITTER
+
+
+def configure_telemetry(emitter: TelemetryEmitter) -> None:
+    """Install ``emitter`` as the process-global emitter, closing the previous one."""
+    global _EMITTER
+    with _EMITTER_LOCK:
+        old = _EMITTER
+        _EMITTER = emitter
+    # Close outside the lock so a slow close() doesn't block other threads.
+    if old is not emitter:
+        try:
+            old.close()
+        except OSError:
+            pass
+
+
+def reset_telemetry() -> None:
+    """Restore the default :class:`NullEmitter`. Test-only convenience."""
+    configure_telemetry(NullEmitter())
+
+
+# ─── Environment-driven auto-configuration ────────────────────────────
+
+
+_ENV_VAR = "EEGDASH_TELEMETRY_PATH"
+
+
+def auto_configure_from_env() -> None:
+    """Install an :class:`NDJSONEmitter` if ``$EEGDASH_TELEMETRY_PATH`` is set; idempotent."""
+    path = os.environ.get(_ENV_VAR)
+    if not path:
+        return
+    current = get_emitter()
+    if isinstance(current, NDJSONEmitter) and current.path == Path(path):
+        return  # already configured for this path
+    configure_telemetry(NDJSONEmitter(path))
+
+
+__all__ = [
+    "NDJSONEmitter",
+    "NullEmitter",
+    "TelemetryEmitter",
+    "TelemetryEvent",
+    "auto_configure_from_env",
+    "configure_telemetry",
+    "get_emitter",
+    "reset_telemetry",
+]

--- a/scripts/ingestions/profiles/.gitignore
+++ b/scripts/ingestions/profiles/.gitignore
@@ -1,0 +1,16 @@
+# Profile artifacts — large binaries / logs that don't belong in git.
+# The deliverable is E2E-FULL-SCALE-PROFILE.md, which summarises and
+# cross-references everything else.
+#
+# Recreate via the reproducibility section at the bottom of the .md.
+
+*.log
+*.pstats
+*.dot
+*.svg
+stage1/
+stage2/
+stage3/
+stage3-sample/
+stage4/
+nemar-fetch.log

--- a/scripts/ingestions/pyproject.toml
+++ b/scripts/ingestions/pyproject.toml
@@ -1,0 +1,263 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Flat layout with non-package directories alongside the bare modules
+# (profiles/, data/, ...). Disable setuptools auto-discovery
+# and ship the bare modules explicitly so `pip install -e .` works.
+[tool.setuptools]
+py-modules = [
+    "_bids",
+    "_clone_config",
+    "_constants",
+    "_digest_config",
+    "_file_utils",
+    "_fingerprint",
+    "_format_parser_registry",
+    "_github",
+    "_http",
+    "_inject_config",
+    "_inject_plan",
+    "_keywords",
+    "_mef3_parser",
+    "_metadata_cascade",
+    "_montage",
+    "_parser_utils",
+    "_serialize",
+    "_set_parser",
+    "_snirf_parser",
+    "_validate",
+]
+
+[project]
+name = "eegdash-ingestions"
+version = "0.1.0"
+description = "BIDS-dataset ingestion pipeline for the eegdash MongoDB"
+requires-python = ">=3.10"
+license = {text = "BSD-3-Clause"}
+authors = [{name = "Bruno Aristimunha", email = "b.aristimunha@gmail.com"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+dependencies = [
+    "httpx[http2]>=0.27",
+    "tenacity>=8",
+    "pydantic>=2.5",
+    "pydantic-settings>=2",
+    "pandas",
+    "mne-bids>=0.14",
+    "python-dotenv>=1",
+    "pooch>=1.7",  # eegdash.testing.data_path() lazy-fetches test corpus
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=4",
+    "pytest-benchmark>=4",
+    "hypothesis>=6.100",
+    "respx>=0.20",
+    "mutmut>=2.4",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+# ─── Tooling ────────────────────────────────────────────────────────────────
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+extend-exclude = ["1_fetch_sources", "data", "__pycache__", ".cache", "mutants"]
+
+[tool.ruff.lint]
+# Initial selection — keep tight from day 1 so quality only ratchets up.
+# BLE (blind-except) is the headline rule for Phase 3 of the robustness
+# programme: every except: / except Exception: gets reviewed individually.
+select = [
+    "E", "F", "W",   # pycodestyle + pyflakes
+    "I",             # isort
+    "B",             # bugbear
+    "BLE",           # blind-except — Phase 3 target
+    "UP",            # pyupgrade
+    "PT",            # pytest-style
+    "RUF",           # ruff-specific
+    "N",             # pep8-naming
+    "PLC0415",       # import-outside-top-level (PEP 8 — lift lazy imports)
+]
+# D (pydocstyle / numpydoc) is selected per-file once the legacy code has
+# been touched up; turning it on globally on day 1 would generate ~1000
+# warnings on existing code we haven't reviewed yet.
+ignore = [
+    "E501",  # line-too-long — ruff format handles wrap
+    "E402",  # module-level imports after code — used by `# noqa: E402` in mne_bids
+]
+
+[tool.ruff.lint.per-file-ignores]
+# The numbered script files are CLI entrypoints; relax the naming rule
+# (N999: invalid-module-name fires on the leading digit).
+"[0-9]*_*.py" = ["N999"]
+# Test files: relaxed naming + Unicode rules.
+#   D                — tests don't need NumPy docstrings.
+#   N802/N806        — pydantic model class names (DatasetModel, RecordModel)
+#                      are referenced in test names + assigned to local vars.
+#   RUF002/RUF003    — docstrings/comments use × (multiply) and – (en-dash)
+#                      in performance/fixture annotations.
+#   BLE001           — broad except in negative-path test scaffolding.
+"tests/**/*.py" = ["D", "N802", "N806", "RUF002", "RUF003", "BLE001"]
+
+# Legacy-file baseline — these rules will be enforced PHASE BY PHASE as the
+# files are touched. Removing an ignore from this list is part of the
+# evaluation hook for the relevant phase.
+#
+# BLE001 — bare-except / broad-except. 72 violations across 17 files. Phase 3
+# of the robustness programme sweeps these; the per-file ignore is removed
+# as each file is cleaned.
+#
+# Other rules are smaller categories (RUF002/003/005/013, B007, N806, etc.)
+# that we'll tidy mechanically when their owning file is next touched.
+# "2_clone.py"                  — bare-excepts swept in Phase 9 F1 fix (commit 14)
+"3_digest.py"                   = ["E741", "RUF003", "RUF005", "RUF013", "RUF046", "B007", "PLC0415"]  # one pre-existing _vhdr_parser lazy import; sweep when file is next touched
+"_github.py"                    = ["PLC0415"]  # PyGithub lazy import inside try/ImportError
+"_set_parser.py"                = ["PLC0415"]  # scipy.io + h5py lazy optional-dep imports
+"inject_nemar_citations.py"     = ["PLC0415"]  # legacy lazy import — sweep with Phase 3
+# "4_validate_output.py"        — bare-excepts swept Phase 3 (commit 17)
+# "5_inject.py"                 — bare-excepts swept Phase 3 (commit 17)
+# "_bids.py"                    — bare-excepts swept in Phase 3 (commit 2)
+"_file_utils.py"                = ["E741", "RUF003", "RUF005"]  # bare-excepts swept Phase 3 (commit 16)
+# "_github.py"                  — bare-excepts swept in Phase 3 (commit 2). 2 deliberate broad
+#                                  catches remain around PyGithub's heterogeneous wrappings, each
+#                                  marked with an inline noqa: BLE001 + rationale.
+# "_http.py"                    — bare-excepts swept in Phase 3 (commit 2)
+# "_mef3_parser.py"             — bare-excepts swept in Phase 3 (commit 1)
+"_montage.py"                   = ["N806", "RUF002", "RUF003", "RUF013", "RUF059"]  # BLE001 swept Phase 3 (final)
+# "_set_parser.py"              — bare-excepts swept in Phase 3 (commit 1)
+# "_snirf_parser.py"            — bare-excepts swept in Phase 3 (commit 1)
+# "_validate.py"                — bare-excepts swept in Phase 3 (commit 2)
+# "api_helper.py"               — bare-excepts swept Phase 3 (commit 16)
+# "inject_nemar_citations.py"   — swept Phase 3 (commit 15)
+# "patch_nemar_records_storage.py" — swept Phase 3 (commit 15)
+# "patch_nemar_source.py"       — swept Phase 3 (commit 15)
+# "time_openneuro_pipeline.py"  — swept Phase 3 (commit 15)
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "mne",
+    "mne_bids",
+    "eegdash",
+    # Local ingestion modules — bare ``_*.py`` files siblings to this
+    # config. Explicitly listed so isort groups them in the first-party
+    # block instead of guessing.
+    "_bids",
+    "_clone_config",
+    "_constants",
+    "_digest_config",
+    "_file_utils",
+    "_fingerprint",
+    "_format_parser_registry",
+    "_github",
+    "_http",
+    "_inject_config",
+    "_inject_plan",
+    "_keywords",
+    "_mef3_parser",
+    "_metadata_cascade",
+    "_montage",
+    "_parser_utils",
+    "_serialize",
+    "_set_parser",
+    "_snirf_parser",
+    "_validate",
+    "_validate_config",
+    "_vhdr_parser",
+]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.mypy]
+python_version = "3.10"
+# Permissive baseline. Tighten per-module as legacy files are refactored
+# under their own characterisation tests (see
+# Phase 8). Goal: --strict on new files; existing files raised
+# incrementally as they're touched.
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# Aspirational `--strict` per file — start with parsers (Phase 1 target).
+module = [
+    "_set_parser",
+    "_vhdr_parser",
+    "_snirf_parser",
+    "_mef3_parser",
+]
+disallow_untyped_defs = true
+warn_return_any = true
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --tb=short"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "network: marks tests that require network access (deselect with '-m \"not network\"')",
+    "integration: marks tests that hit the live cluster (opt-in via EEGDASH_INTEGRATION_API_URL + EEGDASH_INTEGRATION_ADMIN_TOKEN; deselect with '-m \"not integration\"')",
+]
+# Hypothesis: cap example count for CI speed; raise locally for deep fuzz.
+filterwarnings = [
+    "ignore::DeprecationWarning:hypothesis.*",
+]
+
+[tool.coverage.run]
+source = ["."]
+omit = [
+    "tests/*",
+    "1_fetch_sources/*",
+    "*/conftest.py",
+    "__init__.py",
+    # One-off operational scripts (per ADR 0001 banner). These are run
+    # manually for specific ops tasks (NEMAR citation injection, etc.)
+    # and aren't part of the regular ingest pipeline — including them
+    # in coverage drags the total down without value.
+    "api_helper.py",
+    "inject_nemar_citations.py",
+    "patch_nemar_records_storage.py",
+    "patch_nemar_source.py",
+    "time_openneuro_pipeline.py",
+    # Mutmut runtime config (auto-generated by mutmut; not a test target)
+    "mutmut_config.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    'if __name__ == "__main__":',
+    "if TYPE_CHECKING:",
+]
+show_missing = true
+skip_covered = false
+
+# Mutation testing config (mutmut 2.x — see
+# for why we pinned to 2.x rather than 3.x).
+#
+# Run interactively:
+#   cd scripts/ingestions
+#   mutmut run
+#   mutmut results
+#   mutmut show <id>   # to inspect a surviving mutant
+#
+# Target kill ratio: >= 60 % on _vhdr_parser.py before expanding scope.
+
+[tool.mutmut]
+paths_to_mutate = "_vhdr_parser.py"
+tests_dir = "tests/"
+runner = "python -m pytest tests/parsers/test_vhdr.py tests/parsers/test_property.py -x -q --tb=no --no-header -p no:cacheprovider"

--- a/scripts/ingestions/record_enumerator.py
+++ b/scripts/ingestions/record_enumerator.py
@@ -1,0 +1,389 @@
+"""RecordEnumerator — unify the two digest algorithms behind one Seam.
+
+Two Adapters (:class:`BIDSFilesystemEnumerator`, :class:`ManifestEnumerator`)
+share a common abstract base and return type. The factory
+:func:`get_record_enumerator` selects the right one and manages the
+BIDS-to-manifest fallback so the orchestrator never branches on algorithm.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path, PurePath
+from typing import Any
+
+from eegdash.dataset.bids_dataset import EEGBIDSDataset
+from source_adapter import SourceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EnumerationResult:
+    """Shared return type for both :class:`BIDSFilesystemEnumerator` and
+    :class:`ManifestEnumerator`.
+
+    ``montages`` is empty for the manifest path (no filesystem to read
+    ``electrodes.tsv`` from). ``total_files`` is ``None`` for the BIDS
+    path so the summary field is omitted there.
+    """
+
+    dataset_meta: dict[str, Any]
+    records: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    montages: dict[str, dict[str, Any]] = field(default_factory=dict)
+    digest_method: str = "bids_filesystem"
+    total_files: int | None = None
+
+
+class RecordEnumerator(ABC):
+    """Abstract base — produce all Records for one Dataset (one instance per dataset)."""
+
+    def __init__(
+        self,
+        dataset_id: str,
+        dataset_dir: Path,
+        source: str,
+        source_adapter: SourceAdapter,
+        digested_at: str,
+    ) -> None:
+        self.dataset_id = dataset_id
+        self.dataset_dir = dataset_dir
+        self.source = source
+        self.source_adapter = source_adapter
+        self.digested_at = digested_at
+
+    @abstractmethod
+    def enumerate(self) -> EnumerationResult:
+        """Build the Dataset doc + Records + montages.
+
+        Per-file failures go in :attr:`EnumerationResult.errors`; programmer
+        errors propagate normally.
+        """
+
+
+def get_record_enumerator(
+    dataset_id: str,
+    dataset_dir: Path,
+    source: str,
+    source_adapter: SourceAdapter,
+    digested_at: str,
+) -> RecordEnumerator:
+    """Return the appropriate :class:`RecordEnumerator` for this Dataset.
+
+    Tries :class:`BIDSFilesystemEnumerator` when recording files are present;
+    falls back to :class:`ManifestEnumerator` on BIDS construction failure or
+    when only a ``manifest.json`` exists.
+    """
+    has_manifest = (dataset_dir / "manifest.json").exists()
+    has_actual_files = _has_actual_recording_files(dataset_dir)
+
+    # Case 2: no actual files on disk → manifest path is the only option.
+    if has_manifest and not has_actual_files:
+        return ManifestEnumerator(
+            dataset_id, dataset_dir, source, source_adapter, digested_at
+        )
+
+    # Case 1: try BIDS filesystem; on construction failure, fall back.
+    if has_actual_files:
+        try:
+            return BIDSFilesystemEnumerator(
+                dataset_id, dataset_dir, source, source_adapter, digested_at
+            )
+        except (
+            OSError,
+            ValueError,
+            KeyError,
+            FileNotFoundError,
+            PermissionError,
+        ) as exc:
+            if has_manifest:
+                logger.info(
+                    "BIDS load failed for %s (%s); falling back to manifest path",
+                    dataset_id,
+                    exc,
+                )
+                return ManifestEnumerator(
+                    dataset_id, dataset_dir, source, source_adapter, digested_at
+                )
+            raise
+
+    # Case 3: nothing viable — return manifest if present so enumerate() produces
+    # an empty+error result; else let BIDSFilesystemEnumerator try and surface the error.
+    if has_manifest:
+        return ManifestEnumerator(
+            dataset_id, dataset_dir, source, source_adapter, digested_at
+        )
+    return BIDSFilesystemEnumerator(
+        dataset_id, dataset_dir, source, source_adapter, digested_at
+    )
+
+
+def _has_actual_recording_files(dataset_dir: Path) -> bool:
+    """Return True if any recording file or directory exists under ``dataset_dir``.
+
+    Symlinks count — git-annex pointers are present from the pipeline's perspective.
+    """
+    canonical_exts = {
+        ".set",
+        ".edf",
+        ".bdf",
+        ".vhdr",
+        ".fif",
+        ".cnt",
+        ".snirf",
+        ".mefd",
+    }
+    for entry in dataset_dir.rglob("*"):
+        if entry.is_file() or entry.is_symlink():
+            if entry.suffix in canonical_exts:
+                return True
+        if entry.is_dir() and entry.suffix in {".ds", ".mefd"}:
+            return True
+    return False
+
+
+class BIDSFilesystemEnumerator(RecordEnumerator):
+    """Walk a BIDS filesystem via ``EEGBIDSDataset`` (OpenNeuro, NEMAR path)."""
+
+    def enumerate(self) -> EnumerationResult:
+        """Load ``EEGBIDSDataset`` and run the BIDS-filesystem algorithm.
+
+        Raises ``OSError`` / ``ValueError`` / ``KeyError`` / ``FileNotFoundError`` /
+        ``PermissionError`` on a non-viable BIDS root; the factory catches and falls back.
+        """
+        bids_dataset = EEGBIDSDataset(
+            data_dir=str(self.dataset_dir),
+            dataset=self.dataset_id,
+            allow_symlinks=True,
+        )
+        digest_mod = _load_digest_module()
+        return digest_mod._enumerate_via_bids(
+            self.dataset_dir,
+            self.dataset_id,
+            self.source,
+            self.source_adapter,
+            self.digested_at,
+            bids_dataset,
+            manifest_data=load_manifest_or_summary(
+                self.dataset_dir, self.dataset_dir.name
+            )[0],
+        )
+
+
+class ManifestEnumerator(RecordEnumerator):
+    """Walk a flat ``manifest["files"]`` list (API-only Sources or BIDS fallback).
+
+    Used for Zenodo, Figshare, OSF, SciDB, DataRN, and any BIDS clone
+    that is malformed or empty but has a ``manifest.json``.
+    """
+
+    def enumerate(self) -> EnumerationResult:
+        """Run the manifest-only algorithm via the shared helper."""
+        manifest, load_summary = load_manifest_or_summary(
+            self.dataset_dir, self.dataset_id
+        )
+        if manifest is None:
+            assert load_summary is not None  # invariant of load_manifest_or_summary
+            return EnumerationResult(
+                dataset_meta={"dataset_id": self.dataset_id, "source": self.source},
+                # Explicit 0 (not None) so callers can rely on manifest path
+                # always carrying a non-None total_files.
+                total_files=0,
+                errors=[
+                    {
+                        "file": self.dataset_id,
+                        **load_summary,
+                    }
+                ],
+                digest_method="manifest_only",
+            )
+        digest_mod = _load_digest_module()
+        result, total_files = digest_mod._enumerate_via_manifest(
+            self.dataset_id, manifest, self.digested_at
+        )
+        result.total_files = total_files
+        return result
+
+
+_DIGEST_MODULE_CACHE: Any = None
+
+
+def _load_digest_module() -> Any:
+    """Lazy-load ``3_digest.py`` via importlib (digit prefix blocks normal import), cached."""
+    global _DIGEST_MODULE_CACHE
+    if _DIGEST_MODULE_CACHE is not None:
+        return _DIGEST_MODULE_CACHE
+    spec = spec_from_file_location(
+        "_record_enumerator_digest_target",
+        Path(__file__).parent / "3_digest.py",
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise ImportError("could not load 3_digest.py")
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _DIGEST_MODULE_CACHE = mod
+    return mod
+
+
+def load_manifest_or_summary(
+    dataset_dir: Path, dataset_id: str
+) -> tuple[dict | None, dict | None]:
+    """Read ``manifest.json`` and return ``(manifest, None)`` on success or
+    ``(None, summary)`` on failure with distinct ``reason`` fields for missing,
+    corrupt, and permission-denied cases.
+    """
+    manifest_path = dataset_dir / "manifest.json"
+    if not manifest_path.exists():
+        return None, {
+            "status": "skipped",
+            "dataset_id": dataset_id,
+            "reason": "manifest.json not found",
+        }
+    try:
+        with open(manifest_path) as fh:
+            return json.load(fh), None
+    except json.JSONDecodeError as exc:
+        logger.warning("Manifest at %s is corrupt: %s", manifest_path, exc)
+        return None, {
+            "status": "error",
+            "dataset_id": dataset_id,
+            "error": f"Failed to load manifest: {exc}",
+        }
+    except (OSError, ValueError) as exc:
+        logger.warning("Manifest at %s could not be read: %s", manifest_path, exc)
+        return None, {
+            "status": "error",
+            "dataset_id": dataset_id,
+            "error": f"Failed to read manifest: {exc}",
+        }
+
+
+def _json_default_serializer(obj: Any) -> Any:
+    """JSON ``default=`` for ``Path``, ``datetime``/``date``, and numpy scalars.
+
+    Falls through to ``str()`` so an unexpected type never crashes the pipeline.
+    """
+    if isinstance(obj, PurePath):
+        return str(obj)
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    # numpy scalars / common third-party types
+    if hasattr(obj, "item"):
+        try:
+            return obj.item()  # numpy scalar -> Python primitive
+        except (ValueError, TypeError):
+            pass
+    return str(obj)
+
+
+def write_dataset_outputs(
+    dataset_output_dir: Path,
+    result: EnumerationResult,
+    dataset_id: str,
+    source: str,
+    digested_at: str,
+    *,
+    total_files: int | None = None,
+) -> dict[str, Any]:
+    """Write ``_dataset.json``, ``_records.json``, ``_montages.json``, and
+    ``_summary.json`` into ``dataset_output_dir``; return the summary dict.
+
+    ``_montages.json`` is written for every Adapter path (empty dict included).
+    The summary always carries ``digest_method``, ``integrity_issues_count``,
+    and ``montage_count``.
+    """
+    dataset_output_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_path = dataset_output_dir / f"{dataset_id}_dataset.json"
+    with open(dataset_path, "w") as fh:
+        json.dump(
+            dict(result.dataset_meta),
+            fh,
+            indent=2,
+            default=_json_default_serializer,
+        )
+
+    records_with_issues = [
+        r for r in result.records if r.get("_has_missing_files", False)
+    ]
+    integrity_issues_count = len(records_with_issues)
+    if records_with_issues:
+        authors = result.dataset_meta.get("authors", [])
+        contact_info = result.dataset_meta.get("contact_info")
+        source_url = result.dataset_meta.get("external_links", {}).get("source_url")
+        for rec in records_with_issues:
+            if authors:
+                rec["_dataset_authors"] = authors
+            if contact_info:
+                rec["_dataset_contact"] = contact_info
+            if source_url:
+                rec["_source_url"] = source_url
+        logger.warning(
+            "Dataset %s has %d record(s) with missing companion files",
+            dataset_id,
+            integrity_issues_count,
+        )
+        for rec in records_with_issues:
+            issues = rec.get("_data_integrity_issues", [])
+            logger.warning("  - %s: %s", rec.get("bids_relpath"), "; ".join(issues))
+
+    records_path = dataset_output_dir / f"{dataset_id}_records.json"
+    records_data = {
+        "dataset": dataset_id,
+        "source": source,
+        "digested_at": digested_at,
+        "record_count": len(result.records),
+        "records_with_integrity_issues": integrity_issues_count,
+        "records": result.records,
+    }
+    with open(records_path, "w") as fh:
+        json.dump(records_data, fh, indent=2, default=_json_default_serializer)
+
+    montages_path = dataset_output_dir / f"{dataset_id}_montages.json"
+    montages_data = {
+        "dataset": dataset_id,
+        "source": source,
+        "digested_at": digested_at,
+        "montage_count": len(result.montages),
+        "montages": list(result.montages.values()),
+    }
+    with open(montages_path, "w") as fh:
+        json.dump(montages_data, fh, indent=2, default=_json_default_serializer)
+
+    summary: dict[str, Any] = {
+        "status": "success" if result.records else "no_neuro_files",
+        "dataset_id": dataset_id,
+        "source": source,
+        "record_count": len(result.records),
+        "error_count": len(result.errors),
+        "integrity_issues_count": integrity_issues_count,
+        "montage_count": len(result.montages),
+        "dataset_file": str(dataset_path),
+        "records_file": str(records_path),
+        "montages_file": str(montages_path),
+        "digest_method": result.digest_method,
+    }
+    if total_files is not None:
+        summary["total_files"] = total_files
+
+    summary_path = dataset_output_dir / f"{dataset_id}_summary.json"
+    with open(summary_path, "w") as fh:
+        json.dump(summary, fh, indent=2)
+
+    return summary
+
+
+__all__ = [
+    "BIDSFilesystemEnumerator",
+    "EnumerationResult",
+    "ManifestEnumerator",
+    "RecordEnumerator",
+    "get_record_enumerator",
+    "write_dataset_outputs",
+]

--- a/scripts/ingestions/scripts/find_leaked_creds.sh
+++ b/scripts/ingestions/scripts/find_leaked_creds.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Find leaked credentials in commit messages, file contents, and the
+# index. Exit 1 if any are found; 0 otherwise.
+#
+# Patterns target what's been observed leaking historically:
+#   - EEGDASH_ADMIN_TOKEN=<20+ alphanumerics>
+#   - MONGO_INITDB_ROOT_PASSWORD=<8+ chars>
+#   - 40+ char hex strings (CI_TOKEN shape)
+#
+# Add new patterns at the top; the script reports per-pattern matches.
+
+set -u  # not -e: we want to count matches, not bail on first miss
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  printf '[find_leaked_creds] Not in a git repo — refusing to declare clean.\n' >&2
+  exit 2
+fi
+cd "$git_root" >/dev/null
+
+PATTERNS=(
+  'EEGDASH_ADMIN_TOKEN[[:space:]]*[=:][[:space:]]*"?[A-Za-z0-9]{20,}'
+  'MONGO_INITDB_ROOT_PASSWORD[[:space:]]*[=:][[:space:]]*"?[^[:space:]"]{8,}'
+  'ADMIN_TOKEN[[:space:]]*[=:][[:space:]]*"?[A-Za-z0-9]{20,}'
+  'CI_TOKEN[[:space:]]*[=:][[:space:]]*"?[a-f0-9]{40,}'
+  # Generic AWS-style key shape (no separator)
+  'AKIA[0-9A-Z]{16}'
+)
+
+total=0
+
+scan() {
+  local label="$1" cmd="$2"
+  for pat in "${PATTERNS[@]}"; do
+    matches=$(eval "$cmd" 2>/dev/null | grep -E "$pat" || true)
+    if [[ -n "$matches" ]]; then
+      printf '\n=== %s — pattern: %s ===\n' "$label" "$pat"
+      printf '%s\n' "$matches"
+      lines=$(printf '%s\n' "$matches" | wc -l)
+      total=$((total + lines))
+    fi
+  done
+}
+
+scan "Commit messages" "git log --all --format=%B"
+scan "Tracked file contents" "git grep -I -n '' -- . ':(exclude)*.snirf' ':(exclude)*.tmet' ':(exclude)*.edf' ':(exclude)*.bdf' ':(exclude)*.set' ':(exclude)*.fif' ':(exclude)*.vhdr' ':(exclude)*.cnt' ':(exclude)*.nwb' 2>/dev/null"
+scan "Staged changes"  "git diff --cached"
+
+if [[ $total -gt 0 ]]; then
+  printf '\n[find_leaked_creds] Found %d suspect match(es). Investigate above.\n' "$total" >&2
+  exit 1
+fi
+
+printf '[find_leaked_creds] Clean.\n'
+exit 0

--- a/scripts/ingestions/source_adapter.py
+++ b/scripts/ingestions/source_adapter.py
@@ -1,0 +1,226 @@
+"""Per-Source ingest behaviour — SourceAdapter Seam.
+
+One Adapter class per Source, instantiated per Dataset so per-Dataset state
+(apex sidecar cache, annex-key cache) lives as instance attributes. OpenNeuro
+and NEMAR have dedicated subclasses; everything else falls through to
+:class:`DefaultAdapter`. The factory :func:`get_source_adapter` is the sole
+entry point.
+
+The four divergences between OpenNeuro and NEMAR — storage backend tag, base
+URL, per-file addressing (NEMAR requires git-annex SHA resolution), and apex
+sidecar prefetch — are encapsulated here rather than scattered as
+``if source == "nemar"`` ladders across the pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from _file_utils import get_annex_file_key, read_inline_sidecar
+from eegdash.dataset._source_inference import DEFAULT_STORAGE_CONFIG, STORAGE_CONFIGS
+from eegdash.schemas import NEMAR_ROOT_METADATA_FILES
+
+logger = logging.getLogger(__name__)
+
+
+class SourceAdapter(ABC):
+    """Per-Source ingest behaviour for one Dataset.
+
+    Subclasses override only the methods that differ from the default
+    (straight S3/HTTPS addressing, no prefetch, no annex resolution).
+    ``bids_root`` is required for any Adapter that does on-disk reads
+    (NEMAR apex prefetch, annex-key resolution).
+    """
+
+    def __init__(self, dataset_id: str, bids_root: Path | None = None) -> None:
+        self.dataset_id = dataset_id
+        self.bids_root = bids_root
+
+    # ─── Source identity ─────────────────────────────────────────────
+
+    @property
+    @abstractmethod
+    def source_name(self) -> str:
+        """Source identifier as written into Records (``"openneuro"`` etc.)."""
+
+    @property
+    def storage_backend(self) -> str:
+        """The ``Record.storage.backend`` marker for this Source."""
+        return STORAGE_CONFIGS.get(self.source_name, DEFAULT_STORAGE_CONFIG)["backend"]
+
+    @property
+    def storage_base(self) -> str:
+        """The ``Record.storage.base`` URI prefix for this Dataset."""
+        base = STORAGE_CONFIGS.get(self.source_name, DEFAULT_STORAGE_CONFIG)["base"]
+        return f"{base}/{self.dataset_id}"
+
+    # ─── Behaviour hooks ─────────────────────────────────────────────
+
+    def dataset_url(self) -> str | None:
+        """User-facing landing-page URL. Returns ``None`` for secondary Sources."""
+        return None
+
+    def resolve_storage_extensions(
+        self,
+        record_path: Path,
+        dep_paths: list[Path],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Return ``(annex_keys, sidecar_inline)`` for a single Record.
+
+        Default returns two empty dicts. NEMAR overrides to resolve
+        git-annex SHA keys and inline apex sidecar content.
+        """
+        return {}, {}
+
+
+class OpenNeuroAdapter(SourceAdapter):
+    """OpenNeuro Source — direct S3 addressing.
+
+    All file URIs follow ``s3://openneuro.org/<dataset_id>/<rel_path>``.
+    No git-annex resolution required; no sidecar prefetch needed.
+    """
+
+    @property
+    def source_name(self) -> str:
+        return "openneuro"
+
+    def dataset_url(self) -> str | None:
+        """Public OpenNeuro dataset landing page."""
+        return f"https://openneuro.org/datasets/{self.dataset_id}"
+
+
+class NEMARAdapter(SourceAdapter):
+    """NEMAR Source — git-annex SHA addressing + apex sidecar prefetch.
+
+    NEMAR's S3 bucket has ``s3:ListBucket`` closed by design; all file
+    addresses are SHA-resolved via git-annex on the cloned filesystem.
+    The ``backend="nemar"`` marker signals downstream consumers not to
+    attempt a public S3 fetch.  :data:`NEMAR_ROOT_METADATA_FILES` are
+    read once (lazily, into ``_apex_cache``) and reused across every
+    Record to avoid repeated filesystem round-trips.
+    """
+
+    def __init__(self, dataset_id: str, bids_root: Path | None = None) -> None:
+        super().__init__(dataset_id, bids_root)
+        self._apex_cache: dict[str, str] | None = None
+
+    @property
+    def source_name(self) -> str:
+        return "nemar"
+
+    def dataset_url(self) -> str | None:
+        """NEMAR DataExplorer landing page."""
+        return f"https://nemar.org/dataexplorer/detail/{self.dataset_id}"
+
+    def _ensure_apex_cache(self) -> dict[str, str]:
+        """Lazy-build the apex sidecar inline cache (once per Adapter)."""
+        if self._apex_cache is not None:
+            return self._apex_cache
+        cache: dict[str, str] = {}
+        if self.bids_root is None:
+            self._apex_cache = cache
+            return cache
+        for root_name in NEMAR_ROOT_METADATA_FILES:
+            inline = read_inline_sidecar(self.bids_root / root_name)
+            if inline is not None:
+                cache[root_name] = inline
+        self._apex_cache = cache
+        return cache
+
+    def resolve_storage_extensions(
+        self,
+        record_path: Path,
+        dep_paths: list[Path],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Resolve annex keys and inline sidecars for one Record."""
+        annex_keys: dict[str, str] = {}
+        sidecar_inline: dict[str, str] = dict(self._ensure_apex_cache())
+
+        # The recording itself
+        raw_key = get_annex_file_key(record_path)
+        if raw_key is not None:
+            # NEMAR annex keys are stored against the BIDS relative path
+            # — preserve the convention 3_digest used before this refactor.
+            if self.bids_root is not None:
+                try:
+                    rel = str(record_path.relative_to(self.bids_root))
+                except ValueError:
+                    rel = str(record_path)
+            else:
+                rel = str(record_path)
+            annex_keys[rel] = raw_key
+
+        # Each dep file: annex key OR inlined text
+        for dep_path in dep_paths:
+            if self.bids_root is not None:
+                try:
+                    dep_relpath = str(dep_path.relative_to(self.bids_root))
+                except ValueError:
+                    dep_relpath = str(dep_path)
+            else:
+                dep_relpath = str(dep_path)
+
+            dep_key = get_annex_file_key(dep_path)
+            if dep_key is not None:
+                annex_keys[dep_relpath] = dep_key
+                continue
+            if dep_relpath in sidecar_inline:
+                continue  # already covered by apex cache
+            inline = read_inline_sidecar(dep_path)
+            if inline is not None:
+                sidecar_inline[dep_relpath] = inline
+
+        return annex_keys, sidecar_inline
+
+
+class DefaultAdapter(SourceAdapter):
+    """Fallback Adapter for GIN and secondary Sources (table-driven, no overrides)."""
+
+    def __init__(
+        self,
+        dataset_id: str,
+        source_name: str,
+        bids_root: Path | None = None,
+    ) -> None:
+        super().__init__(dataset_id, bids_root)
+        self._source_name = source_name
+
+    @property
+    def source_name(self) -> str:
+        return self._source_name
+
+
+# ─── Factory ──────────────────────────────────────────────────────────
+
+
+_ADAPTER_CLASSES: dict[str, type[SourceAdapter]] = {
+    "openneuro": OpenNeuroAdapter,
+    "nemar": NEMARAdapter,
+}
+
+
+def get_source_adapter(
+    source: str,
+    dataset_id: str,
+    bids_root: Path | None = None,
+) -> SourceAdapter:
+    """Return the :class:`SourceAdapter` for a ``(source, dataset_id)`` pair.
+
+    Unknown sources fall through to :class:`DefaultAdapter`.
+    ``bids_root`` is required for NEMAR (apex prefetch + annex resolution).
+    """
+    adapter_cls = _ADAPTER_CLASSES.get(source)
+    if adapter_cls is None:
+        return DefaultAdapter(dataset_id, source, bids_root)
+    return adapter_cls(dataset_id, bids_root)
+
+
+__all__ = [
+    "DefaultAdapter",
+    "NEMARAdapter",
+    "OpenNeuroAdapter",
+    "SourceAdapter",
+    "get_source_adapter",
+]

--- a/scripts/ingestions/tests/_helpers/__init__.py
+++ b/scripts/ingestions/tests/_helpers/__init__.py
@@ -1,0 +1,42 @@
+"""Shared test helpers — paths, synthetic fixture builders, factories."""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+from pathlib import Path
+from types import ModuleType
+
+# Stable anchor: ``_helpers/__init__.py`` lives at ``tests/_helpers/``,
+# so ``parents[2]`` is ``scripts/ingestions/`` regardless of how deeply
+# a consumer test file is nested under ``tests/``.
+INGEST_DIR = Path(__file__).resolve().parents[2]
+TESTS_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(filename: str) -> ModuleType:
+    """Load a digit-prefixed ingestion script via ``importlib``.
+
+    Replaces the per-file ``_load_digest()`` / ``_load_inject()`` shims
+    that every consumer used to define. Fresh exec per call (matches the
+    original per-test behaviour — no shared module state).
+    """
+    alias = f"loaded_{Path(filename).stem}"
+    spec = _ilu.spec_from_file_location(alias, INGEST_DIR / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_digest() -> ModuleType:
+    """Load ``3_digest.py``."""
+    return load_module("3_digest.py")
+
+
+def load_inject() -> ModuleType:
+    """Load ``5_inject.py``."""
+    return load_module("5_inject.py")
+
+
+__all__ = ["INGEST_DIR", "TESTS_DIR", "load_digest", "load_inject", "load_module"]

--- a/scripts/ingestions/tests/_helpers/builders.py
+++ b/scripts/ingestions/tests/_helpers/builders.py
@@ -1,0 +1,80 @@
+"""Synthetic-fixture builders shared by parser, digest, and pipeline tests.
+
+Each builder constructs a minimal but valid binary fixture on disk so a
+test can exercise the parser/digest path without committing the file
+into ``eegdash-testing-data``. Anything that can be regenerated cheaply
+lives here; anything that needs real signal data lives in the corpus.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import scipy.io as scipy_io
+
+
+def build_synthetic_set_v5(
+    path: Path,
+    *,
+    srate: float = 250.0,
+    nbchan: int = 32,
+    pnts: int = 5000,
+    ch_names: list[str] | None = None,
+) -> Path:
+    """Construct a minimal EEGLAB .set file in MAT v5 format.
+
+    EEGLAB's struct shape (from the .set parser's reading code):
+        EEG.srate         — sampling rate in Hz
+        EEG.nbchan        — channel count
+        EEG.pnts          — number of samples
+        EEG.chanlocs      — struct array with .labels (channel names)
+    """
+    if ch_names is None:
+        ch_names = [f"Ch{i + 1}" for i in range(nbchan)]
+
+    chanlocs_dtype = np.dtype([("labels", "O")])
+    chanlocs = np.zeros(nbchan, dtype=chanlocs_dtype)
+    for i, name in enumerate(ch_names):
+        chanlocs[i] = (name,)
+
+    eeg_struct = {
+        "srate": np.array([[srate]]),
+        "nbchan": np.array([[nbchan]]),
+        "pnts": np.array([[pnts]]),
+        "chanlocs": chanlocs,
+    }
+    scipy_io.savemat(str(path), {"EEG": eeg_struct}, do_compression=False)
+    return path
+
+
+def build_mefd_around_real_tmet(
+    tmp_path: Path,
+    real_tmet: Path,
+    *,
+    channels: list[str] | None = None,
+) -> Path:
+    """Construct a .mefd directory using a real .tmet fixture.
+
+    Per the MEF 3.0 directory layout, each channel needs its own
+    ``<channel>.timd/<channel>-000000.segd/<channel>-000000.tmet`` path.
+    Copies the same real .tmet into each channel's location so every
+    channel loads the canonical fixture. Returns the .mefd path.
+    """
+    if channels is None:
+        channels = ["EKG", "LAD1", "LAD2"]
+
+    mefd = tmp_path / "sub-test_ieeg.mefd"
+    mefd.mkdir()
+    for ch in channels:
+        segd = mefd / f"{ch}.timd" / f"{ch}-000000.segd"
+        segd.mkdir(parents=True)
+        shutil.copy(real_tmet, segd / f"{ch}-000000.tmet")
+    return mefd
+
+
+__all__ = [
+    "build_mefd_around_real_tmet",
+    "build_synthetic_set_v5",
+]

--- a/scripts/ingestions/tests/conftest.py
+++ b/scripts/ingestions/tests/conftest.py
@@ -1,0 +1,68 @@
+"""Pytest configuration and shared fixtures for ingestion tests.
+
+Fixtures defined here are auto-discovered by pytest in every test file
+under ``tests/``. Keep this file small — module-specific fixtures live
+next to the tests that use them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from eegdash.testing import data_path
+
+# Make the ingestion package importable without `pip install -e .` —
+# this is the smallest layer that lets `from _set_parser import …` work
+# from the test files. Once the package is properly installed via the
+# pyproject.toml, this becomes redundant; for now it keeps `pytest`
+# discoverable from any CWD.
+_INGEST_DIR = Path(__file__).resolve().parent.parent
+if str(_INGEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_INGEST_DIR))
+
+# Also make tests/ itself importable so subfolder tests can write
+# `from _helpers.builders import …` without having to spell out
+# `tests._helpers.builders` everywhere.
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+
+# ─── Fixture paths (lazily fetched from eegdash-testing-data) ──────────────
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"  # only inline: records/
+
+
+def _testing_data_root() -> Path:
+    """Resolve the testing-data corpus root, skipping the test on failure."""
+    try:
+        return data_path()
+    except Exception as exc:  # fetch failure → skip cleanly
+        pytest.skip(f"eegdash-testing-data unavailable: {exc}")
+
+
+@pytest.fixture(scope="session")
+def eeg_fixtures_dir() -> Path:
+    """Path to EEG-modality fixtures (EDF/BDF/BV/SET) inside the testing-data corpus."""
+    return _testing_data_root() / "eeg"
+
+
+@pytest.fixture(scope="session")
+def ieeg_fixtures_dir() -> Path:
+    """Path to iEEG-modality fixtures (BrainVision triple, MEF3 header)."""
+    return _testing_data_root() / "ieeg"
+
+
+@pytest.fixture(scope="session")
+def meg_fixtures_dir() -> Path:
+    """Path to MEG-modality fixtures (FIFF samples from MNE-Python BSD-3)."""
+    return _testing_data_root() / "meg"
+
+
+@pytest.fixture(scope="session")
+def digest_snapshots_dir() -> Path:
+    """Directory containing ``digest_snapshots/{inputs,outputs}/ds_snapshot_*``."""
+    return _testing_data_root() / "digest_snapshots"

--- a/scripts/ingestions/tests/github/test_helpers.py
+++ b/scripts/ingestions/tests/github/test_helpers.py
@@ -1,0 +1,94 @@
+"""Tests for ``_github.py`` — token resolution, ISO timestamp formatting, error path."""
+
+from __future__ import annotations
+
+import sys as _sys
+from datetime import datetime, timedelta, timezone
+
+from _github import _pygithub_client, _to_iso, get_github_token
+
+# ─── get_github_token ──────────────────────────────────────────────────────
+
+
+def test_token_from_explicit_arg_wins_over_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env_token")
+    monkeypatch.setenv("GH_TOKEN", "gh_token")
+    assert get_github_token("explicit") == "explicit"
+
+
+def test_token_from_GITHUB_TOKEN_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "from_github_token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert get_github_token() == "from_github_token"
+
+
+def test_token_falls_back_to_GH_TOKEN_env(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "from_gh_token")
+    assert get_github_token() == "from_gh_token"
+
+
+def test_token_returns_none_when_nothing_configured(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert get_github_token() is None
+
+
+def test_token_empty_string_arg_falls_through_to_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "from_env")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert get_github_token("") == "from_env"
+
+
+# ─── _to_iso ──────────────────────────────────────────────────────────────
+
+
+def test_to_iso_returns_none_for_none():
+    assert _to_iso(None) is None
+
+
+def test_to_iso_formats_utc_datetime_with_Z_suffix():
+    dt = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+    out = _to_iso(dt)
+    assert out is not None
+    assert out.endswith("Z")
+    assert "2026-05-22T12:00:00" in out
+
+
+def test_to_iso_assigns_utc_when_naive():
+    dt = datetime(2026, 5, 22, 12, 0, 0)  # naive
+    out = _to_iso(dt)
+    assert out is not None
+    assert out.endswith("Z")
+
+
+def test_to_iso_preserves_non_utc_offsets():
+    tz_offset = timezone(timedelta(hours=5, minutes=30))  # IST
+    dt = datetime(2026, 5, 22, 12, 0, 0, tzinfo=tz_offset)
+    out = _to_iso(dt)
+    assert out is not None
+    assert "+05:30" in out
+
+
+def test_to_iso_round_trips_via_fromisoformat():
+    dt = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+    out = _to_iso(dt)
+    parsed = datetime.fromisoformat(out.replace("Z", "+00:00"))
+    assert parsed == dt
+
+
+# ─── _pygithub_client (graceful import-error path) ────────────────────────
+
+
+def test_pygithub_client_returns_none_when_pygithub_missing(monkeypatch):
+    """ImportError on ``from github import Github`` → return None."""
+    saved = _sys.modules.pop("github", None)
+    monkeypatch.setitem(_sys.modules, "github", None)  # mark as un-importable
+    try:
+        result = _pygithub_client(token=None, per_page=30, timeout=10.0)
+        assert result is None
+    finally:
+        if saved is not None:
+            _sys.modules["github"] = saved
+        else:
+            _sys.modules.pop("github", None)

--- a/scripts/ingestions/tests/github/test_pygithub_fastpath.py
+++ b/scripts/ingestions/tests/github/test_pygithub_fastpath.py
@@ -1,0 +1,120 @@
+"""PyGithub fast-path tests — covers the path where ``from github import Github`` succeeds."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import respx
+
+from _github import fetch_repo_file_text, iter_org_repos
+
+
+def _install_fake_github(monkeypatch, github_class):
+    """Inject a synthetic ``github`` module so ``from github import Github`` returns ``github_class``."""
+    fake_module = SimpleNamespace(Github=github_class)
+    monkeypatch.setitem(sys.modules, "github", fake_module)
+
+
+# ─── iter_org_repos (PyGithub fast-path) ──────────────────────────────────
+
+
+def test_iter_org_repos_yields_dicts_from_pygithub(monkeypatch):
+    fake_repo1 = MagicMock(
+        name="repo1",
+        description="first repo",
+        default_branch="main",
+        pushed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        html_url="https://github.com/eegdash/repo1",
+        stargazers_count=10,
+        forks_count=2,
+        watchers_count=10,
+    )
+    fake_repo1.name = "repo1"
+    fake_repo2 = MagicMock()
+    fake_repo2.name = "repo2"
+    fake_repo2.description = "second repo"
+    fake_repo2.default_branch = "develop"
+    fake_repo2.pushed_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    fake_repo2.html_url = "https://github.com/eegdash/repo2"
+    fake_repo2.stargazers_count = 5
+    fake_repo2.forks_count = 1
+    fake_repo2.watchers_count = 5
+
+    fake_org = MagicMock()
+    fake_org.get_repos.return_value = iter([fake_repo1, fake_repo2])
+
+    fake_gh = MagicMock()
+    fake_gh.get_organization.return_value = fake_org
+
+    fake_github_class = MagicMock(return_value=fake_gh)
+
+    _install_fake_github(monkeypatch, fake_github_class)
+
+    repos = list(iter_org_repos("eegdash", token="fake_token"))
+    assert len(repos) == 2
+    names = {r["name"] for r in repos}
+    assert names == {"repo1", "repo2"}
+    for r in repos:
+        if r.get("pushed_at"):
+            assert r["pushed_at"].endswith("Z")
+
+
+def test_iter_org_repos_falls_back_to_rest_on_pygithub_exception(monkeypatch):
+    """PyGithub raises → falls back to REST path without propagating the exception."""
+    fake_gh = MagicMock()
+    fake_gh.get_organization.side_effect = Exception("rate limited")
+
+    fake_github_class = MagicMock(return_value=fake_gh)
+    _install_fake_github(monkeypatch, fake_github_class)
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(
+            "https://api.github.com/orgs/eegdash/repos",
+            params__contains={"page": "1"},
+        ).mock(return_value=httpx.Response(404))
+        repos = list(iter_org_repos("eegdash", token=None, retries=0))
+    assert isinstance(repos, list)
+
+
+# ─── fetch_repo_file_text (PyGithub fast-path) ────────────────────────────
+
+
+def test_fetch_repo_file_text_uses_pygithub_when_available(monkeypatch):
+    fake_content = MagicMock()
+    fake_content.decoded_content = b"# README\n\nfrom PyGithub"
+
+    fake_repo = MagicMock()
+    fake_repo.get_contents.return_value = fake_content
+
+    fake_gh = MagicMock()
+    fake_gh.get_repo.return_value = fake_repo
+
+    fake_github_class = MagicMock(return_value=fake_gh)
+    _install_fake_github(monkeypatch, fake_github_class)
+
+    text = fetch_repo_file_text(
+        "eegdash", "test-repo", "README.md", ref="main", token="x"
+    )
+    assert text is not None
+    assert "PyGithub" in text
+
+
+def test_fetch_repo_file_text_returns_none_when_content_is_list(monkeypatch):
+    """get_contents on a directory returns a list; adapter must return None."""
+    fake_repo = MagicMock()
+    fake_repo.get_contents.return_value = [MagicMock(), MagicMock()]  # list
+
+    fake_gh = MagicMock()
+    fake_gh.get_repo.return_value = fake_repo
+
+    fake_github_class = MagicMock(return_value=fake_gh)
+    _install_fake_github(monkeypatch, fake_github_class)
+
+    text = fetch_repo_file_text(
+        "eegdash", "test-repo", "somedir", ref="main", token="x"
+    )
+    assert text is None

--- a/scripts/ingestions/tests/github/test_rest_fallback.py
+++ b/scripts/ingestions/tests/github/test_rest_fallback.py
@@ -1,0 +1,131 @@
+"""GitHub adapter REST fallback tests — PyGithub absent, raw GitHub API mocked via respx."""
+
+from __future__ import annotations
+
+import sys
+
+import httpx
+import respx
+
+from _github import (
+    fetch_first_repo_file_text,
+    fetch_repo_file_json,
+    fetch_repo_file_text,
+)
+
+
+def _hide_pygithub(monkeypatch) -> None:
+    """Force ``from github import Github`` to raise ImportError."""
+    monkeypatch.setitem(sys.modules, "github", None)
+
+
+# ─── fetch_repo_file_text (REST fallback) ─────────────────────────────────
+
+
+@respx.mock
+def test_fetch_repo_file_text_rest_fallback_success(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/README.md"
+    respx.get(url).mock(
+        return_value=httpx.Response(200, text="# Test repo\n\nReadme content")
+    )
+    text = fetch_repo_file_text("eegdash", "test-repo", "README.md", ref="main")
+    assert text is not None
+    assert "Test repo" in text
+
+
+@respx.mock
+def test_fetch_repo_file_text_rest_fallback_404_returns_none(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/missing.txt"
+    respx.get(url).mock(return_value=httpx.Response(404))
+    assert (
+        fetch_repo_file_text("eegdash", "test-repo", "missing.txt", ref="main") is None
+    )
+
+
+@respx.mock
+def test_fetch_repo_file_text_rejects_html_doctype(monkeypatch):
+    """200 response with an HTML body (login redirect) → None."""
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/file.txt"
+    respx.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            text="<!DOCTYPE html><html><body>Please login</body></html>",
+        )
+    )
+    assert fetch_repo_file_text("eegdash", "test-repo", "file.txt", ref="main") is None
+
+
+# ─── fetch_first_repo_file_text ───────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_first_returns_earliest_match(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    respx.get(
+        "https://raw.githubusercontent.com/eegdash/test-repo/main/README.md"
+    ).mock(return_value=httpx.Response(404))
+    respx.get("https://raw.githubusercontent.com/eegdash/test-repo/main/README").mock(
+        return_value=httpx.Response(200, text="readme content")
+    )
+
+    text = fetch_first_repo_file_text(
+        "eegdash", "test-repo", ["README.md", "README"], ref="main"
+    )
+    assert text == "readme content"
+
+
+@respx.mock
+def test_fetch_first_returns_none_when_all_404(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    for cand in ("a.txt", "b.txt", "c.txt"):
+        respx.get(
+            f"https://raw.githubusercontent.com/eegdash/test-repo/main/{cand}"
+        ).mock(return_value=httpx.Response(404))
+
+    text = fetch_first_repo_file_text(
+        "eegdash", "test-repo", ["a.txt", "b.txt", "c.txt"], ref="main"
+    )
+    assert text is None
+
+
+# ─── fetch_repo_file_json ─────────────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_repo_file_json_decodes_response(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/config.json"
+    respx.get(url).mock(
+        return_value=httpx.Response(200, json={"key": "value", "n": 42})
+    )
+    out = fetch_repo_file_json("eegdash", "test-repo", "config.json", ref="main")
+    assert out == {"key": "value", "n": 42}
+
+
+@respx.mock
+def test_fetch_repo_file_json_returns_none_on_404(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/missing.json"
+    respx.get(url).mock(return_value=httpx.Response(404))
+    assert (
+        fetch_repo_file_json("eegdash", "test-repo", "missing.json", ref="main") is None
+    )
+
+
+@respx.mock
+def test_fetch_repo_file_json_returns_none_on_malformed_json(monkeypatch):
+    _hide_pygithub(monkeypatch)
+
+    url = "https://raw.githubusercontent.com/eegdash/test-repo/main/bad.json"
+    respx.get(url).mock(return_value=httpx.Response(200, text="not actually json"))
+    assert fetch_repo_file_json("eegdash", "test-repo", "bad.json", ref="main") is None

--- a/scripts/ingestions/tests/parsers/test_extended.py
+++ b/scripts/ingestions/tests/parsers/test_extended.py
@@ -1,0 +1,118 @@
+"""Direct tests for _snirf_parser and _mef3_parser fail paths and synthetic fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _mef3_parser import parse_mef3_metadata
+from _snirf_parser import _parse_snirf_with_h5py, parse_snirf_metadata
+
+# ─── _snirf_parser ────────────────────────────────────────────────────────
+
+
+def test_snirf_missing_file_returns_none(tmp_path: Path):
+    assert parse_snirf_metadata(tmp_path / "missing.snirf") is None
+
+
+def test_snirf_broken_symlink_returns_none(tmp_path: Path):
+    broken = tmp_path / "broken.snirf"
+    broken.symlink_to(tmp_path / ".no_target")
+    assert parse_snirf_metadata(broken) is None
+
+
+def test_snirf_directory_path_returns_none(tmp_path: Path):
+    result = parse_snirf_metadata(tmp_path)
+    assert result is None
+
+
+def test_snirf_garbage_bytes_returns_none(tmp_path: Path):
+    garbage = tmp_path / "garbage.snirf"
+    garbage.write_bytes(b"\x00\x01\x02 not real HDF5")
+    assert parse_snirf_metadata(garbage) is None
+
+
+def test_snirf_h5py_fallback_handles_empty_hdf5(tmp_path: Path):
+    """_parse_snirf_with_h5py on a non-existent file → None."""
+    result = _parse_snirf_with_h5py(tmp_path / "no.snirf")
+    assert result is None
+
+
+def test_snirf_accepts_string_path(tmp_path: Path):
+    """Path arg accepts both Path and str."""
+    assert parse_snirf_metadata(str(tmp_path / "missing.snirf")) is None
+    assert parse_snirf_metadata(tmp_path / "missing.snirf") is None
+
+
+# ─── _mef3_parser (synthetic .mefd directory) ─────────────────────────────
+
+
+def test_mef3_missing_directory_returns_none(tmp_path: Path):
+    assert parse_mef3_metadata(tmp_path / "missing.mefd") is None
+
+
+def test_mef3_non_mefd_suffix_returns_none(tmp_path: Path):
+    other_dir = tmp_path / "data.txt"
+    other_dir.mkdir()
+    assert parse_mef3_metadata(other_dir) is None
+
+
+def test_mef3_file_not_directory_returns_none(tmp_path: Path):
+    fake = tmp_path / "fake.mefd"
+    fake.write_bytes(b"not a directory")
+    assert parse_mef3_metadata(fake) is None
+
+
+def test_mef3_empty_mefd_returns_none(tmp_path: Path):
+    mefd = tmp_path / "empty.mefd"
+    mefd.mkdir()
+    result = parse_mef3_metadata(mefd)
+    assert result is None or result.get("nchans", 0) == 0
+
+
+def test_mef3_extracts_channel_names_from_timd_dirs(tmp_path: Path):
+    """Channel names are derived from .timd directory names."""
+    mefd = tmp_path / "session.mefd"
+    mefd.mkdir()
+    for ch in ("Cz", "Fz", "Pz"):
+        timd = mefd / f"{ch}.timd"
+        timd.mkdir()
+        (timd / "segment.segd").mkdir()
+
+    result = parse_mef3_metadata(mefd)
+    if result is not None:
+        if "ch_names" in result:
+            assert set(result["ch_names"]) == {"Cz", "Fz", "Pz"}
+
+
+def test_mef3_accepts_string_path(tmp_path: Path):
+    """Path arg accepts both Path and str."""
+    mefd = tmp_path / "test.mefd"
+    mefd.mkdir()
+    out_str = parse_mef3_metadata(str(mefd))
+    out_path = parse_mef3_metadata(mefd)
+    assert out_str == out_path
+
+
+_MEF3_RAISING_TARGET: Path | None = None
+_REAL_ITERDIR = Path.iterdir
+
+
+def _iterdir_raises_for_target(self: Path):
+    """Module-level helper to monkey-patch Path.iterdir (avoids nested-function lint)."""
+    if self == _MEF3_RAISING_TARGET:
+        raise OSError("permission denied")
+    yield from _REAL_ITERDIR(self)
+
+
+def test_mef3_handles_unreadable_directory(tmp_path: Path, monkeypatch):
+    """iterdir() OSError is tolerated and returns None."""
+    global _MEF3_RAISING_TARGET
+    mefd = tmp_path / "broken.mefd"
+    mefd.mkdir()
+    _MEF3_RAISING_TARGET = mefd
+    try:
+        monkeypatch.setattr(Path, "iterdir", _iterdir_raises_for_target)
+        result = parse_mef3_metadata(mefd)
+        assert result is None
+    finally:
+        _MEF3_RAISING_TARGET = None

--- a/scripts/ingestions/tests/parsers/test_format_registry.py
+++ b/scripts/ingestions/tests/parsers/test_format_registry.py
@@ -1,0 +1,66 @@
+"""Unit tests for the format-parser registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _format_parser_registry import (
+    FormatParserResult,
+    _parse_edf_with_mne,
+    get_parser_for_extension,
+    registered_extensions,
+)
+
+# ─── Registry coverage ────────────────────────────────────────────────────
+
+
+def test_registry_covers_six_known_extensions():
+    expected = {".edf", ".bdf", ".set", ".vhdr", ".snirf", ".mefd"}
+    assert set(registered_extensions()) == expected
+
+
+def test_get_parser_returns_none_for_unknown_extension():
+    assert get_parser_for_extension(".nii") is None
+    assert get_parser_for_extension("") is None
+    assert get_parser_for_extension(".unknown") is None
+
+
+def test_get_parser_returns_callable_for_known_extension():
+    for ext in registered_extensions():
+        parser = get_parser_for_extension(ext)
+        assert parser is not None, f"no parser for {ext}"
+        assert callable(parser)
+
+
+def test_edf_and_bdf_share_the_same_parser():
+    """Both EDF and BDF share the same MNE wrapper — changing one must affect the other."""
+    assert get_parser_for_extension(".edf") is get_parser_for_extension(".bdf")
+    assert get_parser_for_extension(".edf") is _parse_edf_with_mne
+
+
+# ─── Contract: parsers return None for nonexistent paths ──────────────────
+
+
+def test_edf_parser_returns_none_for_missing_file(tmp_path: Path):
+    result = _parse_edf_with_mne(tmp_path / "does_not_exist.edf")
+    assert result is None
+
+
+def test_edf_parser_returns_none_for_broken_symlink(tmp_path: Path):
+    broken = tmp_path / "broken.edf"
+    broken.symlink_to(tmp_path / ".no_target")
+    result = _parse_edf_with_mne(broken)
+    assert result is None
+
+
+# ─── FormatParserResult shape ─────────────────────────────────────────────
+
+
+def test_format_parser_result_has_expected_optional_fields():
+    """TypedDict accepts the 5 documented keys (all optional, total=False)."""
+    r1: FormatParserResult = {}
+    r2: FormatParserResult = {"sampling_frequency": 250.0}
+    r3: FormatParserResult = {"nchans": 64, "ch_names": ["Fp1", "Fp2"]}
+    r4: FormatParserResult = {"n_times": 5000}
+    r5: FormatParserResult = {"n_samples": 5000}
+    assert all(isinstance(r, dict) for r in (r1, r2, r3, r4, r5))

--- a/scripts/ingestions/tests/parsers/test_mef3.py
+++ b/scripts/ingestions/tests/parsers/test_mef3.py
@@ -1,0 +1,130 @@
+"""Tests for the MEF3 parser: defensive paths and golden values on real fixture."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+from _helpers.builders import build_mefd_around_real_tmet
+
+from _mef3_parser import _parse_tmet_sampling_frequency, parse_mef3_metadata
+from eegdash.testing import data_file
+
+_TMET_FIXTURE = data_file("ieeg/EKG-000000.tmet")
+
+
+# ─── 1. Defensive paths ────────────────────────────────────────────────────
+
+
+def test_parse_mef3_nonexistent_path_returns_none():
+    missing = Path("/tmp/_nonexistent_.mefd")
+    result = parse_mef3_metadata(missing)
+    assert result is None
+
+
+def test_parse_mef3_empty_directory_does_not_crash(tmp_path: Path):
+    empty_mefd = tmp_path / "empty.mefd"
+    empty_mefd.mkdir()
+    try:
+        result = parse_mef3_metadata(empty_mefd)
+        assert result is None or isinstance(result, dict)
+    except (FileNotFoundError, ValueError, KeyError):
+        pass  # acceptable failure modes
+
+
+def test_parse_mef3_file_instead_of_directory(tmp_path: Path):
+    f = tmp_path / "fake.mefd"
+    f.write_bytes(b"not a directory")
+    try:
+        result = parse_mef3_metadata(f)
+        assert result is None or isinstance(result, dict)
+    except (NotADirectoryError, OSError):
+        pass
+
+
+@pytest.mark.parametrize(
+    "subdir_with_garbage",
+    ["timd_0001", "tmet_0001"],
+)
+def test_parse_mef3_directory_with_garbage_subfiles(
+    tmp_path: Path, subdir_with_garbage: str
+):
+    mefd = tmp_path / "data.mefd"
+    sub = mefd / subdir_with_garbage
+    sub.mkdir(parents=True)
+    (sub / "00001.tdat").write_bytes(b"\x00" * 32)
+    try:
+        result = parse_mef3_metadata(mefd)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, OSError):
+        pass
+
+
+# ─── 2. Real fixture — golden values + tolerance ───────────────────────────
+
+
+def test_real_tmet_extracts_sampling_frequency():
+    """ds003708 .tmet: parser walks offsets 1272/1280/1288 and must surface a sfreq in (0.1, 1_000_000)."""
+    sfreq = _parse_tmet_sampling_frequency(_TMET_FIXTURE)
+    assert sfreq is not None
+    assert 0.1 < sfreq < 1_000_000
+    assert sfreq >= 100, f"sfreq = {sfreq} is suspiciously low for clinical iEEG"
+
+
+def test_real_tmet_bytes_are_long_enough_for_parser():
+    """Parser requires >= 1300 bytes; pin fixture size as regression check."""
+    size = _TMET_FIXTURE.stat().st_size
+    assert size >= 1300
+
+
+@pytest.mark.parametrize(
+    ("channels", "expected_sorted"),
+    [
+        pytest.param(
+            ["EKG", "LAD1", "LAD2", "LAD3"],
+            ["EKG", "LAD1", "LAD2", "LAD3"],
+            id="alphabetic_in_alphabetic_out",
+        ),
+        pytest.param(
+            ["ZZZ", "AAA", "MMM"],
+            ["AAA", "MMM", "ZZZ"],
+            id="non_alphabetic_input_sorted_output",
+        ),
+        pytest.param(["solo"], ["solo"], id="single_channel"),
+    ],
+)
+def test_parse_mef3_metadata_channel_layout(
+    tmp_path: Path, channels: list[str], expected_sorted: list[str]
+):
+    """Build a .mefd dir and assert canonical (nchans, sorted ch_names, sampling_frequency) shape."""
+    mefd = build_mefd_around_real_tmet(tmp_path, _TMET_FIXTURE, channels=channels)
+    out = parse_mef3_metadata(mefd)
+    assert out is not None
+    assert out["nchans"] == len(expected_sorted)
+    assert out["ch_names"] == expected_sorted
+    assert "sampling_frequency" in out
+    assert 0.1 < out["sampling_frequency"] < 1_000_000
+
+
+def test_parse_tmet_truncated_file_returns_none(tmp_path: Path):
+    """A .tmet truncated below 1300 bytes returns None (minimum-size check)."""
+    truncated = tmp_path / "EKG-000000.tmet"
+    truncated.write_bytes(_TMET_FIXTURE.read_bytes()[:1200])  # < 1300
+    assert _parse_tmet_sampling_frequency(truncated) is None
+
+
+def test_parse_tmet_with_zeroed_offset_falls_back_to_none(tmp_path: Path):
+    """Sampling-frequency offset holding 0.0 is rejected by the sanity check."""
+    zeroed = tmp_path / "zero.tmet"
+    zeroed.write_bytes(b"\x00" * 16384)
+    assert _parse_tmet_sampling_frequency(zeroed) is None
+
+
+def test_parse_tmet_with_pathological_double_returns_none(tmp_path: Path):
+    """sfreq offset holding an out-of-range value (e.g. 1e10) is rejected."""
+    bad = tmp_path / "bad.tmet"
+    buf = bytearray(b"\x00" * 16384)
+    buf[1272:1280] = struct.pack("<d", 1e10)
+    bad.write_bytes(bytes(buf))
+    assert _parse_tmet_sampling_frequency(bad) is None

--- a/scripts/ingestions/tests/parsers/test_property.py
+++ b/scripts/ingestions/tests/parsers/test_property.py
@@ -1,0 +1,183 @@
+"""Hypothesis property-based tests for the format parsers.
+
+These tests run 200-500 generated inputs against each parser. They
+catch the class of bug that example-based tests miss: an assumption
+about the input shape that holds for the test fixtures but breaks on
+adversarial input. The viewer's session caught a real FIFF parser
+bug this way — synthetic random bytes never accidentally collided
+with the expected magic, so the parser appeared to "work".
+
+The headline property is **no-crash**: a parser may raise a
+*documented* exception class, but it must never SegFault, raise
+BaseException (KeyboardInterrupt, SystemExit), or hang.
+
+Each parser also gets a stability property if applicable:
+- Re-parsing the same bytes twice returns the same value.
+- The output type is bounded (None or dict, never anything else).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from _fingerprint import fingerprint_from_manifest
+from _set_parser import parse_set_metadata
+from _snirf_parser import parse_snirf_metadata
+from _vhdr_parser import parse_vhdr_metadata
+
+# Cap the inputs at 8 KB — the parsers handle real files, but generating
+# arbitrarily-large random buffers makes the test suite slow without
+# finding extra bugs (the parsing logic at byte 8000 is the same as at
+# byte 8 million for these formats).
+ARBITRARY_BUFFER = st.binary(min_size=0, max_size=8192)
+
+
+def _write_and_call(tmp_path: Path, suffix: str, buf: bytes, parser):
+    """Helper: write ``buf`` to a tmp file with ``suffix``, call ``parser``."""
+    f = tmp_path / f"fuzz{suffix}"
+    f.write_bytes(buf)
+    try:
+        result = parser(f)
+    except (
+        ValueError,
+        KeyError,
+        OSError,
+        RuntimeError,
+        UnicodeDecodeError,
+        UnicodeError,
+        TypeError,
+    ):
+        return None  # acceptable failure
+    # Output type contract: every parser returns None or a dict.
+    assert result is None or isinstance(result, dict), (
+        f"parser returned {type(result).__name__}; expected None or dict"
+    )
+    return result
+
+
+# ─── No-crash properties ───────────────────────────────────────────────────
+
+
+@given(buf=ARBITRARY_BUFFER)
+@settings(max_examples=200, deadline=None)
+def test_parse_vhdr_never_crashes(buf: bytes, tmp_path_factory):
+    """parse_vhdr_metadata may raise ValueError/UnicodeDecodeError/OSError
+    but never BaseException or non-Exception types. Output is None|dict."""
+    tmp = tmp_path_factory.mktemp("vhdr_fuzz")
+    _write_and_call(tmp, ".vhdr", buf, parse_vhdr_metadata)
+
+
+@given(buf=ARBITRARY_BUFFER)
+@settings(max_examples=200, deadline=None)
+def test_parse_set_never_crashes(buf: bytes, tmp_path_factory):
+    """parse_set_metadata robust to random bytes."""
+    tmp = tmp_path_factory.mktemp("set_fuzz")
+    _write_and_call(tmp, ".set", buf, parse_set_metadata)
+
+
+@given(buf=ARBITRARY_BUFFER)
+@settings(max_examples=200, deadline=None)
+def test_parse_snirf_never_crashes(buf: bytes, tmp_path_factory):
+    """parse_snirf_metadata (HDF5 container) robust to random bytes."""
+    tmp = tmp_path_factory.mktemp("snirf_fuzz")
+    _write_and_call(tmp, ".snirf", buf, parse_snirf_metadata)
+
+
+# ─── Determinism properties ────────────────────────────────────────────────
+
+
+@given(buf=ARBITRARY_BUFFER)
+@settings(max_examples=50, deadline=None)
+def test_parse_vhdr_is_deterministic(buf: bytes, tmp_path_factory):
+    """Parsing the same bytes twice returns the same value (no hidden state)."""
+    tmp = tmp_path_factory.mktemp("vhdr_det")
+    a = _write_and_call(tmp, ".vhdr", buf, parse_vhdr_metadata)
+    b = _write_and_call(tmp, ".vhdr", buf, parse_vhdr_metadata)
+    assert a == b
+
+
+@given(buf=ARBITRARY_BUFFER)
+@settings(max_examples=50, deadline=None)
+def test_parse_set_is_deterministic(buf: bytes, tmp_path_factory):
+    """parse_set_metadata is a pure function over the file bytes."""
+    tmp = tmp_path_factory.mktemp("set_det")
+    a = _write_and_call(tmp, ".set", buf, parse_set_metadata)
+    b = _write_and_call(tmp, ".set", buf, parse_set_metadata)
+    assert a == b
+
+
+# ─── INI-shaped property for the VHDR parser ───────────────────────────────
+
+
+# A more constrained generator that produces something LIKE a .vhdr —
+# valid INI sections with arbitrary keys. The parser should always
+# return *something* (dict, possibly with `nchans=None`) on well-formed
+# INI even if the keys are wrong.
+ini_value = st.text(
+    # ``blacklist_categories=("Cs",)`` excludes Unicode surrogates
+    # (\ud800-\udfff) which are valid str codepoints but unencodable as
+    # UTF-8 and would crash ``f.write_text``. The newline/=[] exclusions
+    # keep the value within a single INI value cell.
+    alphabet=st.characters(
+        blacklist_characters="\n\r=[]",
+        blacklist_categories=("Cs",),
+    ),
+    min_size=0,
+    max_size=64,
+)
+ini_key = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("L", "Nd"),
+        whitelist_characters="_",
+        blacklist_categories=("Cs",),
+    ),
+    min_size=1,
+    max_size=32,
+)
+ini_section = st.tuples(ini_key, st.dictionaries(ini_key, ini_value, max_size=5))
+
+
+@given(sections=st.lists(ini_section, min_size=0, max_size=4))
+@settings(max_examples=100, deadline=None)
+def test_parse_vhdr_accepts_arbitrary_ini(sections, tmp_path_factory):
+    """A well-formed INI file (with arbitrary keys) doesn't crash parse_vhdr."""
+    tmp = tmp_path_factory.mktemp("vhdr_ini")
+    lines = []
+    for section, kvs in sections:
+        lines.append(f"[{section}]")
+        for k, v in kvs.items():
+            lines.append(f"{k}={v}")
+    text = "\n".join(lines) + "\n"
+    f = tmp / "fuzz.vhdr"
+    f.write_text(text, encoding="utf-8")
+    try:
+        result = parse_vhdr_metadata(f)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, RuntimeError, UnicodeDecodeError):
+        pass  # documented failure modes
+
+
+# ─── Fingerprint stability under property generation ───────────────────────
+
+
+@given(
+    dataset_id=st.text(min_size=1, max_size=32),
+    source=st.sampled_from(["openneuro", "nemar", "figshare", "zenodo", "osf"]),
+    n_files=st.integers(min_value=0, max_value=20),
+)
+@settings(max_examples=100, deadline=None)
+def test_fingerprint_property_deterministic(
+    dataset_id: str, source: str, n_files: int
+) -> None:
+    """For any (dataset_id, source, manifest), the fingerprint is stable."""
+
+    manifest = {
+        "files": [{"path": f"f{i}.edf", "size": i * 100} for i in range(n_files)],
+    }
+    f1 = fingerprint_from_manifest(dataset_id, source, manifest)
+    f2 = fingerprint_from_manifest(dataset_id, source, manifest)
+    assert f1 == f2
+    assert len(f1) == 64

--- a/scripts/ingestions/tests/parsers/test_set.py
+++ b/scripts/ingestions/tests/parsers/test_set.py
@@ -1,0 +1,252 @@
+"""Tests for the EEGLAB .set parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eegdash.testing import data_file
+
+# scipy.io is only needed for the synthetic-MAT v5 section. importorskip
+# at module scope skips ALL three sections cleanly when scipy is absent.
+scipy_io = pytest.importorskip("scipy.io")
+
+import numpy as np
+from _helpers.builders import build_synthetic_set_v5
+
+from _set_parser import diagnose_set_issues, parse_set_metadata
+
+SET_FIXTURE = data_file("eeg/sub-001_task-AuditoryVisualShift_run-01_eeg.set")
+
+
+# ─── 1. Golden values on the truncated fixture ─────────────────────────────
+
+
+def test_parse_set_returns_dict_on_known_fixture():
+    """The committed truncated .set parses to a dict (not None)."""
+    result = parse_set_metadata(SET_FIXTURE)
+    assert isinstance(result, dict), (
+        "parse_set_metadata must return a dict on a parseable header"
+    )
+
+
+def test_parse_set_truncated_fixture_reports_has_fdt_false():
+    """The fixture is a header-only truncation; parser returns ``{'has_fdt': False}``."""
+    result = parse_set_metadata(SET_FIXTURE)
+    assert result == {"has_fdt": False}
+
+
+def test_diagnose_set_truncated_fixture_status_ok():
+    """A parseable header (even without .fdt) diagnoses as 'ok'."""
+    diag = diagnose_set_issues(SET_FIXTURE)
+    assert diag["status"] == "ok"
+    assert diag["issues"] == []
+
+
+def test_diagnose_set_embeds_metadata():
+    """The diagnose output must include the parsed metadata for callers."""
+    diag = diagnose_set_issues(SET_FIXTURE)
+    assert diag["can_extract_metadata"] is True
+    assert diag["metadata"] == {"has_fdt": False}
+
+
+def test_parse_set_nonexistent_path_returns_none_or_raises():
+    """Missing files must not crash. None or FileNotFoundError both acceptable."""
+    missing = Path(__file__).parent / "_nonexistent_.set"
+    try:
+        result = parse_set_metadata(missing)
+        assert result is None or isinstance(result, dict)
+    except (FileNotFoundError, OSError):
+        pass  # acceptable failure
+
+
+@pytest.mark.parametrize(
+    "garbage",
+    [
+        b"",  # empty
+        b"\x00" * 16,  # nulls
+        b"NOT A MAT FILE",  # wrong magic
+        b"\xff\xfe\xfd\xfc" * 256,  # random bytes
+    ],
+)
+def test_parse_set_garbage_inputs_dont_crash(tmp_path: Path, garbage: bytes):
+    """Various malformed inputs must not crash the process."""
+    f = tmp_path / "garbage.set"
+    f.write_bytes(garbage)
+    try:
+        result = parse_set_metadata(f)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, OSError, RuntimeError):
+        pass  # documented failure modes
+
+
+def test_parse_set_with_directory_path_does_not_crash(tmp_path: Path):
+    """Passing a directory path must not crash."""
+    try:
+        result = parse_set_metadata(tmp_path)
+        assert result is None or isinstance(result, dict)
+    except (IsADirectoryError, OSError, PermissionError):
+        pass
+
+
+# ─── 2. Direct extraction on the same fixture ──────────────────────────────
+
+
+def test_parse_set_extracts_sampling_frequency_when_struct_present():
+    """When sampling_frequency is present, it must be a positive float."""
+    out = parse_set_metadata(SET_FIXTURE)
+    assert out is not None
+    if "sampling_frequency" in out:
+        assert isinstance(out["sampling_frequency"], float)
+        assert out["sampling_frequency"] > 0
+
+
+def test_parse_set_extracts_nchans_when_struct_present():
+    """When nchans is present, it must be a positive int."""
+    out = parse_set_metadata(SET_FIXTURE)
+    assert out is not None
+    if "nchans" in out:
+        assert isinstance(out["nchans"], int)
+        assert out["nchans"] > 0
+
+
+def test_parse_set_ch_names_match_nchans_when_both_present():
+    """If both ch_names and nchans are extracted, they're consistent."""
+    out = parse_set_metadata(SET_FIXTURE)
+    assert out is not None
+    if "ch_names" in out and "nchans" in out:
+        assert len(out["ch_names"]) == out["nchans"]
+        assert all(isinstance(n, str) and n for n in out["ch_names"])
+
+
+def test_parse_set_reports_has_fdt():
+    """``has_fdt`` flag indicates companion .fdt file presence."""
+    out = parse_set_metadata(SET_FIXTURE)
+    assert out is not None
+    assert "has_fdt" in out
+    assert isinstance(out["has_fdt"], bool)
+
+
+def test_parse_set_accepts_string_path():
+    """Path arg accepts both Path and str."""
+    out = parse_set_metadata(str(SET_FIXTURE))
+    assert out is not None
+
+
+def test_parse_set_missing_file_returns_none(tmp_path: Path):
+    """Non-existent file → None, no raise."""
+    assert parse_set_metadata(tmp_path / "missing.set") is None
+
+
+def test_parse_set_broken_symlink_returns_none(tmp_path: Path):
+    """git-annex broken symlink → None."""
+    broken = tmp_path / "broken.set"
+    broken.symlink_to(tmp_path / ".no_target")
+    assert parse_set_metadata(broken) is None
+
+
+def test_parse_set_directory_path_does_not_crash(tmp_path: Path):
+    """A directory passed in → no raised exception."""
+    parse_set_metadata(tmp_path)  # must not raise
+
+
+def test_parse_set_garbage_bytes_returns_none(tmp_path: Path):
+    """A .set file that's not a real MATLAB file → None."""
+    garbage = tmp_path / "garbage.set"
+    garbage.write_bytes(b"\x00\x01\x02 not a real .set file")
+    result = parse_set_metadata(garbage)
+    assert result is None or result == {} or "sampling_frequency" not in result
+
+
+# ─── 3. Synthetic MAT v5 — every extraction branch ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "assertion"),
+    [
+        pytest.param(
+            {"srate": 500.0},
+            lambda o: o.get("sampling_frequency") == 500.0,
+            id="srate_to_sampling_frequency",
+        ),
+        pytest.param(
+            {"nbchan": 64},
+            lambda o: o.get("nchans") == 64,
+            id="nbchan_to_nchans",
+        ),
+        pytest.param(
+            {"pnts": 10000},
+            # Some parsers emit n_samples, others emit n_times — accept either.
+            lambda o: o.get("n_samples") == 10000 or o.get("n_times") == 10000,
+            id="pnts_to_n_samples_or_n_times",
+        ),
+    ],
+)
+def test_set_synthetic_extracts_field(tmp_path: Path, kwargs, assertion):
+    """Synthetic MAT v5 builds: EEG.srate/nbchan/pnts → extracted fields."""
+    set_path = build_synthetic_set_v5(tmp_path / "test.set", **kwargs)
+    out = parse_set_metadata(set_path)
+    assert out is not None
+    assert assertion(out), f"assertion failed on output {out!r}"
+
+
+def test_set_extracts_ch_names_from_chanlocs(tmp_path: Path):
+    """``EEG.chanlocs.labels`` becomes ch_names."""
+    set_path = build_synthetic_set_v5(
+        tmp_path / "test.set",
+        nbchan=3,
+        ch_names=["Cz", "Fz", "Pz"],
+    )
+    out = parse_set_metadata(set_path)
+    assert out is not None
+    if "ch_names" in out:
+        assert sorted(out["ch_names"]) == ["Cz", "Fz", "Pz"]
+
+
+@pytest.mark.parametrize(
+    ("companion_present", "expected_has_fdt"),
+    [
+        pytest.param(False, False, id="no_companion_fdt_false"),
+        pytest.param(True, True, id="companion_present_fdt_true"),
+    ],
+)
+def test_set_reports_has_fdt(
+    tmp_path: Path, companion_present: bool, expected_has_fdt: bool
+):
+    """``has_fdt`` reflects sibling .fdt file presence."""
+    set_path = build_synthetic_set_v5(tmp_path / "test.set")
+    if companion_present:
+        (tmp_path / "test.fdt").write_bytes(b"placeholder")
+    out = parse_set_metadata(set_path)
+    assert out is not None
+    assert out.get("has_fdt") is expected_has_fdt
+
+
+def test_set_handles_struct_without_chanlocs(tmp_path: Path):
+    """A .set with just srate/nbchan/pnts (no chanlocs) still parses."""
+    set_path = tmp_path / "minimal.set"
+    scipy_io.savemat(
+        str(set_path),
+        {
+            "EEG": {
+                "srate": np.array([[250.0]]),
+                "nbchan": np.array([[32]]),
+                "pnts": np.array([[1000]]),
+            }
+        },
+    )
+    out = parse_set_metadata(set_path)
+    assert out is not None
+    assert out.get("sampling_frequency") == 250.0
+    assert out.get("nchans") == 32
+
+
+def test_set_returns_none_when_no_eeg_struct(tmp_path: Path):
+    """A MAT file without ``EEG`` at the top → None or empty."""
+    set_path = tmp_path / "noeeg.set"
+    scipy_io.savemat(str(set_path), {"other_var": np.array([1, 2, 3])})
+    out = parse_set_metadata(set_path)
+    if out is not None:
+        assert "sampling_frequency" not in out
+        assert "nchans" not in out

--- a/scripts/ingestions/tests/parsers/test_snirf.py
+++ b/scripts/ingestions/tests/parsers/test_snirf.py
@@ -1,0 +1,233 @@
+"""Tests for the SNIRF (HDF5-based) fNIRS parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eegdash.testing import data_file
+
+# h5py needed for the synthetic + real sections; missing → skip all three.
+h5py = pytest.importorskip("h5py")
+
+import numpy as np
+
+from _snirf_parser import _parse_snirf_with_h5py, parse_snirf_metadata
+
+REAL_FIXTURE = data_file("fnirs/openneuro_real.snirf")
+
+
+# ─── 1. Defensive paths (missing input, garbage, wrong file type) ──────────
+
+
+def test_parse_snirf_nonexistent_path_returns_none():
+    """Missing files return None, do not crash."""
+    missing = Path("/tmp/_nonexistent_.snirf")
+    result = parse_snirf_metadata(missing)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "garbage",
+    [b"", b"\x00" * 16, b"NOT HDF5", b"\xff\xfe\xfd\xfc" * 64],
+)
+def test_parse_snirf_garbage_input_does_not_crash(tmp_path: Path, garbage: bytes):
+    """Various malformed inputs must not crash the process."""
+    f = tmp_path / "garbage.snirf"
+    f.write_bytes(garbage)
+    try:
+        result = parse_snirf_metadata(f)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, OSError, RuntimeError):
+        pass  # documented failure modes
+
+
+def test_parse_snirf_directory_path_does_not_crash(tmp_path: Path):
+    """Passing a directory must not crash."""
+    try:
+        result = parse_snirf_metadata(tmp_path)
+        assert result is None or isinstance(result, dict)
+    except (IsADirectoryError, OSError, PermissionError):
+        pass
+
+
+# ─── 2. Synthetic HDF5 happy-path ──────────────────────────────────────────
+
+
+def _build_synthetic_snirf(
+    path: Path,
+    *,
+    n_channels: int = 3,
+    sampling_frequency: float = 50.0,
+    include_probe_labels: bool = True,
+) -> Path:
+    """Construct a minimal valid SNIRF v1.0 HDF5 file."""
+    duration_s = 2.0
+    n_samples = int(sampling_frequency * duration_s)
+    time_data = np.linspace(0.0, duration_s, n_samples)
+
+    with h5py.File(path, "w") as f:
+        nirs = f.create_group("nirs")
+        data1 = nirs.create_group("data1")
+        data1.create_dataset("time", data=time_data)
+
+        if include_probe_labels:
+            probe = nirs.create_group("probe")
+            probe.create_dataset(
+                "sourceLabels",
+                data=np.array(
+                    [f"S{i + 1}".encode() for i in range(n_channels)],
+                    dtype="S10",
+                ),
+            )
+            probe.create_dataset(
+                "detectorLabels",
+                data=np.array(
+                    [f"D{i + 1}".encode() for i in range(n_channels)],
+                    dtype="S10",
+                ),
+            )
+
+        for i in range(n_channels):
+            ml = data1.create_group(f"measurementList{i + 1}")
+            ml.create_dataset("sourceIndex", data=i + 1)
+            ml.create_dataset("detectorIndex", data=i + 1)
+
+    return path
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field", "expected", "tolerance"),
+    [
+        pytest.param(
+            {"sampling_frequency": 100.0},
+            "sampling_frequency",
+            100.0,
+            1.0,  # 1% tolerance for linspace rounding
+            id="time_deltas_give_sampling_frequency",
+        ),
+        pytest.param(
+            {"n_channels": 5},
+            "nchans",
+            5,
+            0,  # exact
+            id="measurementList_count_gives_nchans",
+        ),
+    ],
+)
+def test_snirf_h5py_extracts_field(
+    tmp_path: Path, kwargs: dict, field: str, expected, tolerance
+):
+    """Synthetic HDF5: time-deltas → sampling_frequency; measurementListN → nchans."""
+    snirf = _build_synthetic_snirf(tmp_path / "test.snirf", **kwargs)
+    out = _parse_snirf_with_h5py(snirf)
+    assert out is not None
+    assert field in out
+    if tolerance:
+        assert abs(out[field] - expected) < tolerance
+    else:
+        assert out[field] == expected
+
+
+def test_snirf_h5py_builds_ch_names_from_probe_labels(tmp_path: Path):
+    """When probe.sourceLabels/detectorLabels are present, channels are named ``<source>-<detector>``."""
+    snirf = _build_synthetic_snirf(tmp_path / "test.snirf", n_channels=3)
+    out = _parse_snirf_with_h5py(snirf)
+    assert out is not None
+    ch_names = out.get("ch_names", [])
+    assert len(ch_names) == 3
+    assert "S1-D1" in ch_names
+    assert "S2-D2" in ch_names
+
+
+def test_snirf_h5py_falls_back_to_indices_when_no_labels(tmp_path: Path):
+    """Without probe labels, channels are named via 1-based indices."""
+    snirf = _build_synthetic_snirf(
+        tmp_path / "test.snirf", n_channels=2, include_probe_labels=False
+    )
+    out = _parse_snirf_with_h5py(snirf)
+    assert out is not None
+    ch_names = out.get("ch_names", [])
+    assert len(ch_names) == 2
+    assert all("-" in c for c in ch_names)
+
+
+def test_snirf_h5py_returns_none_for_hdf5_without_nirs_group(tmp_path: Path):
+    """An HDF5 file without a ``nirs`` group → None."""
+    bad_snirf = tmp_path / "no_nirs.snirf"
+    with h5py.File(bad_snirf, "w") as f:
+        f.create_group("other_group")
+        f.create_dataset("random_data", data=[1, 2, 3])
+    assert _parse_snirf_with_h5py(bad_snirf) is None
+
+
+def test_snirf_h5py_handles_empty_time_dataset(tmp_path: Path):
+    """``data1/time`` with a single point → no sampling_frequency; nchans still extracted."""
+    path = tmp_path / "shortdata.snirf"
+    with h5py.File(path, "w") as f:
+        nirs = f.create_group("nirs")
+        data1 = nirs.create_group("data1")
+        data1.create_dataset("time", data=np.array([0.0]))
+        ml = data1.create_group("measurementList1")
+        ml.create_dataset("sourceIndex", data=1)
+        ml.create_dataset("detectorIndex", data=1)
+    out = _parse_snirf_with_h5py(path)
+    assert out is not None
+    assert "sampling_frequency" not in out
+    assert out.get("nchans") == 1
+
+
+def test_parse_snirf_metadata_uses_h5py_fallback(tmp_path: Path):
+    """The public ``parse_snirf_metadata`` falls through to h5py when MNE can't read the file."""
+    snirf = _build_synthetic_snirf(tmp_path / "via_public.snirf", n_channels=4)
+    out = parse_snirf_metadata(snirf)
+    assert out is not None
+    assert "nchans" in out
+    assert out["nchans"] >= 1
+
+
+# ─── 3. Real fixture (ds007554, CC0, ~10 Hz × 32 channels) ──────────────────
+
+
+def test_real_snirf_returns_sampling_frequency():
+    """The real ds007554 fNIRS recording yields a non-zero sfreq in the expected range."""
+    md = parse_snirf_metadata(REAL_FIXTURE)
+    assert md is not None, "parser returned None on real .snirf"
+    assert md.get("sampling_frequency"), (
+        "real .snirf must yield non-zero sampling_frequency"
+    )
+    sf = md["sampling_frequency"]
+    assert sf > 0
+    assert 1.0 < sf < 200.0, f"sfreq={sf} outside expected fNIRS range"
+
+
+def test_real_snirf_returns_nchans():
+    """The real .snirf has 32 channels (16 sources × 2 wavelengths)."""
+    md = parse_snirf_metadata(REAL_FIXTURE)
+    assert md is not None
+    assert md.get("nchans"), "real .snirf must yield nchans"
+    assert md["nchans"] >= 1
+
+
+def test_real_snirf_returns_n_times():
+    """The real .snirf yields the recording length in samples."""
+    md = parse_snirf_metadata(REAL_FIXTURE)
+    assert md is not None
+    n_times = md.get("n_times")
+    assert n_times is not None, (
+        f"real .snirf must surface n_times; got keys={sorted(md.keys())}"
+    )
+    assert n_times > 0
+
+
+def test_real_snirf_returns_ch_names_matching_nchans():
+    """ch_names length must equal nchans on the real recording."""
+    md = parse_snirf_metadata(REAL_FIXTURE)
+    assert md is not None
+    ch_names = md.get("ch_names")
+    assert ch_names, "real .snirf must yield ch_names"
+    assert isinstance(ch_names, list)
+    assert len(ch_names) == md["nchans"], (
+        f"ch_names ({len(ch_names)}) != nchans ({md['nchans']})"
+    )

--- a/scripts/ingestions/tests/parsers/test_vhdr.py
+++ b/scripts/ingestions/tests/parsers/test_vhdr.py
@@ -1,0 +1,194 @@
+"""Unit tests for the BrainVision ``.vhdr`` parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _vhdr_parser import (
+    diagnose_vhdr_issues,
+    extract_vhdr_references,
+    parse_vhdr_metadata,
+    parse_vhdr_metadata_robust,
+)
+from eegdash.testing import data_file
+
+# ── EEG fixture (ds002336 sub-xp101) ────────────────────────────────────────
+
+EEG_VHDR = data_file("eeg/sub-xp101_task-motorloc_eeg.vhdr")
+EEG_EEG = data_file("eeg/sub-xp101_task-motorloc_eeg.eeg")
+EEG_VMRK = data_file("eeg/sub-xp101_task-motorloc_eeg.vmrk")
+
+# ── iEEG fixture (ds003688 sub-01) ──────────────────────────────────────────
+
+IEEG_VHDR = data_file("ieeg/sub-01_ses-iemu_task-film_acq-clinical_run-1_ieeg.vhdr")
+
+
+# ─── parse_vhdr_metadata — golden values on EEG fixture ────────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        pytest.param("nchans", 64, id="nchans=64"),
+        pytest.param("sampling_frequency", 5000.0, id="sfreq=5000Hz"),
+    ],
+)
+def test_parse_vhdr_eeg_returns_expected_field(field: str, expected):
+    meta = parse_vhdr_metadata(EEG_VHDR)
+    assert meta is not None
+    assert meta[field] == expected
+
+
+def test_parse_vhdr_eeg_returns_correct_channel_label_count():
+    meta = parse_vhdr_metadata(EEG_VHDR)
+    assert meta is not None
+    assert len(meta["ch_names"]) == meta["nchans"] == 64
+
+
+@pytest.mark.parametrize(
+    ("idx", "expected_name"),
+    [
+        (0, "Fp1"),
+        (1, "Fp2"),
+        (17, "Cz"),
+        (31, "ECG"),  # the only non-EEG channel in this montage
+        (63, "CPz"),
+    ],
+)
+def test_parse_vhdr_eeg_channel_names_at_known_positions(
+    idx: int, expected_name: str
+) -> None:
+    meta = parse_vhdr_metadata(EEG_VHDR)
+    assert meta is not None
+    assert meta["ch_names"][idx] == expected_name
+
+
+# ─── parse_vhdr_metadata — golden values on iEEG fixture ───────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        pytest.param("nchans", 111, id="nchans=111"),
+        pytest.param("sampling_frequency", 2048.0, id="sfreq=2048Hz"),
+    ],
+)
+def test_parse_vhdr_ieeg_returns_expected_field(field: str, expected):
+    meta = parse_vhdr_metadata(IEEG_VHDR)
+    assert meta is not None
+    assert meta[field] == expected
+
+
+@pytest.mark.parametrize(
+    ("ch_name_or_idx", "expected"),
+    [
+        pytest.param(0, "AR1", id="idx_0_is_AR1"),
+        pytest.param(1, "AR2", id="idx_1_is_AR2"),
+        pytest.param("EMG+", "EMG+", id="EMG+_present_anywhere"),
+    ],
+)
+def test_parse_vhdr_ieeg_channel_layout(ch_name_or_idx, expected: str):
+    meta = parse_vhdr_metadata(IEEG_VHDR)
+    assert meta is not None
+    if isinstance(ch_name_or_idx, int):
+        assert meta["ch_names"][ch_name_or_idx] == expected
+    else:
+        assert expected in meta["ch_names"]
+
+
+# ─── extract_vhdr_references — sibling file resolution ─────────────────────
+
+
+def test_extract_vhdr_references_resolves_datafile():
+    refs = extract_vhdr_references(EEG_VHDR)
+    assert refs["datafile"] == "sub-xp101_task-motorloc_eeg.eeg"
+
+
+def test_extract_vhdr_references_resolves_markerfile():
+    refs = extract_vhdr_references(EEG_VHDR)
+    assert refs["markerfile"] == "sub-xp101_task-motorloc_eeg.vmrk"
+
+
+def test_extract_vhdr_references_reports_companion_existence():
+    refs = extract_vhdr_references(EEG_VHDR)
+    assert refs["datafile_exists"] is True
+    assert refs["markerfile_exists"] is True
+
+
+# ─── diagnose_vhdr_issues — happy path ─────────────────────────────────────
+
+
+def test_diagnose_vhdr_eeg_reports_ok():
+    diag = diagnose_vhdr_issues(EEG_VHDR)
+    assert diag["status"] == "ok"
+    assert diag["issues"] == []
+
+
+def test_diagnose_vhdr_eeg_extracts_metadata_field():
+    diag = diagnose_vhdr_issues(EEG_VHDR)
+    assert diag["can_extract_metadata"] is True
+    assert diag["metadata"]["nchans"] == 64
+    assert diag["metadata"]["sampling_frequency"] == 5000.0
+
+
+# ─── parse_vhdr_metadata_robust — fallback chain ───────────────────────────
+
+
+def test_parse_vhdr_robust_matches_strict_on_core_fields():
+    """Robust parser returns the same core fields; auxiliary ``_status``/``_diagnosis`` are not compared."""
+    strict = parse_vhdr_metadata(EEG_VHDR)
+    robust = parse_vhdr_metadata_robust(EEG_VHDR)
+    assert strict is not None
+    assert robust is not None
+    for field in ("nchans", "sampling_frequency", "ch_names"):
+        assert robust[field] == strict[field], f"mismatch on {field!r}"
+
+
+def test_parse_vhdr_robust_surfaces_diagnosis_field():
+    robust = parse_vhdr_metadata_robust(EEG_VHDR)
+    assert robust is not None
+    assert "_diagnosis" in robust
+    assert robust["_status"] == "ok"
+
+
+# ─── Edge cases — defensive parsing ────────────────────────────────────────
+
+
+def test_parse_vhdr_nonexistent_path_returns_none_or_raises():
+    """Missing file must not crash; may return None or raise FileNotFoundError/OSError."""
+    missing = Path(__file__).parent / "_nonexistent_.vhdr"
+    try:
+        result = parse_vhdr_metadata(missing)
+        assert result is None or isinstance(result, dict)
+    except (FileNotFoundError, OSError):
+        pass  # acceptable failure
+
+
+def test_parse_vhdr_empty_file_returns_none(tmp_path: Path):
+    empty = tmp_path / "empty.vhdr"
+    empty.write_bytes(b"")
+    try:
+        result = parse_vhdr_metadata(empty)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, RuntimeError):
+        pass
+
+
+def test_parse_vhdr_garbage_bytes_does_not_crash(tmp_path: Path):
+    garbage = tmp_path / "garbage.vhdr"
+    garbage.write_bytes(b"\x00\x01\x02\x03\x04\xff\xfe\xfd" * 100)
+    try:
+        result = parse_vhdr_metadata(garbage)
+        assert result is None or isinstance(result, dict)
+    except (ValueError, KeyError, UnicodeDecodeError):
+        pass
+
+
+def test_parse_vhdr_returns_none_for_directory(tmp_path: Path):
+    try:
+        result = parse_vhdr_metadata(tmp_path)
+        assert result is None or isinstance(result, dict)
+    except (IsADirectoryError, OSError, PermissionError):
+        pass

--- a/scripts/ingestions/tests/test_smoke.py
+++ b/scripts/ingestions/tests/test_smoke.py
@@ -1,0 +1,81 @@
+"""Smoke tests for fixture-corpus presence + license attribution.
+
+A handful of canary checks proving (a) the eegdash-testing-data corpus
+landed in the local cache and (b) every modality/format pair the
+parsers expect is represented. The "does pytest collect at all" test
+that used to live here was a pure tautology and was removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_fixtures_directory_exists(eeg_fixtures_dir: Path) -> None:
+    """The CC0 fixture corpus has been fetched into the cache.
+
+    Without these fixtures, Phase 1 parser tests cannot run. The
+    fixture itself triggers the lazy download from eegdash-testing-data
+    on first use; this test is the canary that the download landed.
+    """
+    assert eeg_fixtures_dir.exists(), (
+        f"fixtures dir missing at {eeg_fixtures_dir} — "
+        "run `python -m eegdash.testing` to fetch the corpus"
+    )
+    edf_files = list(eeg_fixtures_dir.glob("*.edf"))
+    assert len(edf_files) >= 1, "expected at least one .edf fixture"
+
+
+def test_attribution_file_present(eeg_fixtures_dir: Path) -> None:
+    """Fixture provenance must be documented.
+
+    Every fixture binary in the corpus is derived from a CC0 or
+    BSD-licensed source. The attribution file is the contract that
+    keeps this redistributable.
+    """
+    attribution = eeg_fixtures_dir / "LICENSE-ATTRIBUTION.md"
+    assert attribution.exists(), (
+        "eeg/LICENSE-ATTRIBUTION.md must document the source of each "
+        "binary fixture (BIDS dataset accession + license)."
+    )
+    text = attribution.read_text()
+    assert "CC0" in text, "attribution must mention the CC0 license"
+
+
+@pytest.mark.parametrize(
+    ("modality", "suffix"),
+    [
+        ("eeg", ".edf"),
+        ("eeg", ".bdf"),
+        ("eeg", ".vhdr"),
+        ("eeg", ".set"),
+        ("ieeg", ".vhdr"),
+        ("meg", ".fif"),
+    ],
+)
+def test_modality_format_coverage(
+    modality: str,
+    suffix: str,
+    eeg_fixtures_dir: Path,
+    ieeg_fixtures_dir: Path,
+    meg_fixtures_dir: Path,
+) -> None:
+    """At least one fixture exists for each (modality, format) pair.
+
+    This is the matrix that proves the test corpus covers every reader
+    we are expected to test. If a future contributor adds a new reader
+    (CTF, SNIRF, etc.), the matrix grows.
+    """
+    fixtures_root = {
+        "eeg": eeg_fixtures_dir,
+        "ieeg": ieeg_fixtures_dir,
+        "meg": meg_fixtures_dir,
+    }[modality]
+    matches = list(fixtures_root.glob(f"*{suffix}"))
+    assert matches, (
+        f"no {modality}{suffix} fixture in {fixtures_root}. "
+        "Add it to eegdash/eegdash-testing-data and bump the pin in "
+        "eegdash/testing.py."
+    )

--- a/scripts/ingestions/tests/unit/test_bids_paths.py
+++ b/scripts/ingestions/tests/unit/test_bids_paths.py
@@ -1,0 +1,304 @@
+"""Tests for ``_bids.py`` — BIDS structure validation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _bids import (
+    BIDS_DATASET_ZIP_PATTERN,
+    BIDS_OPTIONAL_FILES,
+    BIDS_REQUIRED_FILES,
+    BIDS_SUBJECT_PATTERN,
+    collect_bids_matches,
+    count_bad_channels,
+    find_channels_tsv,
+    validate_bids_structure_from_files,
+    validate_bids_structure_from_names,
+)
+
+# ─── collect_bids_matches ─────────────────────────────────────────────────
+
+
+def test_collect_matches_required_files_case_insensitive():
+    """Required-file lookup is case-insensitive."""
+    out = collect_bids_matches(
+        ["Dataset_Description.JSON", "other.txt"],
+        required_files=["dataset_description.json"],
+        optional_files=[],
+    )
+    assert "dataset_description.json" in out["required_found"]
+
+
+def test_collect_returns_empty_for_empty_input():
+    out = collect_bids_matches(
+        [],
+        required_files=["dataset_description.json"],
+        optional_files=[],
+    )
+    assert out["required_found"] == []
+    assert out["subject_files"] == []
+    assert out["bids_zip_files"] == []
+
+
+def test_collect_finds_subject_folders():
+    out = collect_bids_matches(
+        ["sub-01", "sub-02", "README.md"],
+        required_files=[],
+        optional_files=[],
+    )
+    assert sorted(out["subject_files"]) == ["sub-01", "sub-02"]
+    assert out["subject_zips"] == []
+
+
+def test_collect_finds_subject_zips():
+    """Subject zips are flagged separately for downstream extraction."""
+    out = collect_bids_matches(
+        ["sub-01.zip", "sub-02.zip", "data.csv"],
+        required_files=[],
+        optional_files=[],
+    )
+    assert sorted(out["subject_zips"]) == ["sub-01.zip", "sub-02.zip"]
+    assert sorted(out["subject_files"]) == ["sub-01.zip", "sub-02.zip"]
+
+
+def test_collect_with_dataset_zip_pattern_finds_bids_zips():
+    """BIDS_DATASET_ZIP_PATTERN matches 'bids'/'dataset' prefixes and '_bids.zip' suffix; plain 'data.zip' does not match."""
+    out = collect_bids_matches(
+        ["dataset_bids_v1.zip", "study_bids.zip", "data.zip", "results.csv"],
+        required_files=[],
+        optional_files=[],
+        dataset_zip_pattern=BIDS_DATASET_ZIP_PATTERN,
+    )
+    assert "dataset_bids_v1.zip" in out["bids_zip_files"]
+    assert "study_bids.zip" in out["bids_zip_files"]
+    assert "data.zip" not in out["bids_zip_files"]
+    assert "results.csv" not in out["bids_zip_files"]
+
+
+def test_collect_dataset_zip_matcher_search_finds_pattern_anywhere():
+    """``matcher='search'`` finds patterns anywhere in the filename."""
+    files = ["prefix_data_bids.zip"]
+    search_result = collect_bids_matches(
+        files,
+        required_files=[],
+        optional_files=[],
+        dataset_zip_pattern=BIDS_DATASET_ZIP_PATTERN,
+        dataset_zip_matcher="search",
+    )
+    assert "prefix_data_bids.zip" in search_result["bids_zip_files"]
+
+
+# ─── validate_bids_structure_from_names ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("names", "kwargs", "checks"),
+    [
+        pytest.param(
+            ["dataset_description.json", "sub-01", "sub-02", "README"],
+            {},
+            {
+                "is_bids": True,
+                "subject_count": 2,
+                "bids_files_found_includes": "dataset_description.json",
+            },
+            id="test_validate_structure_recognises_bids_root",
+        ),
+        pytest.param(
+            ["data1.csv", "data2.csv", "README.txt"],
+            {},
+            {"is_bids": False, "subject_count": 0},
+            id="test_validate_structure_rejects_non_bids_layout",
+        ),
+        pytest.param(
+            ["sub-01.zip", "sub-02.zip", "sub-03.zip"],
+            {},
+            {"is_bids": True, "subject_count": 3, "has_subject_zips": True},
+            id="test_validate_structure_accepts_subject_zips_alone",
+        ),
+        pytest.param(
+            ["sub-01"],
+            {},
+            {"is_bids": False},
+            id="test_validate_structure_requires_min_subjects",
+        ),
+        pytest.param(
+            ["data_bids.zip"],
+            {"dataset_zip_pattern": BIDS_DATASET_ZIP_PATTERN},
+            {"is_bids": True, "has_bids_zip": True},
+            id="test_validate_structure_accepts_dataset_zip",
+        ),
+        pytest.param(
+            ["sub-01", "sub-02"],
+            {"include_subject_files": True},
+            {"subject_files_sorted": ["sub-01", "sub-02"]},
+            id="test_validate_structure_include_subject_files_returns_list",
+        ),
+        pytest.param(
+            [f"sub-{i:03d}" for i in range(50)],
+            {"include_subject_files": True, "subject_files_limit": 5},
+            {"subject_files_len": 5},
+            id="test_validate_structure_subject_files_limit_respected",
+        ),
+    ],
+)
+def test_validate_structure_from_names(names, kwargs, checks):
+    """validate_bids_structure_from_names behaves correctly across layouts."""
+    out = validate_bids_structure_from_names(names, **kwargs)
+    if "is_bids" in checks:
+        assert out["is_bids"] is checks["is_bids"]
+    if "subject_count" in checks:
+        assert out["subject_count"] == checks["subject_count"]
+    if "bids_files_found_includes" in checks:
+        assert checks["bids_files_found_includes"] in out["bids_files_found"]
+    if "has_subject_zips" in checks:
+        assert out["has_subject_zips"] is checks["has_subject_zips"]
+    if "has_bids_zip" in checks:
+        assert out["has_bids_zip"] is checks["has_bids_zip"]
+    if "subject_files_sorted" in checks:
+        assert sorted(out["subject_files"]) == checks["subject_files_sorted"]
+    if "subject_files_len" in checks:
+        assert len(out["subject_files"]) == checks["subject_files_len"]
+
+
+# ─── validate_bids_structure_from_files ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("files", "name_key", "checks"),
+    [
+        pytest.param(
+            [
+                {"name": "dataset_description.json"},
+                {"name": "sub-01"},
+                {"name": "sub-02"},
+            ],
+            "name",
+            {"is_bids": True, "subject_count": 2},
+            id="test_validate_from_files_extracts_name_key",
+        ),
+        pytest.param(
+            [],
+            "name",
+            {"is_bids": False, "subject_count": 0},
+            id="test_validate_from_files_handles_empty_list",
+        ),
+        pytest.param(
+            [{"size": 100}, {"size": 200}],
+            "name",
+            {"is_bids": False},
+            id="test_validate_from_files_tolerates_missing_name_key",
+        ),
+    ],
+)
+def test_validate_from_files(files, name_key, checks):
+    """validate_bids_structure_from_files handles dict-list inputs; missing name keys are treated as empty strings."""
+    out = validate_bids_structure_from_files(files, name_key=name_key)
+    if "is_bids" in checks:
+        assert out["is_bids"] is checks["is_bids"]
+    if "subject_count" in checks:
+        assert out["subject_count"] == checks["subject_count"]
+
+
+# ─── find_channels_tsv ─────────────────────────────────────────────────────
+
+
+def test_find_channels_tsv_returns_parent_default_when_no_match(tmp_path: Path):
+    """When no channels.tsv exists, returns ``parent/channels.tsv`` (path may not exist)."""
+    eeg_file = tmp_path / "sub-01_eeg.edf"
+    eeg_file.touch()
+    out = find_channels_tsv(eeg_file)
+    assert out.name == "channels.tsv"
+    assert out.parent == tmp_path
+
+
+def test_find_channels_tsv_prefers_canonical_filename(tmp_path: Path):
+    """``channels.tsv`` (no prefix) is returned if it exists."""
+    eeg_file = tmp_path / "sub-01_eeg.edf"
+    eeg_file.touch()
+    (tmp_path / "channels.tsv").touch()
+    out = find_channels_tsv(eeg_file)
+    assert out.name == "channels.tsv"
+
+
+def test_find_channels_tsv_falls_back_to_prefix_match(tmp_path: Path):
+    """Falls back to ``<stem>_channels.tsv`` when no bare ``channels.tsv`` exists."""
+    eeg_file = tmp_path / "sub-01_task-rest_eeg.edf"
+    eeg_file.touch()
+    prefix_tsv = tmp_path / "sub-01_task-rest_channels.tsv"
+    prefix_tsv.touch()
+    out = find_channels_tsv(eeg_file)
+    assert out.name == "sub-01_task-rest_channels.tsv"
+
+
+# ─── count_bad_channels ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(
+            "name\ttype\tstatus\nCz\teeg\tgood\nFz\teeg\tgood\n",
+            0,
+            id="test_count_bad_channels_returns_zero_when_no_bad",
+        ),
+        pytest.param(
+            "name\ttype\tstatus\nCz\teeg\tgood\nFz\teeg\tbad\nOz\teeg\tbad\n",
+            2,
+            id="test_count_bad_channels_counts_bad_status",
+        ),
+        pytest.param(
+            "name\tstatus\nCz\tBAD\nFz\tBad\nOz\tbad\nPz\tgood\n",
+            3,
+            id="test_count_bad_channels_case_insensitive",
+        ),
+        pytest.param(
+            "name\ttype\nCz\teeg\nFz\teeg\n",
+            None,
+            id="test_count_bad_channels_returns_none_for_no_status_column",
+        ),
+    ],
+)
+def test_count_bad_channels_tsv_content(tmp_path: Path, content, expected):
+    """count_bad_channels counts bad-status rows; no status column returns None."""
+    tsv = tmp_path / "channels.tsv"
+    tsv.write_text(content, encoding="utf-8")
+    assert count_bad_channels(tsv) == expected
+
+
+def test_count_bad_channels_returns_none_for_missing_file(tmp_path: Path):
+    """Missing file → None (distinct from zero bad channels)."""
+    assert count_bad_channels(tmp_path / "missing.tsv") is None
+
+
+def test_count_bad_channels_tolerates_malformed_tsv(tmp_path: Path):
+    """A garbage file returns None or int, never raises."""
+    tsv = tmp_path / "channels.tsv"
+    tsv.write_bytes(b"\x00\xff\x01 garbage")
+    result = count_bad_channels(tsv)
+    assert result is None or isinstance(result, int)
+
+
+# ─── Constants ─────────────────────────────────────────────────────────────
+
+
+def test_bids_required_files_contains_dataset_description():
+    assert "dataset_description.json" in BIDS_REQUIRED_FILES
+
+
+def test_bids_optional_files_contains_canonical_set():
+    for f in ("participants.tsv", "readme", "changes"):
+        assert f in BIDS_OPTIONAL_FILES
+
+
+def test_bids_subject_pattern_matches_canonical_names():
+    """``sub-XX``, ``sub-001``, ``sub-A1B2`` all match; ``Sub-`` is case-insensitive."""
+    for name in ("sub-01", "sub-001", "sub-A1B2", "Sub-99"):
+        assert BIDS_SUBJECT_PATTERN.match(name), f"{name=} should match"
+
+
+def test_bids_subject_pattern_rejects_non_subject_names():
+    for name in ("ses-01", "data1", "subject-01", "sub_01"):
+        assert not BIDS_SUBJECT_PATTERN.match(name), f"{name=} should not match"

--- a/scripts/ingestions/tests/unit/test_file_utils.py
+++ b/scripts/ingestions/tests/unit/test_file_utils.py
@@ -1,0 +1,194 @@
+"""Tests for _file_utils.py: BIDS classification, git-annex pointer resolution, inline-sidecar gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _file_utils import (
+    get_annex_file_key,
+    get_annex_file_size,
+    is_bids_file,
+    is_bids_root_file,
+    parse_annex_size,
+    read_inline_sidecar,
+)
+
+# ─── is_bids_file / is_bids_root_file ────────────────────────────────────
+
+
+def test_is_bids_file_recognises_subject_prefix():
+    assert is_bids_file("sub-01_eeg.edf") is True
+    assert is_bids_file("data/sub-01/eeg/sub-01_eeg.vhdr") is True
+
+
+def test_is_bids_file_recognises_canonical_extensions():
+    # FIF and SNIRF are NOT in BIDS_DATA_EXTENSIONS; pinned so future expansion is visible.
+    for ext in (".edf", ".bdf", ".vhdr", ".set", ".cnt", ".nwb"):
+        assert is_bids_file(f"random_name{ext}") is True, (
+            f"BIDS data extension {ext} should match"
+        )
+
+
+def test_is_bids_file_recognises_root_files():
+    assert is_bids_file("dataset_description.json") is True
+    assert is_bids_file("README") is True
+    assert is_bids_file("participants.tsv") is True
+
+
+def test_is_bids_file_rejects_random_csv():
+    assert is_bids_file("results.csv") is False
+    assert is_bids_file("analysis.py") is False
+
+
+# ─── is_bids_root_file ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        pytest.param("dataset_description.json", True, id="canonical_json"),
+        pytest.param("README", True, id="readme"),
+        pytest.param("DATASET_DESCRIPTION.JSON", True, id="case_insensitive"),
+        pytest.param("sub-01_eeg.edf", False, id="subject_file_not_root"),
+        pytest.param("results.csv", False, id="non_bids_csv"),
+    ],
+)
+def test_is_bids_root_file(path: str, expected: bool):
+    assert is_bids_root_file(path) is expected
+
+
+# ─── parse_annex_size ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        pytest.param("MD5E-s12345--abcdef.fif", 12345, id="md5_key"),
+        pytest.param("SHA256E-s9999999--deadbeef.edf", 9999999, id="sha256_key"),
+        pytest.param("/some/path/MD5E-s512000--abc123def.fif", 512000, id="full_path"),
+        pytest.param("sub-01_eeg.edf", None, id="no_annex_key"),
+        pytest.param("random text", None, id="plain_text"),
+    ],
+)
+def test_parse_annex_size(key: str, expected: int | None):
+    # regex uses `search` so full paths match too (see `full_path` case)
+    assert parse_annex_size(key) == expected
+
+
+# ─── get_annex_file_key (symlink + smudged-pointer paths) ─────────────────
+
+
+def test_get_annex_file_key_returns_none_for_regular_file(tmp_path: Path):
+    f = tmp_path / "regular.txt"
+    f.write_text("just text, not annex")
+    assert get_annex_file_key(f) is None
+
+
+def test_get_annex_file_key_from_symlink(tmp_path: Path):
+    annex_key = "MD5E-s12345--abc123def456.fif"
+    link = tmp_path / "data.fif"
+    target = Path(f".git/annex/objects/XX/YY/{annex_key}/{annex_key}")
+    link.symlink_to(target)
+    out = get_annex_file_key(link)
+    assert out == annex_key
+
+
+def test_get_annex_file_key_from_smudged_pointer(tmp_path: Path):
+    # Smudged-pointer mode: file exists but holds only the annex path, not data.
+    annex_key = "SHA256E-s99999--deadbeef.edf"
+    pointer = tmp_path / "data.edf"
+    pointer.write_text(f"/annex/objects/{annex_key}\n")
+    out = get_annex_file_key(pointer)
+    assert out == annex_key
+
+
+def test_get_annex_file_key_returns_none_for_oversized_file(tmp_path: Path):
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"x" * 1000)  # > 256
+    assert get_annex_file_key(big) is None
+
+
+def test_get_annex_file_key_returns_none_for_pointer_without_annex_path(tmp_path: Path):
+    sidecar = tmp_path / "small.json"
+    sidecar.write_text('{"key": "value"}')
+    assert get_annex_file_key(sidecar) is None
+
+
+# ─── get_annex_file_size ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected"),
+    [
+        pytest.param("symlink_with_key", 4096, id="symlink_key"),
+        pytest.param("real_file", 1234, id="real_file_size"),
+        pytest.param("missing", 0, id="missing_returns_zero"),
+    ],
+)
+def test_get_annex_file_size(tmp_path: Path, fixture: str, expected: int):
+    if fixture == "symlink_with_key":
+        annex_key = "MD5E-s4096--abc123.fif"
+        path = tmp_path / "data.fif"
+        target = Path(f".git/annex/objects/XX/YY/{annex_key}/{annex_key}")
+        path.symlink_to(target)
+    elif fixture == "real_file":
+        path = tmp_path / "real.bin"
+        path.write_bytes(b"x" * 1234)
+    else:  # missing
+        path = tmp_path / "missing.txt"
+
+    assert get_annex_file_size(path) == expected
+
+
+# ─── read_inline_sidecar ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected_check"),
+    [
+        pytest.param("utf8_tsv", "sub-01", id="reads_utf8_tsv"),
+        pytest.param("oversized", None, id="rejects_oversized"),
+        pytest.param(
+            "non_allowlisted_ext", None, id="rejects_non_allowlisted_extension"
+        ),
+        pytest.param("symlink", None, id="rejects_symlinks"),
+        pytest.param("missing", None, id="missing_returns_none"),
+        pytest.param("empty_tsv", "", id="empty_file_returns_empty_string"),
+    ],
+)
+def test_read_inline_sidecar(tmp_path: Path, fixture: str, expected_check: str | None):
+    # Empty allowlisted file yields "" (not None) — empty content is valid.
+    if fixture == "utf8_tsv":
+        f = tmp_path / "participants.tsv"
+        f.write_text("participant_id\tage\nsub-01\t30\n")
+        out = read_inline_sidecar(f)
+        assert out is not None
+        assert expected_check in out
+        return
+    elif fixture == "oversized":
+        f = tmp_path / "huge.tsv"
+        f.write_bytes(b"x" * (6 * 1024 * 1024))  # 6 MB
+    elif fixture == "non_allowlisted_ext":
+        f = tmp_path / "data.edf"
+        f.write_bytes(b"some binary")
+    elif fixture == "symlink":
+        target = tmp_path / "real.tsv"
+        target.write_text("data")
+        f = tmp_path / "link.tsv"
+        f.symlink_to(target)
+    elif fixture == "missing":
+        f = tmp_path / "missing.tsv"
+    elif fixture == "empty_tsv":
+        f = tmp_path / "empty.tsv"
+        f.write_text("")
+
+    assert read_inline_sidecar(f) == expected_check
+
+
+def test_read_inline_sidecar_accepts_known_basenames(tmp_path: Path):
+    for name in ("README", "CHANGES", "LICENSE"):
+        f = tmp_path / name
+        f.write_text("content for " + name)
+        assert read_inline_sidecar(f) is not None

--- a/scripts/ingestions/tests/unit/test_find_leaked_creds.py
+++ b/scripts/ingestions/tests/unit/test_find_leaked_creds.py
@@ -1,0 +1,133 @@
+"""Tests for the find_leaked_creds.sh scanner (Task 5)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from _helpers import INGEST_DIR as _INGEST_DIR
+
+SCANNER = _INGEST_DIR / "scripts" / "find_leaked_creds.sh"
+
+
+# Synthesised token used ONLY in a temp git repo for scanner verification.
+# DO NOT CONCATENATE THESE STRINGS — split intentionally so this test
+# fixture file itself doesn't trip the find-leaked-creds scanner under
+# pre-commit. See find_leaked_creds.sh PATTERNS.
+_TOKEN_VAR = "EEGDASH_" + "ADMIN_TOKEN"
+_TOKEN_VAL = "AdminWrite2025" + "SecureTokenABC123"  # 30 alnum chars total
+_PLANTED_SECRET = f"{_TOKEN_VAR}={_TOKEN_VAL}"
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    """Create a tiny git repo with a planted secret in a commit message."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    f = tmp_path / "f.txt"
+    f.write_text("hello\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "f.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "commit",
+            "-q",
+            "-m",
+            f"test commit\n\n{_PLANTED_SECRET}",
+        ],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    return tmp_path
+
+
+def test_scanner_detects_token_in_commit_message(fake_repo):
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=fake_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "EEGDASH_ADMIN_TOKEN" in result.stdout
+    assert result.returncode == 1  # found leaks -> exit 1
+
+
+def test_scanner_clean_repo_exits_0(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "x.txt").write_text("clean\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "x.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "-m", "harmless"],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_scanner_detects_yaml_form_token(tmp_path):
+    """The pattern set must also catch ``KEY: value`` (YAML / docker-compose).
+
+    Real-world driver: the cluster's ``docker-compose.yml`` writes
+    credentials in YAML form, not env-shell form. A scanner that only
+    matches ``=`` would miss them.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    f = tmp_path / "compose-like.yml"
+    # Use split literal so this test file itself doesn't trip the scanner
+    # under pre-commit (see also the existing _TOKEN_VAR pattern).
+    yaml_secret = "ADMIN_TOKEN" + ": AdminWrite2025" + "SecureTokenABC123"
+    f.write_text(f"environment:\n  {yaml_secret}\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "compose-like.yml"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "-m", "add config"],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert "ADMIN_TOKEN" in result.stdout
+    assert result.returncode == 1
+
+
+def test_scanner_outside_git_repo_exits_2(tmp_path):
+    """In a non-git directory, scanner must refuse to claim clean."""
+    # tmp_path is NOT a git repo. Confirm:
+    result = subprocess.run(
+        ["bash", str(SCANNER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Not in a git repo" in result.stderr

--- a/scripts/ingestions/tests/unit/test_fingerprint.py
+++ b/scripts/ingestions/tests/unit/test_fingerprint.py
@@ -1,0 +1,184 @@
+"""Unit tests for the manifest-fingerprint helpers in ``_fingerprint``.
+
+Fingerprints are content-addressed identifiers used by the ingestion
+pipeline to detect when a dataset has actually changed (so the digest
+step can skip unchanged inputs). They must be:
+
+- **Deterministic**: same input → same fingerprint.
+- **Stable across orderings**: file-order in the manifest must NOT
+  affect the output (we sort).
+- **Sensitive to the dataset id**: same files but different dataset
+  → different fingerprint (so seeded by dataset_id + source).
+- **Robust to absent fields**: missing ``size``, missing inner files,
+  empty manifests — all must produce a fingerprint, not crash.
+"""
+
+from __future__ import annotations
+
+import string
+
+import pytest
+
+from _fingerprint import _hash_entries, fingerprint_from_manifest
+
+# ─── Determinism ───────────────────────────────────────────────────────────
+
+
+def test_fingerprint_is_deterministic():
+    """Calling twice with the same input returns the same fingerprint."""
+    manifest = {"files": [{"path": "a.edf", "size": 100}]}
+    f1 = fingerprint_from_manifest("ds001", "openneuro", manifest)
+    f2 = fingerprint_from_manifest("ds001", "openneuro", manifest)
+    assert f1 == f2
+
+
+def test_fingerprint_is_a_hex_sha256():
+    """The fingerprint format must be a stable 64-char lowercase hex string."""
+    f = fingerprint_from_manifest("ds001", "openneuro", {})
+    assert len(f) == 64
+    assert all(c in string.hexdigits.lower() for c in f)
+
+
+# ─── Stability across orderings ────────────────────────────────────────────
+
+
+def test_fingerprint_ignores_file_order():
+    """Re-ordering ``files`` in the manifest must NOT change the fingerprint."""
+    f_a_b = fingerprint_from_manifest(
+        "ds001",
+        "openneuro",
+        {"files": [{"path": "a.edf", "size": 100}, {"path": "b.edf", "size": 200}]},
+    )
+    f_b_a = fingerprint_from_manifest(
+        "ds001",
+        "openneuro",
+        {"files": [{"path": "b.edf", "size": 200}, {"path": "a.edf", "size": 100}]},
+    )
+    assert f_a_b == f_b_a
+
+
+# ─── Sensitivity to changes ────────────────────────────────────────────────
+
+
+def test_fingerprint_changes_with_dataset_id():
+    """Same files, different dataset → different fingerprint (seed is per-dataset)."""
+    manifest = {"files": [{"path": "a.edf", "size": 100}]}
+    f1 = fingerprint_from_manifest("ds001", "openneuro", manifest)
+    f2 = fingerprint_from_manifest("ds002", "openneuro", manifest)
+    assert f1 != f2
+
+
+def test_fingerprint_changes_with_source():
+    """Same files, different source → different fingerprint."""
+    manifest = {"files": [{"path": "a.edf", "size": 100}]}
+    f1 = fingerprint_from_manifest("ds001", "openneuro", manifest)
+    f2 = fingerprint_from_manifest("ds001", "nemar", manifest)
+    assert f1 != f2
+
+
+def test_fingerprint_changes_when_a_file_size_changes():
+    """One byte different in a file size → entirely different fingerprint
+    (sha256's avalanche property)."""
+    f1 = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 100}]}
+    )
+    f2 = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 101}]}
+    )
+    assert f1 != f2
+
+
+def test_fingerprint_changes_when_a_file_path_changes():
+    """Different path → different fingerprint."""
+    f1 = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 100}]}
+    )
+    f2 = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "b.edf", "size": 100}]}
+    )
+    assert f1 != f2
+
+
+# ─── Robustness to absent / weird inputs ──────────────────────────────────
+
+
+def test_fingerprint_empty_manifest():
+    """An empty manifest still produces a (constant) fingerprint."""
+    f = fingerprint_from_manifest("ds001", "openneuro", {})
+    assert len(f) == 64
+
+
+def test_fingerprint_manifest_without_files_key():
+    """A manifest lacking the ``files`` key produces same output as empty."""
+    f_empty = fingerprint_from_manifest("ds001", "openneuro", {})
+    f_no_files = fingerprint_from_manifest("ds001", "openneuro", {"other_field": 42})
+    assert f_empty == f_no_files
+
+
+def test_fingerprint_file_missing_size_treats_as_zero():
+    """A file entry with no ``size`` defaults to size=0."""
+    f_no_size = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf"}]}
+    )
+    f_size_zero = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 0}]}
+    )
+    assert f_no_size == f_size_zero
+
+
+def test_fingerprint_uses_name_when_path_missing():
+    """The fingerprint accepts ``name`` as a fallback for ``path``."""
+    f_path = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 100}]}
+    )
+    f_name = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"name": "a.edf", "size": 100}]}
+    )
+    assert f_path == f_name
+
+
+def test_fingerprint_files_without_path_or_name_are_skipped():
+    """A file entry with neither ``path`` nor ``name`` is dropped silently."""
+    f_with = fingerprint_from_manifest(
+        "ds001", "openneuro", {"files": [{"path": "a.edf", "size": 100}]}
+    )
+    f_plus_bogus = fingerprint_from_manifest(
+        "ds001",
+        "openneuro",
+        {"files": [{"path": "a.edf", "size": 100}, {"size": 999}]},
+    )
+    assert f_with == f_plus_bogus
+
+
+# ─── _hash_entries primitive ───────────────────────────────────────────────
+
+
+def test_hash_entries_empty_input_is_constant():
+    """``_hash_entries([])`` must be a stable constant — used as the
+    fingerprint for an empty manifest."""
+    h1 = _hash_entries([])
+    h2 = _hash_entries([])
+    assert h1 == h2
+    assert len(h1) == 64
+
+
+def test_hash_entries_seeded_differs_from_unseeded():
+    """A non-empty seed produces a different hash than the unseeded form."""
+    unseeded = _hash_entries([("a", 1)])
+    seeded = _hash_entries([("a", 1)], seed="x")
+    assert unseeded != seeded
+
+
+@pytest.mark.parametrize(
+    ("entries_a", "entries_b"),
+    [
+        # Order doesn't matter because _hash_entries sorts.
+        ([("a", 1), ("b", 2)], [("b", 2), ("a", 1)]),
+        ([("z", 9), ("a", 1)], [("a", 1), ("z", 9)]),
+    ],
+)
+def test_hash_entries_sort_invariance(
+    entries_a: list[tuple[str, int]], entries_b: list[tuple[str, int]]
+) -> None:
+    """Re-ordering input entries does not change the hash."""
+    assert _hash_entries(entries_a) == _hash_entries(entries_b)

--- a/scripts/ingestions/tests/unit/test_http.py
+++ b/scripts/ingestions/tests/unit/test_http.py
@@ -1,0 +1,389 @@
+"""Tests for the shared HTTP client (``_http``). All calls intercepted via respx."""
+
+from __future__ import annotations
+
+import warnings
+
+import httpx
+import pytest
+import respx
+
+import _http
+from _http import (
+    build_headers,
+    close_client,
+    get_client,
+    make_authed_client,
+    make_retry_client,
+    request_json,
+    request_response,
+    request_text,
+)
+
+API = "https://example.invalid/api"
+
+
+@pytest.fixture
+def _no_cache_env(monkeypatch):
+    """Disable caching and reset the module-level client singleton."""
+    monkeypatch.setenv("EEGDASH_HTTP_CACHE", "0")
+    monkeypatch.setenv("EEGDASH_HTTP_CACHE_DISABLED", "1")
+    close_client()
+
+    _http._client = None
+    yield
+    _http._client = None
+    close_client()
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_200_returns_payload_and_response():
+    route = respx.get(API).mock(
+        return_value=httpx.Response(200, json={"key": "value", "n": 42})
+    )
+    payload, response = request_json("GET", API)
+    assert payload == {"key": "value", "n": 42}
+    assert response is not None
+    assert response.status_code == 200
+    assert route.call_count == 1
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_404_returns_none_payload_with_response():
+    """404 is not in DEFAULT_RETRY_STATUSES; returns (None, response) without raising."""
+    route = respx.get(API).mock(return_value=httpx.Response(404))
+    payload, response = request_json("GET", API)
+    assert payload is None
+    assert response is not None
+    assert response.status_code == 404
+    assert route.call_count == 1, "404 must not be retried"
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_502_retries_then_succeeds_on_3rd_attempt():
+    route = respx.get(API).mock(
+        side_effect=[
+            httpx.Response(502),
+            httpx.Response(502),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    payload, _ = request_json("GET", API, retries=3, backoff_factor=0.0)
+    assert payload == {"ok": True}
+    assert route.call_count == 3, "expected 2 retries before the 200"
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_persistent_500_returns_none_payload():
+    """Exhausted retries return (None, last_5xx_response)."""
+    route = respx.get(API).mock(return_value=httpx.Response(503))
+    payload, response = request_json("GET", API, retries=2, backoff_factor=0.0)
+    assert payload is None
+    assert response is not None
+    assert response.status_code == 503
+    assert route.call_count == 2  # tenacity counts attempts, not retries
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_timeout_returns_none_payload():
+    """Persistent timeouts return (None, None); no response object is available."""
+    respx.get(API).mock(side_effect=httpx.TimeoutException("upstream"))
+    payload, response = request_json("GET", API, retries=2, backoff_factor=0.0)
+    assert payload is None
+    assert response is None
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_raise_for_request_surfaces_network_error():
+    respx.get(API).mock(side_effect=httpx.TimeoutException("upstream"))
+    with pytest.raises(httpx.TimeoutException):
+        request_json(
+            "GET",
+            API,
+            retries=1,
+            backoff_factor=0.0,
+            raise_for_request=True,
+        )
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_malformed_json_returns_none_payload():
+    route = respx.get(API).mock(
+        return_value=httpx.Response(
+            200,
+            content=b"not valid json {{ ... ]]",
+            headers={"content-type": "text/plain"},
+        )
+    )
+    payload, response = request_json("GET", API)
+    assert payload is None
+    assert response is not None
+    assert response.status_code == 200
+    assert route.call_count == 1
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_retry_disabled_with_retries_zero():
+    route = respx.get(API).mock(return_value=httpx.Response(503))
+    payload, _ = request_json("GET", API, retries=1, backoff_factor=0.0)
+    assert payload is None
+    assert route.call_count == 1
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_408_request_timeout_is_retried_by_default():
+    """408 is in DEFAULT_RETRY_STATUSES — some upstreams use it instead of 504."""
+    route = respx.get(API).mock(
+        side_effect=[
+            httpx.Response(408),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    payload, _ = request_json("GET", API, retries=2, backoff_factor=0.0)
+    assert payload == {"ok": True}
+    assert route.call_count == 2, "408 must be in DEFAULT_RETRY_STATUSES"
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_json_custom_retry_statuses():
+    route = respx.get(API).mock(
+        side_effect=[
+            httpx.Response(418),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    payload, _ = request_json(
+        "GET",
+        API,
+        retries=2,
+        backoff_factor=0.0,
+        retry_statuses={418},
+    )
+    assert payload == {"ok": True}
+    assert route.call_count == 2
+
+
+def test_make_retry_client_emits_deprecation_warning():
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        client = make_retry_client("dummy_token")
+        client.close()
+
+    deprecation = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert deprecation, "expected DeprecationWarning"
+    assert "make_authed_client" in str(deprecation[0].message)
+
+
+def test_make_retry_client_returns_same_shape_as_authed_client():
+    """Deprecation alias produces identical headers and timeout to make_authed_client."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        deprecated_client = make_retry_client("dummy_token")
+        new_client = make_authed_client("dummy_token")
+
+    try:
+        assert deprecated_client.headers.get("Authorization") == new_client.headers.get(
+            "Authorization"
+        )
+        assert deprecated_client.timeout == new_client.timeout
+    finally:
+        deprecated_client.close()
+        new_client.close()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_key_values"),
+    [
+        pytest.param(
+            {"accept": "application/json"},
+            {"Accept": "application/json"},
+            id="includes_accept",
+        ),
+        pytest.param(
+            {},
+            {"User-Agent": True},  # sentinel: key present and non-empty
+            id="includes_user_agent_by_default",
+        ),
+        pytest.param(
+            {
+                "accept": "application/json",
+                "extra": {"Authorization": "Bearer token", "X-Custom": "value"},
+            },
+            {
+                "Authorization": "Bearer token",
+                "X-Custom": "value",
+                "Accept": "application/json",
+            },
+            id="merges_extra",
+        ),
+    ],
+)
+def test_build_headers_matrix(kwargs, expected_key_values):
+    """Extra headers merge into defaults; User-Agent is always present."""
+    out = build_headers(**kwargs)
+    for key, value in expected_key_values.items():
+        if value is True:
+            assert key in out
+            assert out[key]
+        else:
+            assert out[key] == value
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+@pytest.mark.parametrize(
+    ("mock_kwargs", "call_kwargs", "expected_text", "expected_status"),
+    [
+        pytest.param(
+            {"return_value": httpx.Response(200, text="hello")},
+            {},
+            "hello",
+            200,
+            id="200_returns_text",
+        ),
+        pytest.param(
+            {"return_value": httpx.Response(200, text="hello world")},
+            {"retries": 1, "backoff_factor": 0.0},
+            "hello world",
+            200,
+            id="returns_text_and_response",
+        ),
+        pytest.param(
+            {"return_value": httpx.Response(404, text="not found")},
+            {"retries": 1, "backoff_factor": 0.0},
+            None,  # caller inspects response, text not asserted
+            404,
+            id="404_returns_text_with_response",
+        ),
+        pytest.param(
+            {"side_effect": httpx.TimeoutException("upstream")},
+            {"retries": 1, "backoff_factor": 0.0},
+            None,
+            None,  # no response on timeout
+            id="timeout_returns_none_pair",
+        ),
+    ],
+)
+def test_request_text_status_matrix(
+    mock_kwargs, call_kwargs, expected_text, expected_status
+):
+    """4xx returns (text, response); persistent network failure returns (None, None)."""
+    respx.get(API).mock(**mock_kwargs)
+    text, response = request_text("GET", API, **call_kwargs)
+    if expected_status is None:
+        assert text is None
+        assert response is None
+    else:
+        assert response is not None
+        assert response.status_code == expected_status
+        if expected_text is not None:
+            assert text == expected_text
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_text_raise_for_status_propagates_4xx():
+    respx.get(API).mock(return_value=httpx.Response(404))
+    with pytest.raises(httpx.HTTPStatusError):
+        request_text("GET", API, retries=1, backoff_factor=0.0, raise_for_status=True)
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_text_raise_for_request_propagates_network():
+    respx.get(API).mock(side_effect=httpx.ConnectError("down"))
+    with pytest.raises(httpx.ConnectError):
+        request_text("GET", API, retries=1, backoff_factor=0.0, raise_for_request=True)
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_response_returns_raw_response():
+    respx.get(API).mock(return_value=httpx.Response(200, text="body"))
+    response = request_response("GET", API, retries=1, backoff_factor=0.0)
+    assert response is not None
+    assert response.status_code == 200
+    assert response.text == "body"
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_response_returns_none_on_timeout():
+    respx.get(API).mock(side_effect=httpx.TimeoutException("up"))
+    response = request_response("GET", API, retries=1, backoff_factor=0.0)
+    assert response is None
+
+
+@respx.mock
+@pytest.mark.usefixtures("_no_cache_env")
+def test_request_response_post_with_json_body():
+    route = respx.post(API).mock(return_value=httpx.Response(200, text="ok"))
+    response = request_response(
+        "POST",
+        API,
+        json_body={"key": "value"},
+        retries=1,
+        backoff_factor=0.0,
+    )
+    assert response is not None
+    assert response.status_code == 200
+    assert route.call_count == 1
+
+
+def test_get_client_returns_singleton():
+    close_client()
+    c1 = get_client()
+    c2 = get_client()
+    assert c1 is c2
+    close_client()
+
+
+def test_get_client_recreates_after_close():
+    close_client()
+    c1 = get_client()
+    close_client()
+    c2 = get_client()
+    assert c1 is not c2
+    close_client()
+
+
+def test_make_authed_client_sets_authorization_header():
+    client = make_authed_client("my_token_abc")
+    try:
+        assert "Authorization" in client.headers
+        assert "my_token_abc" in client.headers["Authorization"]
+        assert client.headers["Authorization"].startswith("Bearer ")
+    finally:
+        client.close()
+
+
+def test_make_retry_client_includes_authorization():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        client = make_retry_client("retry_token_xyz")
+    try:
+        assert "Authorization" in client.headers
+        assert "retry_token_xyz" in client.headers["Authorization"]
+    finally:
+        client.close()
+
+
+def test_make_retry_client_has_transport_with_retries():
+    """make_retry_client sets a non-default transport on the httpx.Client."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        client = make_retry_client("token")
+    try:
+        assert client._transport is not None
+    finally:
+        client.close()

--- a/scripts/ingestions/tests/unit/test_metadata_cascade.py
+++ b/scripts/ingestions/tests/unit/test_metadata_cascade.py
@@ -1,0 +1,341 @@
+"""Tests for MetadataCascade: each step in isolation plus full-chain integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest  # noqa: F401 — kept for `monkeypatch` discovery
+
+import _metadata_cascade as mc
+from _metadata_cascade import (
+    CascadeContext,
+    CascadeResult,
+    MetadataCascade,
+    MneBidsStep,
+)
+
+# ─── CascadeContext + CascadeResult ───────────────────────────────────────
+
+
+def test_cascade_context_derives_ext_and_root():
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(
+        bids_dataset=bids_dataset,
+        bids_file="sub-01/eeg/sub-01_task-rest_eeg.vhdr",
+    )
+    assert ctx.ext == ".vhdr"
+    assert ctx.bids_file_path == Path("sub-01/eeg/sub-01_task-rest_eeg.vhdr")
+    assert ctx.bids_root == Path("/tmp/bids")
+
+
+def test_cascade_result_defaults_are_none():
+    result = CascadeResult()
+    assert result.sampling_frequency is None
+    assert result.nchans is None
+    assert result.ntimes is None
+    assert result.ch_names is None
+    assert result.fif_is_split is False
+    assert result.fif_continuations_ok is True
+    assert set(result.provenance.keys()) == {
+        "sampling_frequency",
+        "nchans",
+        "ntimes",
+        "ch_names",
+    }
+    assert all(v is None for v in result.provenance.values())
+
+
+def test_cascade_result_stamp_only_fires_on_none_to_non_none_transition():
+    # first-writer-wins
+    r = CascadeResult()
+    r.stamp("first_source", "sampling_frequency", old=None, new=500.0)
+    assert r.provenance["sampling_frequency"] == "first_source"
+    r.stamp("second_source", "sampling_frequency", old=500.0, new=750.0)
+    assert r.provenance["sampling_frequency"] == "first_source"
+
+    # old is a non-None falsy value: no stamp (legacy `old is None` check)
+    r2 = CascadeResult()
+    r2.stamp("any_source", "nchans", old=0, new=500)
+    assert r2.provenance["nchans"] is None, (
+        "stamp must not fire when old is a non-None falsy value "
+        "(legacy _stamp_provenance used `old is None` check)"
+    )
+
+    # old=None, new=None: no stamp
+    r3 = CascadeResult()
+    r3.stamp("any_source", "ntimes", old=None, new=None)
+    assert r3.provenance["ntimes"] is None
+
+
+# ─── MneBidsStep ──────────────────────────────────────────────────────────
+
+
+def test_mne_bids_step_fills_from_attribute_getters():
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    bids_dataset.get_bids_file_attribute.side_effect = lambda key, _file: {
+        "sfreq": "500",
+        "nchans": "64",
+        "ntimes": "1000",
+    }[key]
+    bids_dataset.channel_labels.return_value = ["F1", "F2", "Cz"]
+
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+    result = CascadeResult()
+
+    MneBidsStep().fill(ctx, result)
+
+    assert result.sampling_frequency == 500.0
+    assert result.nchans == 3  # channel_labels count overrides sidecar nchans
+    assert result.ntimes == 1000
+    assert result.ch_names == ["F1", "F2", "Cz"]
+    assert result.provenance == {
+        "sampling_frequency": "mne_bids",
+        "nchans": "mne_bids",
+        "ntimes": "mne_bids",
+        "ch_names": "mne_bids",
+    }
+
+
+def test_mne_bids_step_handles_missing_sidecar_gracefully():
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    bids_dataset.get_bids_file_attribute.side_effect = FileNotFoundError(
+        "sidecar missing"
+    )
+    bids_dataset.channel_labels.side_effect = OSError("annex broken")
+
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+    result = CascadeResult()
+    MneBidsStep().fill(ctx, result)
+
+    assert result.sampling_frequency is None
+    assert result.nchans is None
+    assert all(v is None for v in result.provenance.values())
+
+
+# ─── ModalitySidecarStep ──────────────────────────────────────────────────
+
+
+def test_modality_sidecar_step_only_fills_unset_fields(monkeypatch):
+    monkeypatch.setattr(
+        mc,
+        "extract_sfreq_nchans_from_modality_sidecar",
+        lambda _path, _root, sf_in, nc_in: (sf_in or 250.0, nc_in or 32),
+    )
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+    result = CascadeResult(sampling_frequency=None, nchans=None)
+
+    mc.ModalitySidecarStep().fill(ctx, result)
+
+    assert result.sampling_frequency == 250.0
+    assert result.nchans == 32
+    assert result.provenance["sampling_frequency"] == "modality_sidecar"
+    assert result.provenance["nchans"] == "modality_sidecar"
+
+
+def test_modality_sidecar_step_does_not_overwrite_filled_fields(monkeypatch):
+    monkeypatch.setattr(
+        mc,
+        "extract_sfreq_nchans_from_modality_sidecar",
+        lambda _p, _r, sf, nc: (sf or 250.0, nc or 32),
+    )
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+
+    result = CascadeResult(sampling_frequency=500.0, nchans=None)
+    result.provenance["sampling_frequency"] = "mne_bids"
+
+    mc.ModalitySidecarStep().fill(ctx, result)
+
+    assert result.sampling_frequency == 500.0  # unchanged
+    assert result.provenance["sampling_frequency"] == "mne_bids"  # first-writer wins
+    assert result.nchans == 32  # nchans WAS unset, so step fills
+    assert result.provenance["nchans"] == "modality_sidecar"
+
+
+# ─── ChannelsTsvStep ──────────────────────────────────────────────────────
+
+
+def test_channels_tsv_step_fills_from_helper(monkeypatch):
+    monkeypatch.setattr(
+        mc,
+        "extract_sfreq_nchans_from_channels_tsv",
+        lambda _p, _r, sf, nc: (sf or 1000.0, nc or 19),
+    )
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+    result = CascadeResult()
+
+    mc.ChannelsTsvStep().fill(ctx, result)
+
+    assert result.sampling_frequency == 1000.0
+    assert result.nchans == 19
+    assert result.provenance["sampling_frequency"] == "channels_tsv"
+    assert result.provenance["nchans"] == "channels_tsv"
+
+
+# ─── BinaryParserStep ─────────────────────────────────────────────────────
+
+
+def test_binary_parser_step_uses_registry(monkeypatch):
+    monkeypatch.setattr(
+        mc,
+        "get_parser_for_extension",
+        lambda ext: (
+            (
+                lambda _p: {
+                    "sampling_frequency": 256.0,
+                    "nchans": 16,
+                    "n_times": 100000,
+                }
+            )
+            if ext == ".edf"
+            else None
+        ),
+    )
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.edf")
+    result = CascadeResult()
+
+    mc.BinaryParserStep().fill(ctx, result)
+
+    assert result.sampling_frequency == 256.0
+    assert result.nchans == 16
+    assert result.ntimes == 100000
+    assert result.provenance["sampling_frequency"] == "binary_parser"
+
+
+def test_binary_parser_step_skipped_when_all_fields_filled(monkeypatch):
+    fake_parser = MagicMock(return_value={"sampling_frequency": 999.0, "nchans": 1})
+    monkeypatch.setattr(
+        mc, "get_parser_for_extension", MagicMock(return_value=fake_parser)
+    )
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.edf")
+    result = CascadeResult(
+        sampling_frequency=500.0, nchans=64, ntimes=1000, ch_names=["F1"]
+    )
+
+    mc.BinaryParserStep().fill(ctx, result)
+
+    fake_parser.assert_not_called()
+    assert result.sampling_frequency == 500.0
+
+
+# ─── MneFallbackStep ──────────────────────────────────────────────────────
+
+
+def test_mne_fallback_step_fills_vhdr_ntimes(monkeypatch):
+    fake_raw = MagicMock()
+    fake_raw.n_times = 200000
+    fake_raw.close = MagicMock()
+
+    fake_mne = MagicMock()
+    fake_mne.io.read_raw_brainvision.return_value = fake_raw
+
+    monkeypatch.setattr(mc, "mne", fake_mne)
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.vhdr")
+    result = CascadeResult(sampling_frequency=500.0, nchans=32, ntimes=None)
+
+    mc.MneFallbackStep().fill(ctx, result)
+
+    assert result.ntimes == 200000
+    assert result.provenance["ntimes"] == "mne_fallback"
+    fake_raw.close.assert_called_once()
+
+
+def test_mne_fallback_step_fif_split_metadata(monkeypatch):
+    monkeypatch.setattr(
+        mc,
+        "_parse_fif_with_mne",
+        lambda _path: (
+            {
+                "sampling_frequency": 1000.0,
+                "nchans": 306,
+                "n_times": 60000,
+                "ch_names": ["MEG001"],
+            },
+            True,
+        ),
+    )
+
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    ctx = CascadeContext(bids_dataset, "sub-01_meg.fif")
+    result = CascadeResult()
+
+    mc.MneFallbackStep().fill(ctx, result)
+
+    assert result.fif_is_split is True
+    assert result.sampling_frequency == 1000.0
+    assert result.provenance["sampling_frequency"] == "mne_fallback"
+
+
+# ─── Integration: full cascade ────────────────────────────────────────────
+
+
+def test_metadata_cascade_runs_all_steps_in_order(monkeypatch):
+    bids_dataset = MagicMock()
+    bids_dataset.bidsdir = "/tmp/bids"
+    bids_dataset.get_bids_file_attribute.side_effect = lambda key, _f: (
+        "500" if key == "sfreq" else None
+    )
+    bids_dataset.channel_labels.return_value = None
+
+    monkeypatch.setattr(
+        mc,
+        "extract_sfreq_nchans_from_modality_sidecar",
+        lambda _p, _r, sf, nc: (sf, nc or 32),
+    )
+    monkeypatch.setattr(
+        mc,
+        "extract_sfreq_nchans_from_channels_tsv",
+        lambda _p, _r, sf, nc: (sf, nc),
+    )
+    monkeypatch.setattr(
+        mc,
+        "get_parser_for_extension",
+        lambda _ext: lambda _p: {"n_times": 10000, "ch_names": ["A1", "A2"]},
+    )
+
+    ctx = CascadeContext(bids_dataset, "sub-01_eeg.edf")
+    result = MetadataCascade().run(ctx)
+
+    assert result.sampling_frequency == 500.0
+    assert result.nchans == 32
+    assert result.ntimes == 10000
+    assert result.ch_names == ["A1", "A2"]
+    assert result.provenance == {
+        "sampling_frequency": "mne_bids",
+        "nchans": "modality_sidecar",
+        "ntimes": "binary_parser",
+        "ch_names": "binary_parser",
+    }
+
+
+def test_metadata_cascade_default_steps_in_correct_order():
+    cascade = MetadataCascade()
+    assert [type(s).__name__ for s in cascade.steps] == [
+        "MneBidsStep",
+        "ModalitySidecarStep",
+        "ChannelsTsvStep",
+        "BinaryParserStep",
+        "MneFallbackStep",
+    ]

--- a/scripts/ingestions/tests/unit/test_parser_utils.py
+++ b/scripts/ingestions/tests/unit/test_parser_utils.py
@@ -1,0 +1,234 @@
+"""Tests for ``_parser_utils.py`` — pure path/URL/security helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _parser_utils import (
+    build_s3_url,
+    extract_dataset_info,
+    extract_openneuro_info,
+    is_broken_symlink,
+    path_is_within_root,
+    read_with_encoding_fallback,
+    validate_file_path,
+)
+
+# ─── is_broken_symlink ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected"),
+    [
+        pytest.param("real_file", False, id="real-file"),
+        pytest.param("broken_link", True, id="broken"),
+        pytest.param("valid_link", False, id="valid-link"),
+        pytest.param("missing_path", False, id="missing"),
+    ],
+)
+def test_is_broken_symlink(tmp_path: Path, setup: str, expected: bool):
+    if setup == "real_file":
+        path = tmp_path / "real.txt"
+        path.write_text("hi")
+    elif setup == "broken_link":
+        path = tmp_path / "broken.lnk"
+        path.symlink_to(tmp_path / ".no_such_target")
+    elif setup == "valid_link":
+        target = tmp_path / "target.txt"
+        target.write_text("hi")
+        path = tmp_path / "good.lnk"
+        path.symlink_to(target)
+    else:
+        path = tmp_path / "missing.txt"
+    assert is_broken_symlink(path) is expected
+
+
+# ─── extract_dataset_info ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_source", "expected_id", "expected_rel"),
+    [
+        pytest.param(
+            "/clones/ds002893/sub-01/eeg/file.vhdr",
+            "openneuro",
+            "ds002893",
+            "sub-01/eeg/file.vhdr",
+            id="openneuro_ds_prefix",
+        ),
+        pytest.param(
+            "/clones/nm000176/sub-01/meg/file.fif",
+            "nemar",
+            "nm000176",
+            "sub-01/meg/file.fif",
+            id="nemar_nm_prefix",
+        ),
+    ],
+)
+def test_extract_dataset_info_recognised_source(
+    path: str, expected_source: str, expected_id: str, expected_rel: str
+):
+    out = extract_dataset_info(Path(path))
+    assert out is not None
+    source, ds_id, rel = out
+    assert source == expected_source
+    assert ds_id == expected_id
+    assert rel == expected_rel
+
+
+def test_extract_dataset_info_unrecognised_returns_none():
+    out = extract_dataset_info(Path("/clones/zenodo_12345/sub-01/file.edf"))
+    assert out is None
+
+
+def test_extract_dataset_info_normalises_backslashes():
+    out = extract_dataset_info(Path("/clones/ds002893/sub-01/eeg/file.vhdr"))
+    assert out is not None
+    _, _, rel = out
+    assert "\\" not in rel
+
+
+# ─── extract_openneuro_info (backward-compat wrapper) ─────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path_str", "expected"),
+    [
+        pytest.param(
+            "/clones/ds002893/sub-01/eeg/file.vhdr",
+            ("ds002893", "sub-01/eeg/file.vhdr"),
+            id="pair",
+        ),
+        pytest.param(
+            "/clones/nm000176/sub-01/file.fif",
+            None,
+            id="nemar",
+        ),
+        pytest.param(
+            "/clones/garbage_path/file.edf",
+            None,
+            id="unknown",
+        ),
+    ],
+)
+def test_extract_openneuro_info(path_str: str, expected):
+    assert extract_openneuro_info(Path(path_str)) == expected
+
+
+# ─── build_s3_url ──────────────────────────────────────────────────────────
+
+
+def test_build_s3_url_openneuro():
+    out = build_s3_url("ds002893", "sub-01/eeg/file.vhdr", source="openneuro")
+    assert out == (
+        "https://s3.amazonaws.com/openneuro.org/ds002893/sub-01/eeg/file.vhdr"
+    )
+
+
+def test_build_s3_url_nemar():
+    out = build_s3_url("nm000176", "objects/MD5E-s12345--abc.fif", source="nemar")
+    assert "nemar/nm000176/objects/" in out
+
+
+def test_build_s3_url_url_encodes_special_characters():
+    out = build_s3_url("ds001", "sub-01/eeg/file with spaces.vhdr")
+    assert "/sub-01/" in out
+    assert "%20" in out
+
+
+def test_build_s3_url_rejects_unknown_source():
+    with pytest.raises(ValueError, match="Unsupported source"):
+        build_s3_url("ds001", "file.edf", source="unknown_source")
+
+
+def test_build_s3_url_default_source_is_openneuro():
+    out = build_s3_url("ds001", "sub-01/file.vhdr")
+    assert "openneuro.org" in out
+
+
+# ─── path_is_within_root ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected"),
+    [
+        pytest.param("inside", True, id="inside"),
+        pytest.param("outside", False, id="outside"),
+        pytest.param("string_args", True, id="string-arg"),
+        pytest.param("self", True, id="self"),
+    ],
+)
+def test_path_within_root(tmp_path: Path, setup: str, expected: bool):
+    if setup == "inside":
+        path = tmp_path / "sub" / "file.txt"
+        path.parent.mkdir()
+        path.touch()
+        assert path_is_within_root(path, tmp_path) is expected
+    elif setup == "outside":
+        outside = tmp_path / ".." / "evil.txt"
+        assert path_is_within_root(outside, tmp_path) is expected
+    elif setup == "string_args":
+        path = tmp_path / "sub" / "file.txt"
+        path.parent.mkdir()
+        path.touch()
+        assert path_is_within_root(str(path), str(tmp_path)) is expected
+    else:
+        assert path_is_within_root(tmp_path, tmp_path) is expected
+
+
+# ─── validate_file_path ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected"),
+    [
+        pytest.param("real_file", True, id="real"),
+        pytest.param("missing", False, id="missing"),
+        pytest.param("broken_symlink", False, id="broken-symlink"),
+        pytest.param("directory", True, id="dir"),
+    ],
+)
+def test_validate_file_path(tmp_path: Path, setup: str, expected: bool):
+    if setup == "real_file":
+        path = tmp_path / "real.txt"
+        path.write_text("hi")
+    elif setup == "missing":
+        path = tmp_path / "missing.txt"
+    elif setup == "broken_symlink":
+        path = tmp_path / "broken"
+        path.symlink_to(tmp_path / ".no_such_target")
+    else:  # directory
+        path = tmp_path
+    assert validate_file_path(path) is expected
+
+
+# ─── read_with_encoding_fallback ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("setup", "check"),
+    [
+        pytest.param("utf8", "exact", id="utf8"),
+        pytest.param("latin1", "contains", id="latin1"),
+        pytest.param("missing", "none", id="missing"),
+    ],
+)
+def test_read_encoding_fallback(tmp_path: Path, setup: str, check: str):
+    if setup == "utf8":
+        f = tmp_path / "utf8.txt"
+        f.write_text("Hello, world!\nLine 2\n", encoding="utf-8")
+        out = read_with_encoding_fallback(f)
+        assert out == "Hello, world!\nLine 2\n"
+    elif setup == "latin1":
+        # latin-1 bytes that are NOT valid UTF-8: 0xe9 by itself.
+        f = tmp_path / "latin1.txt"
+        f.write_bytes(b"foo \xe9 bar\n")
+        out = read_with_encoding_fallback(f)
+        assert out is not None
+        assert "foo" in out
+        assert "bar" in out
+    else:  # missing
+        out = read_with_encoding_fallback(tmp_path / "missing.txt")
+        assert out is None

--- a/scripts/ingestions/tests/unit/test_parser_utils_network.py
+++ b/scripts/ingestions/tests/unit/test_parser_utils_network.py
@@ -1,0 +1,256 @@
+"""Tests for ``fetch_bytes_from_s3``, ``head_content_length``, and ``fetch_from_s3``."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+import _parser_utils
+from _parser_utils import (
+    fetch_bytes_from_s3,
+    fetch_from_s3,
+    head_content_length,
+    reset_http_client_for_testing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_http_client():
+    """Each test gets a fresh pooled client so respx hooks attach cleanly."""
+    reset_http_client_for_testing()
+    yield
+    reset_http_client_for_testing()
+
+
+# ─── fetch_bytes_from_s3 ──────────────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_bytes_from_s3_returns_requested_range():
+    """Happy path: server returns 1024 bytes; fetch returns them."""
+    payload = b"x" * 1024
+    respx.get("https://s3.example.com/file").mock(
+        return_value=httpx.Response(206, content=payload)
+    )
+    out = fetch_bytes_from_s3("https://s3.example.com/file", max_bytes=1024)
+    assert out == payload
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "mock_kwargs",
+    [
+        pytest.param({"return_value": httpx.Response(404)}, id="http_error_404"),
+        pytest.param(
+            {"side_effect": httpx.ConnectError("DNS lookup failed")},
+            id="connect_error",
+        ),
+        pytest.param(
+            {"side_effect": httpx.TimeoutException("slow")},
+            id="timeout",
+        ),
+    ],
+)
+def test_fetch_bytes_from_s3_failure_returns_none(mock_kwargs):
+    """Any HTTP / network failure surfaces as ``None`` rather than a raise."""
+    respx.get("https://s3.example.com/file").mock(**mock_kwargs)
+    assert (
+        fetch_bytes_from_s3("https://s3.example.com/file", max_bytes=1024, timeout=0.1)
+        is None
+    )
+
+
+@respx.mock
+def test_fetch_bytes_caps_response_at_max_bytes_when_server_ignores_range():
+    """Response is capped at ``max_bytes`` even when the server returns the full body."""
+    big_payload = b"x" * 100_000  # server returned 100 KB
+    respx.get("https://lazy-server.example.com/file").mock(
+        return_value=httpx.Response(200, content=big_payload)
+    )
+    out = fetch_bytes_from_s3("https://lazy-server.example.com/file", max_bytes=1024)
+    assert out is not None
+    assert len(out) == 1024
+
+
+@respx.mock
+def test_fetch_bytes_sends_correct_range_header():
+    """Verify the Range header is built correctly (bytes=start-end inclusive)."""
+    route = respx.get("https://s3.example.com/file").mock(
+        return_value=httpx.Response(206, content=b"y" * 256)
+    )
+    fetch_bytes_from_s3("https://s3.example.com/file", start=128, max_bytes=256)
+    assert route.called
+    sent = route.calls.last.request
+    # bytes=128-(128+256-1) → bytes=128-383
+    assert sent.headers["Range"] == "bytes=128-383"
+
+
+# ─── head_content_length ──────────────────────────────────────────────────
+
+
+@respx.mock
+def test_head_content_length_parses_int():
+    """Content-Length header returned as int."""
+    respx.head("https://s3.example.com/file").mock(
+        return_value=httpx.Response(200, headers={"Content-Length": "12345"})
+    )
+    assert head_content_length("https://s3.example.com/file") == 12345
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "mock_kwargs",
+    [
+        # No Content-Length header
+        pytest.param(
+            {"return_value": httpx.Response(200, headers={})},
+            id="header_missing",
+        ),
+        # 4xx response
+        pytest.param(
+            {"return_value": httpx.Response(404)},
+            id="http_error",
+        ),
+        # Non-numeric Content-Length
+        pytest.param(
+            {
+                "return_value": httpx.Response(
+                    200, headers={"Content-Length": "not_a_number"}
+                )
+            },
+            id="non_numeric_value",
+        ),
+    ],
+)
+def test_head_content_length_returns_none_on_unparseable(mock_kwargs):
+    """Missing header, HTTP error, and non-numeric value all surface as None."""
+    respx.head("https://s3.example.com/file").mock(**mock_kwargs)
+    assert head_content_length("https://s3.example.com/file") is None
+
+
+# ─── fetch_from_s3 (text variant) ─────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_from_s3_decodes_utf8():
+    """UTF-8 response body decoded cleanly."""
+    respx.get("https://s3.example.com/file.txt").mock(
+        return_value=httpx.Response(200, content=b"Hello, world!\nLine 2")
+    )
+    out = fetch_from_s3("https://s3.example.com/file.txt")
+    assert out is not None
+    assert "Hello, world!" in out
+
+
+@respx.mock
+def test_fetch_from_s3_falls_back_to_latin1():
+    """When UTF-8 decoding fails, tries latin-1."""
+    respx.get("https://s3.example.com/file.txt").mock(
+        # 0xe9 is invalid UTF-8 mid-byte but valid latin-1 ('é')
+        return_value=httpx.Response(200, content=b"foo \xe9 bar")
+    )
+    out = fetch_from_s3("https://s3.example.com/file.txt")
+    assert out is not None
+    assert "foo" in out
+    assert "bar" in out
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "mock_kwargs",
+    [
+        pytest.param({"return_value": httpx.Response(404)}, id="http_error"),
+        pytest.param(
+            {"side_effect": httpx.ConnectError("DNS lookup failed")},
+            id="connect_error",
+        ),
+    ],
+)
+def test_fetch_from_s3_returns_none_on_failure(mock_kwargs):
+    """HTTP error and network error both surface as ``None``."""
+    respx.get("https://s3.example.com/missing").mock(**mock_kwargs)
+    assert fetch_from_s3("https://s3.example.com/missing") is None
+
+
+# ─── Pooled-client behaviour ──────────────────────────────────────────────
+
+
+@respx.mock
+def test_http_client_is_a_singleton():
+    """Repeated calls to ``_http_client`` return the same client instance."""
+    c1 = _parser_utils._http_client()
+    c2 = _parser_utils._http_client()
+    c3 = _parser_utils._http_client()
+    assert c1 is c2 is c3
+
+
+@respx.mock
+def test_reset_http_client_for_testing_actually_rebuilds():
+    """``reset_http_client_for_testing`` drops the cached client; next call rebuilds it."""
+    c1 = _parser_utils._http_client()
+    reset_http_client_for_testing()
+    c2 = _parser_utils._http_client()
+    assert c1 is not c2
+
+
+@respx.mock
+def test_repeated_head_calls_reuse_pooled_client():
+    """All HEAD calls during a session go through the same httpx.Client."""
+    respx.head("https://s3.example.com/a.fif").mock(
+        return_value=httpx.Response(200, headers={"Content-Length": "100"})
+    )
+    respx.head("https://s3.example.com/b.fif").mock(
+        return_value=httpx.Response(200, headers={"Content-Length": "200"})
+    )
+    respx.head("https://s3.example.com/c.fif").mock(
+        return_value=httpx.Response(200, headers={"Content-Length": "300"})
+    )
+
+    client_before = _parser_utils._http_client()
+    assert head_content_length("https://s3.example.com/a.fif") == 100
+    assert head_content_length("https://s3.example.com/b.fif") == 200
+    assert head_content_length("https://s3.example.com/c.fif") == 300
+    client_after = _parser_utils._http_client()
+
+    assert client_before is client_after, (
+        "head_content_length must reuse the pooled client across "
+        "calls — rebuilding loses keep-alive benefit"
+    )
+
+
+@respx.mock
+def test_mixed_helpers_share_one_client():
+    """All three public helpers route through the same pooled client."""
+    respx.get("https://s3.example.com/range").mock(
+        return_value=httpx.Response(206, content=b"x" * 32)
+    )
+    respx.head("https://s3.example.com/head").mock(
+        return_value=httpx.Response(200, headers={"Content-Length": "42"})
+    )
+    respx.get("https://s3.example.com/text").mock(
+        return_value=httpx.Response(200, content=b"hello")
+    )
+
+    c0 = _parser_utils._http_client()
+    fetch_bytes_from_s3("https://s3.example.com/range", max_bytes=32)
+    head_content_length("https://s3.example.com/head")
+    fetch_from_s3("https://s3.example.com/text")
+    c1 = _parser_utils._http_client()
+
+    assert c0 is c1
+
+
+def test_http_client_enables_http2():
+    """Shared client is constructed with ``http2=True``."""
+    client = _parser_utils._http_client()
+    transport = client._transport
+    pool = getattr(transport, "_pool", None)
+    assert pool is not None, (
+        "client._transport._pool not found — httpx internal layout may "
+        "have changed; update the test"
+    )
+    assert getattr(pool, "_http2", False) is True, (
+        "Shared httpx.Client must be constructed with http2=True so "
+        "concurrent HEAD requests multiplex over one connection"
+    )

--- a/scripts/ingestions/tests/unit/test_path_traversal.py
+++ b/scripts/ingestions/tests/unit/test_path_traversal.py
@@ -1,0 +1,210 @@
+"""Regression tests for path-traversal hardening.
+
+Three findings are addressed in the same commit:
+
+- **F1** — ``_set_parser`` now uses ``validate_file_path`` for the
+  existence check (so broken git-annex symlinks behave consistently
+  with the other parsers).
+- **F2** — ``_vhdr_parser.extract_vhdr_references`` rejects DataFile/
+  MarkerFile references that resolve outside the .vhdr's parent
+  directory (defense against a malicious .vhdr that names
+  ``DataFile=../../../etc/passwd``).
+- **F3** — A new helper ``_parser_utils.path_is_within_root`` formalises
+  the containment check and is what F2 calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Allow tests to import the parser modules without installing the package.
+from _parser_utils import path_is_within_root
+from _set_parser import parse_set_metadata
+from _vhdr_parser import extract_vhdr_references
+from _vhdr_parser import extract_vhdr_references as _refs
+
+# ─── path_is_within_root ──────────────────────────────────────────────────
+
+
+def test_within_root_basic(tmp_path: Path) -> None:
+    """Normal sub-path is contained."""
+    sub = tmp_path / "sub-01" / "eeg" / "file.set"
+    sub.parent.mkdir(parents=True)
+    sub.touch()
+    assert path_is_within_root(sub, tmp_path) is True
+
+
+def test_within_root_dot_dot_escape_is_rejected(tmp_path: Path) -> None:
+    """Path traversal via ``..`` is rejected after resolution."""
+    sub = tmp_path / "child"
+    sub.mkdir()
+    outside = sub / ".." / ".." / "tmp"
+    # `outside` resolves to tmp_path.parent / tmp / which is outside `sub`.
+    assert path_is_within_root(outside, sub) is False
+
+
+def test_within_root_self_returns_true(tmp_path: Path) -> None:
+    """A path equal to root is itself in-root."""
+    assert path_is_within_root(tmp_path, tmp_path) is True
+
+
+def test_within_root_nonexistent_path_still_evaluated(tmp_path: Path) -> None:
+    """The function tests STRUCTURE; existence is irrelevant.
+
+    A path that doesn't exist but lexically belongs in the tree is
+    accepted. Callers that need existence-AND-containment should call
+    ``.exists()`` separately.
+    """
+    candidate = tmp_path / "future" / "file.set"
+    # The parent doesn't exist yet, but the resolved structural answer
+    # is still "inside tmp_path".
+    assert path_is_within_root(candidate, tmp_path) is True
+
+
+def test_within_root_symlink_out_of_tree_is_rejected(tmp_path: Path) -> None:
+    """A symlink that points OUT of the tree fails the check.
+
+    The threat model includes symlinks that look
+    inside-tree by name but resolve outside (e.g., a malicious dataset
+    archive that ships ``sub-01/data.set -> /etc/passwd``).
+    """
+    outside = tmp_path.parent / "outside_target.set"
+    outside.touch()
+    try:
+        inside = tmp_path / "sub-01" / "data.set"
+        inside.parent.mkdir(parents=True)
+        inside.symlink_to(outside)
+        # The symlink LOOKS inside tmp_path by name; resolve() reveals
+        # the truth.
+        assert path_is_within_root(inside, tmp_path) is False
+    finally:
+        if outside.exists():
+            outside.unlink()
+
+
+# ─── F2: extract_vhdr_references rejects out-of-tree DataFile= ───────────
+
+
+def _write_vhdr(parent: Path, datafile: str, markerfile: str = "") -> Path:
+    """Write a minimal .vhdr file with a chosen DataFile=/MarkerFile= line."""
+    vhdr = parent / "sub-01_eeg.vhdr"
+    content = "Brain Vision Data Exchange Header File Version 1.0\n"
+    content += "[Common Infos]\n"
+    content += f"DataFile={datafile}\n"
+    if markerfile:
+        content += f"MarkerFile={markerfile}\n"
+    content += "Codepage=UTF-8\n"
+    vhdr.write_text(content)
+    return vhdr
+
+
+def test_extract_vhdr_references_accepts_in_tree_sibling(tmp_path: Path) -> None:
+    """Normal sibling .eeg file resolves and is marked exists=True."""
+    vhdr = _write_vhdr(tmp_path, "sub-01_eeg.eeg")
+    (tmp_path / "sub-01_eeg.eeg").write_bytes(b"\x00" * 16)
+    refs = extract_vhdr_references(vhdr)
+    assert refs["datafile"] == "sub-01_eeg.eeg"
+    assert refs["datafile_exists"] is True
+
+
+def test_extract_vhdr_references_rejects_dotdot_path(tmp_path: Path) -> None:
+    """A DataFile= that escapes the parent dir is recorded but NOT
+    marked exists, even when the target file ACTUALLY EXISTS where the
+    traversal resolves.
+
+    This is the critical test for the security check at the heart of
+    ``path_is_within_root(...) AND data_path.exists()``.
+    The naive bug (``or`` instead of ``and``, surfaced as mutmut
+    mutant 80) only manifests when BOTH:
+        - the path traversal puts the resolved target outside parent
+        - the target file actually exists on disk
+
+    The earlier version of this test had the outside file at the wrong
+    path, so ``data_path.exists()`` was also False — both ``and`` and
+    ``or`` returned False, and the test couldn't distinguish them.
+    """
+    inner = tmp_path / "dataset_root"
+    inner.mkdir()
+    # CRITICAL: place the target where ``../evil_target.eeg`` resolves
+    # from inside ``inner``, i.e. at ``tmp_path/evil_target.eeg``.
+    # If this file isn't created at that exact path, ``data_path.exists()``
+    # returns False and the test passes by accident even with a broken
+    # security check.
+    outside_target = tmp_path / "evil_target.eeg"
+    outside_target.write_bytes(b"\x00")
+    try:
+        vhdr = _write_vhdr(inner, "../evil_target.eeg")
+        # Sanity: the target really does exist where the traversal points
+
+        assert (vhdr.parent / "../evil_target.eeg").resolve().exists(), (
+            "fixture bug: target file not at the resolved-traversal path"
+        )
+        refs = _refs(vhdr)
+        # Field is still surfaced (we don't lie about what's in the file)
+        assert refs["datafile"] == "../evil_target.eeg"
+        # ... but it MUST NOT be treated as a valid sibling.
+        # If a code change weakens this (e.g., ``or`` instead of ``and``
+        # — mutmut mutant 80), the existence check overrides the
+        # containment check and this assertion fails.
+        assert refs["datafile_exists"] is False
+    finally:
+        if outside_target.exists():
+            outside_target.unlink()
+
+
+def test_extract_vhdr_references_rejects_absolute_path(tmp_path: Path) -> None:
+    """An absolute path in DataFile= is rejected too."""
+    vhdr = _write_vhdr(tmp_path, "/etc/passwd")
+    refs = extract_vhdr_references(vhdr)
+    assert refs["datafile"] == "/etc/passwd"
+    assert refs["datafile_exists"] is False
+
+
+def test_extract_vhdr_references_rejects_dotdot_markerfile(tmp_path: Path) -> None:
+    """MarkerFile= gets the same containment treatment as DataFile=.
+
+    Same fixture shape as ``test_extract_vhdr_references_rejects_dotdot_path``:
+    the marker file is placed AT the path where the ``../`` traversal
+    resolves, so ``data_path.exists()`` is True and the test
+    distinguishes ``AND`` (correct) from ``OR`` (mutant 80 analog).
+    """
+    inner = tmp_path / "dataset_root"
+    inner.mkdir()
+    outside_marker = tmp_path / "evil.vmrk"  # where ../evil.vmrk resolves
+    outside_marker.write_bytes(b"\x00")
+    try:
+        vhdr = _write_vhdr(inner, "sub-01_eeg.eeg", markerfile="../evil.vmrk")
+        refs = extract_vhdr_references(vhdr)
+        assert refs["markerfile"] == "../evil.vmrk"
+        assert refs["markerfile_exists"] is False
+    finally:
+        if outside_marker.exists():
+            outside_marker.unlink()
+
+
+def test_extract_vhdr_references_subdirectory_sibling_is_accepted(
+    tmp_path: Path,
+) -> None:
+    """A subdirectory sibling is still within the .vhdr's parent → OK."""
+    sub = tmp_path / "data"
+    sub.mkdir()
+    (sub / "channels.eeg").write_bytes(b"\x00")
+    vhdr = _write_vhdr(tmp_path, "data/channels.eeg")
+    refs = extract_vhdr_references(vhdr)
+    assert refs["datafile_exists"] is True
+
+
+# ─── F3: _set_parser uses validate_file_path now ──────────────────────────
+
+
+def test_set_parser_handles_broken_symlink(tmp_path: Path) -> None:
+    """A broken git-annex-style symlink returns None, not a crash.
+
+    Before F3, the parser used a raw .exists() check that returns True
+    for broken symlinks (the symlink itself exists; its target doesn't).
+    scipy.io.loadmat would then crash on the dangling target.
+    """
+
+    broken_link = tmp_path / "broken.set"
+    broken_link.symlink_to(tmp_path / ".does_not_exist")
+    assert parse_set_metadata(broken_link) is None

--- a/scripts/ingestions/tests/unit/test_rate_limited.py
+++ b/scripts/ingestions/tests/unit/test_rate_limited.py
@@ -1,0 +1,185 @@
+"""Tests for the ``rate_limited`` decorator in ``_file_utils.py``.
+
+Factory helpers at module level satisfy the no-nested-functions rule.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from _file_utils import rate_limited
+
+
+def _make_response(status_code: int) -> httpx.Response:
+    """Construct a Response object suitable for raising as HTTPStatusError."""
+    return httpx.Response(status_code, request=httpx.Request("GET", "http://x"))
+
+
+def _make_http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Construct an HTTPStatusError carrying the given status code."""
+    return httpx.HTTPStatusError(
+        str(status_code),
+        request=httpx.Request("GET", "http://x"),
+        response=_make_response(status_code),
+    )
+
+
+def _make_request_error(msg: str = "network") -> httpx.RequestError:
+    """Construct a RequestError (network-tier failure)."""
+    return httpx.RequestError(msg, request=httpx.Request("GET", "http://x"))
+
+
+# ─── Module-level factory helpers (allowed by no-nested-functions) ────────
+
+
+class _Counter:
+    """Mutable call counter shared between a test and its factory-made fn."""
+
+    def __init__(self) -> None:
+        self.n = 0
+
+    def bump(self) -> None:
+        self.n += 1
+
+
+def make_always_succeeds(counter: _Counter) -> Callable[[], str]:
+    def fn() -> str:
+        counter.bump()
+        return "ok"
+
+    return fn
+
+
+def make_429_then_success(counter: _Counter) -> Callable[[], str]:
+    def fn() -> str:
+        counter.bump()
+        if counter.n == 1:
+            raise _make_http_error(429)
+        return "recovered"
+
+    return fn
+
+
+def make_network_error_then_success(counter: _Counter) -> Callable[[], str]:
+    def fn() -> str:
+        counter.bump()
+        if counter.n == 1:
+            raise _make_request_error("connection reset")
+        return "recovered"
+
+    return fn
+
+
+def make_always_raises_http(status_code: int, counter: _Counter) -> Callable[[], Any]:
+    def fn() -> Any:
+        counter.bump()
+        raise _make_http_error(status_code)
+
+    return fn
+
+
+def make_always_raises_network(counter: _Counter) -> Callable[[], Any]:
+    def fn() -> Any:
+        counter.bump()
+        raise _make_request_error("DNS fail")
+
+    return fn
+
+
+def make_always_raises_attribute_error(counter: _Counter) -> Callable[[], Any]:
+    def fn() -> Any:
+        counter.bump()
+        raise AttributeError("'NoneType' object has no attribute 'foo'")
+
+    return fn
+
+
+def make_timestamp_fn() -> Callable[[], float]:
+    def fn() -> float:
+        return time.monotonic()
+
+    return fn
+
+
+# ─── Happy paths: pass-through + retry-then-recover ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_result", "expected_calls"),
+    [
+        pytest.param(make_always_succeeds, "ok", 1, id="passthrough_on_success"),
+        pytest.param(make_429_then_success, "recovered", 2, id="retry_on_429"),
+        pytest.param(
+            make_network_error_then_success,
+            "recovered",
+            2,
+            id="retry_on_network_error",
+        ),
+    ],
+)
+def test_rate_limited_recovers(factory, expected_result, expected_calls):
+    counter = _Counter()
+    fn = rate_limited(min_interval=0.0, max_retries=3)(factory(counter))
+    assert fn() == expected_result
+    assert counter.n == expected_calls
+
+
+# ─── Non-retryable HTTP statuses: surface on the first attempt ──────────────
+
+
+@pytest.mark.parametrize("status_code", [404, 500], ids=["404", "500"])
+def test_rate_limited_surfaces_non_retryable_http_error(status_code):
+    counter = _Counter()
+    fn = rate_limited(min_interval=0.0, max_retries=3)(
+        make_always_raises_http(status_code, counter)
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        fn()
+    assert counter.n == 1, f"{status_code} must be raised on the first attempt"
+
+
+# ─── Exhausted retries: legacy contract returns None ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "factory_builder",
+    [
+        pytest.param(lambda c: make_always_raises_http(429, c), id="persistent_429"),
+        pytest.param(make_always_raises_network, id="persistent_network_error"),
+    ],
+)
+def test_rate_limited_returns_none_after_exhausted_retries(factory_builder):
+    counter = _Counter()
+    fn = rate_limited(min_interval=0.0, max_retries=2)(factory_builder(counter))
+    assert fn() is None
+    assert counter.n == 2
+
+
+# ─── Rate-limit spacing ─────────────────────────────────────────────────────
+
+
+def test_rate_limited_enforces_min_interval():
+    """Consecutive calls are spaced at least min_interval seconds apart."""
+    fn = rate_limited(min_interval=0.1, max_retries=1)(make_timestamp_fn())
+    t1 = fn()
+    t2 = fn()
+    # Allow a 5 % timing-jitter margin on slow CI runners.
+    assert (t2 - t1) >= 0.095, f"second call too soon ({t2 - t1:.3f}s)"
+
+
+# ─── Programmer errors propagate (no retry, no swallow) ─────────────────────
+
+
+def test_rate_limited_propagates_attribute_error():
+    counter = _Counter()
+    fn = rate_limited(min_interval=0.0, max_retries=3)(
+        make_always_raises_attribute_error(counter)
+    )
+    with pytest.raises(AttributeError):
+        fn()
+    assert counter.n == 1, "programmer errors must not be retried"

--- a/scripts/ingestions/tests/unit/test_serialize.py
+++ b/scripts/ingestions/tests/unit/test_serialize.py
@@ -1,0 +1,296 @@
+"""Unit tests for ``_serialize.py`` — deterministic JSON / dataset-id helpers.
+
+``_serialize.py`` powers the dataset-listing utilities shared by every
+``1_fetch_sources/*`` script. Critical reproducibility surface (stable
+bytes, deterministic dataset_id, deduplication) — the regressions caught
+here are silent bit-drift in the source-listing artefacts.
+"""
+
+from __future__ import annotations
+
+import json
+import re as _re
+import sys
+from pathlib import Path
+
+import pytest
+
+from _serialize import (
+    SUBJECT_COUNT_PATTERNS,
+    deduplicate_dataset_ids,
+    extract_subjects_count,
+    extract_surname,
+    extract_year,
+    generate_dataset_id,
+    normalize_dataset,
+    save_datasets_deterministically,
+    setup_paths,
+)
+
+# ─── setup_paths ──────────────────────────────────────────────────────────
+
+
+def test_setup_paths_is_idempotent():
+    """Second call must not grow sys.path further (idempotency invariant)."""
+    before = len(sys.path)
+    setup_paths()
+    after_first = len(sys.path)
+    setup_paths()
+    after_second = len(sys.path)
+    assert after_first == after_second
+    assert after_first - before <= 2
+
+
+# ─── extract_subjects_count ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param(None, 0, id="empty_none"),
+        pytest.param("", 0, id="empty_string"),
+        pytest.param("This study had 42 subjects", 42, id="had_N_subjects"),
+        pytest.param("Data from 17 participants", 17, id="from_N_participants"),
+        pytest.param("N = 25 healthy controls", 25, id="N_equals_with_qualifier"),
+        pytest.param("n = 30", 30, id="n_lowercase_equals_space"),
+        pytest.param("N=8 patients", 8, id="N_uppercase_no_space"),
+        pytest.param("5 individuals", 5, id="individuals"),
+        pytest.param("12 volunteers", 12, id="volunteers"),
+        pytest.param("8 children", 8, id="children"),
+        pytest.param("15 adults", 15, id="adults"),
+        pytest.param("recorded from 20 subjects", 20, id="recorded_from"),
+        pytest.param("data from 7 patients", 7, id="data_from_patients"),
+        pytest.param("ID 99999 subjects", 0, id="value_above_10000_rejected"),
+        pytest.param("This is just a description", 0, id="no_keyword"),
+        pytest.param("Music perception study", 0, id="unrelated_text"),
+    ],
+)
+def test_subjects_count_extracts(text, expected: int):
+    """Empty / pattern variants / sanity-rejection matrix."""
+    assert extract_subjects_count(text) == expected
+
+
+# ─── extract_surname ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # Firstname Lastname
+        pytest.param("John Smith", "Smith", id="firstname-lastname"),
+        pytest.param("Alice Marie Johnson", "Johnson", id="multi-middle-name"),
+        # Lastname, Firstname (BibTeX-style)
+        pytest.param("Smith, John", "Smith", id="bibtex-comma"),
+        pytest.param("Johnson, Alice Marie", "Johnson", id="bibtex-multi"),
+        # Initials shouldn't end up as the surname
+        pytest.param("J. Smith", "Smith", id="single-initial-firstname"),
+        pytest.param("F. M. Lastname", "Lastname", id="two-initials"),
+        # Suffixes (Jr/Sr/III/Ph.D.) stripped
+        pytest.param("John Smith Jr.", "Smith", id="suffix-jr"),
+        pytest.param("Mary Johnson Ph.D.", "Johnson", id="suffix-phd"),
+        pytest.param("Robert Brown III", "Brown", id="suffix-iii"),
+        # Accented characters normalised to ASCII for ID stability
+        pytest.param("José García", "Garcia", id="unicode-spanish"),
+        pytest.param("Müller", "Muller", id="unicode-umlaut"),
+        # None / empty / length-1 → None
+        pytest.param("", None, id="empty"),
+        pytest.param(None, None, id="none"),
+        pytest.param("   ", None, id="whitespace-only"),
+        pytest.param("X", None, id="length-1"),
+    ],
+)
+def test_surname_extracts(name, expected):
+    """Name formats / suffixes / unicode / invalid input matrix."""
+    assert extract_surname(name) == expected
+
+
+# ─── extract_year ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # ISO date / datetime
+        pytest.param("2024-01-15T10:30:00Z", "2024", id="iso-datetime"),
+        pytest.param("2024-01-15", "2024", id="iso-date"),
+        pytest.param("2024", "2024", id="year-only"),
+        # Found in arbitrary text
+        pytest.param("published in 2023", "2023", id="in-text"),
+        pytest.param("doi:10.5281/zenodo.2019", "2019", id="in-doi"),
+        # None / empty / no match → None
+        pytest.param(None, None, id="none"),
+        pytest.param("", None, id="empty"),
+        pytest.param("some text with no year", None, id="no-year"),
+        # Only 19xx / 20xx considered sensible
+        pytest.param("1850 study", None, id="century-too-old"),
+        pytest.param("2100 prediction", None, id="century-too-new"),
+        pytest.param("1999 published", "1999", id="1999-edge"),
+        pytest.param("2099 forecast", "2099", id="2099-edge"),
+    ],
+)
+def test_extract_year(text, expected):
+    """ISO / free-text / range-limit / no-match matrix."""
+    assert extract_year(text) == expected
+
+
+# ─── generate_dataset_id ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("args", "kwargs", "expected"),
+    [
+        pytest.param(
+            ("zenodo", ["John Smith"], "2024"),
+            {},
+            "Smith2024",
+            id="surname-year-format",
+        ),
+        pytest.param(
+            ("zenodo", ["", "X", "Alice Johnson"], "2023"),
+            {},
+            "Johnson2023",
+            id="walks-list-for-extractable-surname",
+        ),
+        pytest.param(
+            ("figshare",),
+            {"authors": [], "fallback_id": "12345"},
+            "figshare_12345",
+            id="fallback-to-source-id",
+        ),
+        pytest.param(
+            ("scidb",),
+            {},
+            "scidb_unknown",
+            id="unknown-when-nothing-works",
+        ),
+        # index=2 → suffix _3 (1-indexed in users' eyes)
+        pytest.param(
+            ("zenodo", ["Smith, J."], "2024"),
+            {"index": 2},
+            "Smith2024_3",
+            id="appends-disambiguating-index",
+        ),
+    ],
+)
+def test_generate_dataset_id(args, kwargs, expected):
+    """Surname-year / fallback / index matrix."""
+    assert generate_dataset_id(*args, **kwargs) == expected
+
+
+# ─── deduplicate_dataset_ids ──────────────────────────────────────────────
+# Kept standalone: each case has a structurally different assertion shape
+# (ordered-list equality vs distinctness via len(set()) vs other-fields
+# preservation) — parametrising would force a branch-on-id inside the body
+# which defeats the readability win.
+
+
+def test_dedup_handles_no_duplicates():
+    datasets = [{"dataset_id": "Smith2023"}, {"dataset_id": "Johnson2024"}]
+    out = deduplicate_dataset_ids(datasets)
+    assert [d["dataset_id"] for d in out] == ["Smith2023", "Johnson2024"]
+
+
+def test_dedup_renames_duplicates_with_suffix():
+    datasets = [
+        {"dataset_id": "Smith2024"},
+        {"dataset_id": "Smith2024"},
+        {"dataset_id": "Smith2024"},
+    ]
+    out = deduplicate_dataset_ids(datasets)
+    ids = [d["dataset_id"] for d in out]
+    assert ids[0] == "Smith2024"
+    assert len(set(ids)) == 3
+
+
+def test_dedup_preserves_other_fields():
+    """Only ``dataset_id`` is rewritten; other fields untouched."""
+    datasets = [
+        {"dataset_id": "X", "name": "alpha", "year": 2023},
+        {"dataset_id": "X", "name": "beta", "year": 2024},
+    ]
+    out = deduplicate_dataset_ids(datasets)
+    assert out[0]["name"] == "alpha"
+    assert out[1]["name"] == "beta"
+    assert out[0]["year"] == 2023
+    assert out[1]["year"] == 2024
+
+
+# ─── save_datasets_deterministically ──────────────────────────────────────
+
+
+def test_save_deterministic_produces_stable_bytes(tmp_path: Path):
+    """Saving twice with the same input → byte-identical files."""
+    datasets = [
+        {"dataset_id": "Z", "tasks": ["rest"]},
+        {"dataset_id": "A", "tasks": ["motor", "language"]},
+    ]
+    out1 = tmp_path / "first.json"
+    out2 = tmp_path / "second.json"
+    save_datasets_deterministically(datasets, out1)
+    save_datasets_deterministically(datasets, out2)
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+def test_save_sorts_by_dataset_id(tmp_path: Path):
+    """Output is sorted by ``dataset_id`` for stable diffs across runs."""
+    datasets = [{"dataset_id": "Zzz"}, {"dataset_id": "Aaa"}, {"dataset_id": "Mmm"}]
+    out = tmp_path / "sorted.json"
+    save_datasets_deterministically(datasets, out)
+    payload = json.loads(out.read_text())
+    assert isinstance(payload, list)
+    ids = [d["dataset_id"] for d in payload]
+    assert ids == sorted(ids)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_unique"),
+    [
+        pytest.param({}, 2, id="default-dedups"),
+        pytest.param({"deduplicate_ids": False}, 1, id="skip-dedup-preserves-dupes"),
+    ],
+)
+def test_save_deduplication_toggle(tmp_path: Path, kwargs, expected_unique):
+    """``deduplicate_ids`` flag: default dedups, False preserves duplicate IDs."""
+    datasets = [{"dataset_id": "Smith2024"}, {"dataset_id": "Smith2024"}]
+    out = tmp_path / "x.json"
+    save_datasets_deterministically(datasets, out, **kwargs)
+    payload = json.loads(out.read_text())
+    ids = [d["dataset_id"] for d in payload]
+    assert len(set(ids)) == expected_unique
+
+
+# ─── normalize_dataset ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(
+            {"dataset_id": "X", "name": "Test", "year": None, "modalities": ["eeg"]},
+            {"dataset_id": "X", "name": "Test", "modalities": ["eeg"]},
+            id="strips-none-values",
+        ),
+        pytest.param(
+            {"dataset_id": "X", "ages": [42, 21, 35]},
+            {"dataset_id": "X", "ages": [42, 21, 35]},
+            id="preserves-list-order",
+        ),
+        pytest.param(
+            {"dataset_id": "X", "metadata": {"keep": "yes", "drop": None}},
+            {"dataset_id": "X", "metadata": {"keep": "yes"}},
+            id="recurses-into-nested-dicts",
+        ),
+    ],
+)
+def test_normalize_dataset(raw, expected):
+    """None-stripping + list-order preservation + nested-dict recursion."""
+    assert normalize_dataset(raw) == expected
+
+
+# ─── SUBJECT_COUNT_PATTERNS sanity check ──────────────────────────────────
+
+
+def test_subject_count_patterns_compile():
+    """Every pattern is a valid regex (catches typos at import time)."""
+    for pattern in SUBJECT_COUNT_PATTERNS:
+        _re.compile(pattern)

--- a/scripts/ingestions/tests/unit/test_stage_configs.py
+++ b/scripts/ingestions/tests/unit/test_stage_configs.py
@@ -1,0 +1,732 @@
+"""Tests for the Pydantic-settings stage configs (clone / inject / cross-stage invariants)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from pydantic import ValidationError
+
+from _clone_config import (
+    KNOWN_SOURCES,
+    CloneConfig,
+    load_clone_config_from_argv,
+)
+from _digest_config import (
+    DEFAULT_DATASET_TIMEOUT_SECONDS,
+    DigestConfig,
+    load_digest_config_from_argv,
+)
+from _inject_config import (
+    DEFAULT_API_URL,
+    LOCAL_FALLBACK_DATABASES,
+    InjectConfig,
+    _valid_databases_cache,
+    clear_valid_databases_cache,
+    fetch_valid_databases_from_api,
+    load_inject_config_from_argv,
+)
+from _validate_config import (
+    ValidateConfig,
+    load_validate_config_from_argv,
+)
+
+# ─── 1. Clone config ──────────────────────────────────────────────
+
+
+def test_clone_config_defaults(tmp_path: Path):
+    c = CloneConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.output == Path("data/cloned")
+    assert c.sources is None
+    assert c.timeout == 300
+    assert c.workers == 8
+    assert c.limit is None
+    assert c.limit_per_source is None
+    assert c.datasets is None
+    assert c.manifest_only is False
+
+
+def test_clone_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError):
+        CloneConfig(input=tmp_path / "does_not_exist")
+
+
+# ─── Bounds ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("workers", 0, id="workers_below_min"),
+        pytest.param("workers", 9999, id="workers_above_max"),
+        pytest.param("timeout", 0, id="timeout_below_min"),
+        pytest.param("timeout", 60 * 60 * 24, id="timeout_above_6h"),
+        pytest.param("limit", 0, id="limit_below_min"),
+        pytest.param("limit_per_source", 0, id="limit_per_source_below_min"),
+    ],
+)
+def test_clone_config_field_bounds_reject_invalid(
+    tmp_path: Path, field: str, invalid_value: int
+):
+    with pytest.raises(ValidationError):
+        CloneConfig(input=tmp_path, **{field: invalid_value})
+
+
+def test_clone_config_workers_in_range_accepted(tmp_path: Path):
+    c = CloneConfig(input=tmp_path, workers=64)
+    assert c.workers == 64
+
+
+# ─── Sources validation ───────────────────────────────────────────────────
+
+
+def test_clone_config_accepts_known_sources(tmp_path: Path):
+    c = CloneConfig(
+        input=tmp_path,
+        sources=["openneuro", "nemar", "zenodo"],
+    )
+    assert c.sources == ["openneuro", "nemar", "zenodo"]
+
+
+def test_clone_config_rejects_unknown_source(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        CloneConfig(input=tmp_path, sources=["openneuro", "made_up_source"])
+    msg = str(exc.value)
+    assert "made_up_source" in msg
+
+
+@pytest.mark.parametrize("source", sorted(KNOWN_SOURCES))
+def test_clone_config_accepts_known_source(tmp_path: Path, source: str):
+    c = CloneConfig(input=tmp_path, sources=[source])
+    assert c.sources == [source]
+
+
+# ─── CLI parsing ──────────────────────────────────────────────────────────
+
+
+def test_clone_argv_parses_all_flags(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    c = load_clone_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--output",
+            str(out_dir),
+            "--sources",
+            "openneuro",
+            "nemar",
+            "--timeout",
+            "600",
+            "--workers",
+            "4",
+            "--limit",
+            "10",
+            "--limit-per-source",
+            "5",
+            "--datasets",
+            "ds-001",
+            "--manifest-only",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.output == out_dir
+    assert c.sources == ["openneuro", "nemar"]
+    assert c.timeout == 600
+    assert c.workers == 4
+    assert c.limit == 10
+    assert c.limit_per_source == 5
+    assert c.datasets == ["ds-001"]
+    assert c.manifest_only is True
+
+
+def test_clone_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_CLONE_WORKERS=16 → workers via env."""
+    monkeypatch.setenv("EEGDASH_CLONE_WORKERS", "16")
+    c = load_clone_config_from_argv(["--input", str(tmp_path)])
+    assert c.workers == 16
+
+
+def test_clone_argv_validation_error_for_unknown_source_via_argparse(
+    tmp_path: Path,
+):
+    """argparse choices=KNOWN_SOURCES rejects unknown sources via SystemExit before Pydantic."""
+    with pytest.raises(SystemExit):
+        load_clone_config_from_argv(
+            [
+                "--input",
+                str(tmp_path),
+                "--sources",
+                "made_up_source",
+            ]
+        )
+
+
+# ─── 2. Inject config ──────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _prime_valid_databases_cache():
+    """Pre-seed the cache so the field_validator skips real HTTP calls in CI."""
+    clear_valid_databases_cache()
+    _valid_databases_cache[DEFAULT_API_URL] = LOCAL_FALLBACK_DATABASES
+    yield
+    clear_valid_databases_cache()
+
+
+# ─── Defaults + required fields ───────────────────────────────────────────
+
+
+def test_config_requires_database():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(dry_run=True)
+    assert "database" in str(exc.value).lower()
+
+
+def test_config_rejects_invalid_database():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(database="not_a_real_db", dry_run=True)
+    msg = str(exc.value)
+    assert "database" in msg.lower()
+
+
+@pytest.mark.parametrize(
+    "database",
+    [
+        "eegdash",
+        "eegdash_dev",
+        "eegdash_archive",
+        "eegdash_staging",
+        "eegdash_v1",
+    ],
+)
+def test_config_accepts_each_valid_database(database: str):
+    c = InjectConfig(database=database, dry_run=True)
+    assert c.database == database
+
+
+def test_config_defaults():
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.api_url == DEFAULT_API_URL
+    assert c.input == Path("digestion_output")
+    assert c.batch_size == 1000
+    assert c.dry_run is True
+    assert c.only_datasets is False
+    assert c.only_records is False
+    assert c.only_montages is False
+    assert c.skip_montages is False
+    assert c.force is False
+    assert c.skip_validation is False
+    assert c.data_quality_threshold == 10.0
+    assert c.compute_stats is False
+    assert c.datasets is None
+
+
+# ─── Bounds ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("batch_size", 0, id="batch_size_lower"),
+        pytest.param("batch_size", 20_000, id="batch_size_upper"),
+        pytest.param("data_quality_threshold", -1.0, id="dqt_below_zero"),
+        pytest.param("data_quality_threshold", 101.0, id="dqt_above_100"),
+    ],
+)
+def test_inject_config_field_bounds_reject_invalid(field: str, invalid_value):
+    with pytest.raises(ValidationError):
+        InjectConfig(database="eegdash_dev", dry_run=True, **{field: invalid_value})
+
+
+@pytest.mark.parametrize("threshold", [0.0, 50.0, 100.0])
+def test_inject_data_quality_threshold_in_range_accepted(threshold: float):
+    c = InjectConfig(
+        database="eegdash_dev", data_quality_threshold=threshold, dry_run=True
+    )
+    assert c.data_quality_threshold == threshold
+
+
+# ─── Mutually-exclusive only-* flags ──────────────────────────────────────
+
+
+def test_two_only_flags_rejected():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            only_datasets=True,
+            only_records=True,
+            dry_run=True,
+        )
+    assert "mutually exclusive" in str(exc.value).lower()
+
+
+def test_three_only_flags_rejected():
+    with pytest.raises(ValidationError):
+        InjectConfig(
+            database="eegdash_dev",
+            only_datasets=True,
+            only_records=True,
+            only_montages=True,
+            dry_run=True,
+        )
+
+
+def test_each_single_only_flag_accepted():
+    for flag in ("only_datasets", "only_records", "only_montages"):
+        kw = {"database": "eegdash_dev", "dry_run": True, flag: True}
+        c = InjectConfig(**kw)
+        assert getattr(c, flag) is True
+
+
+# ─── only-montages + skip-montages contradict ─────────────────────────────
+
+
+def test_only_and_skip_montages_contradict():
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            only_montages=True,
+            skip_montages=True,
+            dry_run=True,
+        )
+    assert "contradict" in str(exc.value).lower()
+
+
+# ─── input must exist (unless dry-run) ────────────────────────────────────
+
+
+def test_missing_input_dir_rejected_when_not_dry_run(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_dev",
+            input=tmp_path / "does_not_exist",
+            dry_run=False,
+        )
+    assert "input" in str(exc.value).lower()
+
+
+def test_missing_input_dir_allowed_in_dry_run(tmp_path: Path):
+    """Dry-run skips the existence check — useful for --help-style runs."""
+    InjectConfig(
+        database="eegdash_dev",
+        input=tmp_path / "does_not_exist",
+        dry_run=True,
+    )
+
+
+def test_existing_input_dir_accepted(tmp_path: Path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    c = InjectConfig(database="eegdash_dev", input=real_dir, dry_run=False)
+    assert c.input == real_dir
+
+
+# ─── Env var fallback for token ───────────────────────────────────────────
+
+
+def test_token_explicit_arg_used_when_provided():
+    c = InjectConfig(database="eegdash_dev", token="explicit", dry_run=True)
+    assert c.token == "explicit"
+
+
+def test_token_reads_from_eegdash_admin_token_env(monkeypatch):
+    """When --token is missing, read EEGDASH_ADMIN_TOKEN (legacy ops-script convention)."""
+    monkeypatch.setenv("EEGDASH_ADMIN_TOKEN", "from_env")
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.token == "from_env"
+
+
+def test_token_none_when_neither_arg_nor_env(monkeypatch):
+    monkeypatch.delenv("EEGDASH_ADMIN_TOKEN", raising=False)
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.token is None
+
+
+# ─── Convenience accessors (want_datasets / want_records / want_montages) ─
+
+
+def test_want_accessors_default_true():
+    c = InjectConfig(database="eegdash_dev", dry_run=True)
+    assert c.want_datasets is True
+    assert c.want_records is True
+    assert c.want_montages is True
+
+
+@pytest.mark.parametrize(
+    ("flag", "want_datasets", "want_records", "want_montages"),
+    [
+        pytest.param("only_datasets", True, False, False, id="only_datasets"),
+        pytest.param("only_records", False, True, False, id="only_records"),
+        pytest.param("only_montages", False, False, True, id="only_montages"),
+    ],
+)
+def test_only_flag_filters_other_paths(
+    flag: str,
+    want_datasets: bool,
+    want_records: bool,
+    want_montages: bool,
+):
+    c = InjectConfig(database="eegdash_dev", dry_run=True, **{flag: True})
+    assert c.want_datasets is want_datasets
+    assert c.want_records is want_records
+    assert c.want_montages is want_montages
+
+
+def test_skip_montages_disables_montage_only():
+    c = InjectConfig(database="eegdash_dev", skip_montages=True, dry_run=True)
+    assert c.want_datasets is True
+    assert c.want_records is True
+    assert c.want_montages is False
+
+
+# ─── CLI parsing ──────────────────────────────────────────────────────────
+
+
+def test_argv_parses_minimum_required():
+    c = load_inject_config_from_argv(["--database", "eegdash_dev", "--dry-run"])
+    assert c.database == "eegdash_dev"
+    assert c.dry_run is True
+
+
+def test_argv_parses_all_string_flags():
+    c = load_inject_config_from_argv(
+        [
+            "--database",
+            "eegdash_dev",
+            "--api-url",
+            "https://test.example.com",
+            "--token",
+            "my-token",
+            "--batch-size",
+            "500",
+            "--dry-run",
+        ]
+    )
+    assert c.api_url == "https://test.example.com"
+    assert c.token == "my-token"
+    assert c.batch_size == 500
+
+
+def test_argv_parses_only_datasets_flag():
+    c = load_inject_config_from_argv(
+        ["--database", "eegdash_dev", "--only-datasets", "--dry-run"]
+    )
+    assert c.only_datasets is True
+    assert c.want_records is False
+
+
+def test_argv_parses_dataset_filter_list():
+    c = load_inject_config_from_argv(
+        [
+            "--database",
+            "eegdash_dev",
+            "--datasets",
+            "ds-001",
+            "ds-002",
+            "ds-003",
+            "--dry-run",
+        ]
+    )
+    assert c.datasets == ["ds-001", "ds-002", "ds-003"]
+
+
+def test_argv_validation_surfaces_via_validation_error():
+    with pytest.raises(ValidationError):
+        load_inject_config_from_argv(
+            [
+                "--database",
+                "eegdash_dev",
+                "--only-datasets",
+                "--only-records",
+                "--dry-run",
+            ]
+        )
+
+
+def test_argv_unknown_flag_rejected_by_argparse():
+    with pytest.raises(SystemExit):
+        load_inject_config_from_argv(
+            ["--database", "eegdash_dev", "--bogus-flag", "--dry-run"]
+        )
+
+
+# ─── fetch_valid_databases_from_api ────────────────────────────────────────
+
+
+@respx.mock
+def test_fetch_valid_databases_returns_api_list_on_200():
+    api_url = "https://api.example.test"
+    respx.get(f"{api_url}/admin/valid-databases").mock(
+        return_value=httpx.Response(
+            200, json={"databases": ["eegdash", "eegdash_dev", "eegdash_v2"]}
+        )
+    )
+
+    result = fetch_valid_databases_from_api(api_url, token="dummy")
+
+    assert result == frozenset({"eegdash", "eegdash_dev", "eegdash_v2"})
+
+
+@respx.mock
+def test_fetch_valid_databases_is_cached_per_api_url():
+    """Second call to the same api_url skips the network."""
+    clear_valid_databases_cache()
+    api_url = "https://cache-test.example"
+    route = respx.get(f"{api_url}/admin/valid-databases").mock(
+        return_value=httpx.Response(200, json={"databases": ["eegdash"]})
+    )
+
+    fetch_valid_databases_from_api(api_url, token=None)
+    fetch_valid_databases_from_api(api_url, token=None)
+    fetch_valid_databases_from_api(api_url, token=None)
+
+    assert route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("mock_kwargs", "expected"),
+    [
+        pytest.param(
+            {"return_value": httpx.Response(404, json={"detail": "not found"})},
+            None,
+            id="returns_none_on_404",
+        ),
+        pytest.param(
+            {"side_effect": httpx.ConnectError("boom")},
+            None,
+            id="returns_none_on_network_error",
+        ),
+        pytest.param(
+            {"return_value": httpx.Response(200, json={"unexpected": "shape"})},
+            None,
+            id="returns_none_on_missing_key",
+        ),
+    ],
+)
+@respx.mock
+def test_fetch_valid_databases_returns_none_on_error(mock_kwargs, expected):
+    clear_valid_databases_cache()
+    api_url = "https://error-case.example"
+    respx.get(f"{api_url}/admin/valid-databases").mock(**mock_kwargs)
+    assert fetch_valid_databases_from_api(api_url, token="x") is expected
+
+
+# ─── InjectConfig integration with the API-fetch field validator ──────────
+
+
+@respx.mock
+def test_inject_config_rejects_unknown_database_via_local_fallback(tmp_path):
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    with pytest.raises(ValidationError) as exc:
+        InjectConfig(
+            database="eegdash_does_not_exist",
+            input=tmp_path,
+            dry_run=True,
+        )
+    assert "valid set" in str(exc.value)
+
+
+@respx.mock
+def test_inject_config_accepts_database_only_in_api_set(tmp_path):
+    """API response extends the valid set beyond LOCAL_FALLBACK_DATABASES."""
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(
+            200,
+            json={"databases": ["eegdash", "eegdash_dev", "eegdash_v99_future"]},
+        )
+    )
+
+    c = InjectConfig(
+        database="eegdash_v99_future",
+        input=tmp_path,
+        dry_run=True,
+    )
+    assert c.database == "eegdash_v99_future"
+
+
+@respx.mock
+def test_inject_config_accepts_local_name_when_api_set_omits_it(tmp_path):
+    """LOCAL_FALLBACK_DATABASES names are accepted even when absent from the API set."""
+    clear_valid_databases_cache()
+    respx.get(f"{DEFAULT_API_URL}/admin/valid-databases").mock(
+        return_value=httpx.Response(200, json={"databases": ["eegdash", "eegdash_dev"]})
+    )
+
+    c = InjectConfig(
+        database="eegdash_archive",
+        input=tmp_path,
+        dry_run=True,
+    )
+    assert c.database == "eegdash_archive"
+
+
+@respx.mock
+def test_fetch_valid_databases_caches_failure_to_avoid_repeated_network_hits():
+    """Network failure is cached; subsequent calls return None without re-hitting the server."""
+    clear_valid_databases_cache()
+    api_url = "https://failure-cache.example"
+    route = respx.get(f"{api_url}/admin/valid-databases").mock(
+        side_effect=httpx.ConnectError("boom")
+    )
+
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+    assert fetch_valid_databases_from_api(api_url, token=None) is None
+
+    assert route.call_count == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stage 4 — ValidateConfig
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_validate_config_defaults(tmp_path: Path):
+    c = ValidateConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.pre_check is False
+    assert c.verbose is False
+    assert c.strict is False
+    assert c.json_output is False
+
+
+def test_validate_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        ValidateConfig(input=tmp_path / "does_not_exist")
+    assert "input" in str(exc.value).lower()
+
+
+def test_validate_config_accepts_real_input(tmp_path: Path):
+    c = ValidateConfig(input=tmp_path)
+    assert c.input == tmp_path
+
+
+def test_validate_argv_parses_all_flags(tmp_path: Path):
+    c = load_validate_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--pre-check",
+            "--verbose",
+            "--strict",
+            "--json",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.pre_check is True
+    assert c.verbose is True
+    assert c.strict is True
+    assert c.json_output is True
+
+
+def test_validate_argv_short_flag_for_input(tmp_path: Path):
+    """-i is an alias for --input."""
+    c = load_validate_config_from_argv(["-i", str(tmp_path)])
+    assert c.input == tmp_path
+
+
+def test_validate_argv_short_flag_for_verbose(tmp_path: Path):
+    """-v is an alias for --verbose."""
+    c = load_validate_config_from_argv(["-i", str(tmp_path), "-v"])
+    assert c.verbose is True
+
+
+def test_validate_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_VALIDATE_STRICT=1 → strict via env."""
+    monkeypatch.setenv("EEGDASH_VALIDATE_STRICT", "1")
+    c = load_validate_config_from_argv(["-i", str(tmp_path)])
+    assert c.strict is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stage 3 — DigestConfig
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_digest_config_defaults(tmp_path: Path):
+    c = DigestConfig(input=tmp_path)
+    assert c.input == tmp_path
+    assert c.output == Path("digestion_output")
+    assert c.datasets is None
+    assert c.workers == 1
+    assert c.limit is None
+    assert c.dataset_timeout == float(DEFAULT_DATASET_TIMEOUT_SECONDS)
+
+
+def test_digest_config_rejects_missing_input(tmp_path: Path):
+    with pytest.raises(ValidationError):
+        DigestConfig(input=tmp_path / "does_not_exist")
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("workers", 0, id="workers_lower_bound"),
+        pytest.param("workers", 9999, id="workers_upper_bound"),
+        pytest.param("limit", 0, id="limit_lower_bound"),
+        pytest.param("dataset_timeout", 0.0, id="dataset_timeout_zero"),
+        pytest.param("dataset_timeout", -1.0, id="dataset_timeout_negative"),
+        pytest.param(
+            "dataset_timeout",
+            float(60 * 60 * 24),
+            id="dataset_timeout_upper_bound",
+        ),
+    ],
+)
+def test_digest_config_field_bounds_reject_invalid(
+    tmp_path: Path, field: str, invalid_value
+):
+    with pytest.raises(ValidationError):
+        DigestConfig(input=tmp_path, **{field: invalid_value})
+
+
+def test_digest_config_datasets_filter(tmp_path: Path):
+    c = DigestConfig(input=tmp_path, datasets=["ds-001", "ds-002"])
+    assert c.datasets == ["ds-001", "ds-002"]
+
+
+def test_digest_argv_parses_all_flags(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    c = load_digest_config_from_argv(
+        [
+            "--input",
+            str(tmp_path),
+            "--output",
+            str(out_dir),
+            "--datasets",
+            "ds-001",
+            "ds-002",
+            "--workers",
+            "4",
+            "--limit",
+            "10",
+            "--dataset-timeout",
+            "300",
+        ]
+    )
+    assert c.input == tmp_path
+    assert c.output == out_dir
+    assert c.datasets == ["ds-001", "ds-002"]
+    assert c.workers == 4
+    assert c.limit == 10
+    assert c.dataset_timeout == 300.0
+
+
+def test_digest_argv_env_var_picked_up(tmp_path: Path, monkeypatch):
+    """EEGDASH_DIGEST_WORKERS=8 → workers=8 via env."""
+    monkeypatch.setenv("EEGDASH_DIGEST_WORKERS", "8")
+    c = load_digest_config_from_argv(["--input", str(tmp_path)])
+    assert c.workers == 8
+
+
+def test_digest_argv_validation_error_surfaces(tmp_path: Path):
+    """Bad CLI → ValidationError, not a vague argparse failure."""
+    with pytest.raises(ValidationError):
+        load_digest_config_from_argv(["--input", str(tmp_path), "--workers", "0"])

--- a/scripts/ingestions/tests/unit/test_validate.py
+++ b/scripts/ingestions/tests/unit/test_validate.py
@@ -1,0 +1,409 @@
+"""Tests for ``_validate.py`` — schema gate (validators + helpers)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from _validate import (
+    DATA_QUALITY_FIELDS,
+    NEURO_EXTENSIONS,
+    RECOMMENDED_DATASET_FIELDS,
+    VALID_SOURCES,
+    VALID_STORAGE_PATTERNS,
+    ValidationResult,
+    validate_dataset,
+    validate_digestion_output,
+    validate_record,
+    validate_storage_url,
+)
+from eegdash.testing import data_file
+
+
+def _minimal_valid_record() -> dict:
+    return {
+        "dataset": "ds002893",
+        "bids_relpath": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+        "digested_at": "2026-05-22T12:00:00+00:00",
+        "recording_modality": ["eeg"],
+        "storage": {
+            "base": "s3://openneuro.org/ds002893",
+            "backend": "s3",
+            "raw_key": "sub-01/eeg/sub-01_task-rest_eeg.edf",
+            "dep_keys": [],
+        },
+    }
+
+
+def _minimal_valid_dataset() -> dict:
+    return {
+        "dataset_id": "ds002893",
+        "source": "openneuro",
+        "ingestion_fingerprint": "abc123def456" + "0" * 20,
+        "name": "Test dataset",
+        "digested_at": "2026-05-22T12:00:00+00:00",
+        "recording_modality": ["eeg"],
+    }
+
+
+# ─── validate_record ──────────────────────────────────────────────────────
+
+
+def test_validate_record_accepts_minimal_valid_record():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.errors == []
+    assert result.stats["storage_errors"] == 0
+
+
+def test_validate_record_flags_storage_url_mismatch():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"]["base"] = "s3://nemar/ds002893"  # wrong source
+
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats["storage_errors"] == 1
+    assert any(e.get("field") == "storage.base" for e in result.errors), (
+        f"no storage.base error in {result.errors}"
+    )
+
+
+def test_validate_record_missing_mandatory_field_raises_pydantic_error():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    del rec["bids_relpath"]
+
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert len(result.errors) >= 1
+    assert any("record" in str(e) for e in result.errors)
+
+
+@pytest.mark.parametrize(
+    ("override", "counter", "expected"),
+    [
+        pytest.param({}, "missing_nchans", 1, id="nchans_missing"),
+        pytest.param({}, "missing_sampling_frequency", 1, id="sfreq_missing"),
+        pytest.param(
+            {"nchans": 0}, "missing_nchans", 1, id="nchans_zero_treated_missing"
+        ),
+        pytest.param(
+            {"nchans": 64, "sampling_frequency": 250.0},
+            "missing_nchans",
+            0,
+            id="nchans_present_not_counted",
+        ),
+        pytest.param(
+            {"nchans": 64, "sampling_frequency": 250.0},
+            "missing_sampling_frequency",
+            0,
+            id="sfreq_present_not_counted",
+        ),
+    ],
+)
+def test_validate_record_missing_field_counters(
+    override: dict, counter: str, expected: int
+):
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec.update(override)
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats[counter] == expected
+
+
+def test_validate_record_first_record_only_emits_recommended_warnings():
+    """Only record_idx == 0 emits recommended-field warnings."""
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds002893", "openneuro", result, record_idx=0)
+    first_warning_count = len(result.warnings)
+    assert first_warning_count > 0
+
+    validate_record(rec, "ds002893", "openneuro", result, record_idx=1)
+    assert len(result.warnings) == first_warning_count
+
+
+def test_validate_record_unknown_source_passes_storage_check():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    validate_record(rec, "ds-xxx", "brand_new_source", result)
+    assert result.stats["storage_errors"] == 0
+
+
+def test_validate_record_handles_missing_storage_dict():
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"] = {}
+    validate_record(rec, "ds002893", "openneuro", result)
+    assert result.stats["storage_errors"] == 0
+
+
+# ─── validate_dataset ─────────────────────────────────────────────────────
+
+
+def test_validate_dataset_accepts_minimal_valid_dataset():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    validate_dataset(ds, result)
+    assert result.errors == []
+    assert result.stats["invalid_source"] == 0
+
+
+def test_validate_dataset_warns_on_unknown_source():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    ds["source"] = "made_up_source"
+    validate_dataset(ds, result)
+    assert result.stats["invalid_source"] == 1
+    assert any(w.get("field") == "source" for w in result.warnings), (
+        f"no source warning in {result.warnings}"
+    )
+
+
+def test_validate_dataset_accepts_all_known_sources():
+    for source in VALID_SOURCES:
+        result = ValidationResult()
+        ds = _minimal_valid_dataset()
+        ds["source"] = source
+        validate_dataset(ds, result)
+        assert result.stats["invalid_source"] == 0, (
+            f"{source} should be a valid source but warned"
+        )
+
+
+def test_validate_dataset_warns_on_missing_recommended():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    for field in RECOMMENDED_DATASET_FIELDS:
+        ds.pop(field, None)
+    validate_dataset(ds, result)
+    assert len(result.warnings) >= len(RECOMMENDED_DATASET_FIELDS)
+
+
+def test_validate_dataset_handles_no_dataset_id():
+    result = ValidationResult()
+    ds = _minimal_valid_dataset()
+    del ds["dataset_id"]
+    validate_dataset(ds, result)
+    assert len(result.errors) >= 1
+
+
+# ─── validate_digestion_output (entry point) ──────────────────────────────
+
+
+def test_validate_digestion_output_returns_error_for_missing_dir(tmp_path: Path):
+    out = validate_digestion_output(tmp_path / "no_such_dir")
+    assert len(out.errors) >= 1
+    assert any("does not exist" in str(e) for e in out.errors)
+
+
+def test_validate_digestion_output_empty_dir(tmp_path: Path):
+    out = validate_digestion_output(tmp_path)
+    assert out.stats["datasets_checked"] == 0
+    assert out.errors == []
+
+
+def test_validate_digestion_output_walks_dataset_dirs(tmp_path: Path):
+    for ds_id in ("ds001", "ds002"):
+        ds_dir = tmp_path / ds_id
+        ds_dir.mkdir()
+        dataset = _minimal_valid_dataset()
+        dataset["dataset_id"] = ds_id
+        (ds_dir / f"{ds_id}_dataset.json").write_text(json.dumps(dataset))
+        records_doc = {
+            "dataset_id": ds_id,
+            "records": [_minimal_valid_record() | {"dataset": ds_id}],
+        }
+        (ds_dir / f"{ds_id}_records.json").write_text(json.dumps(records_doc))
+
+    out = validate_digestion_output(tmp_path)
+    assert out.stats["datasets_checked"] == 2
+    assert out.stats["records_checked"] == 2
+
+
+def test_validate_digestion_output_surfaces_malformed_json(tmp_path: Path):
+    ds_dir = tmp_path / "ds_bad"
+    ds_dir.mkdir()
+    (ds_dir / "ds_bad_dataset.json").write_text("{ this is not json")
+
+    out = validate_digestion_output(tmp_path)
+    assert any("Invalid JSON" in str(e) for e in out.errors), (
+        f"expected 'Invalid JSON' error, got {out.errors}"
+    )
+
+
+def test_validate_digestion_output_accepts_snapshot_fixture():
+    """End-to-end pin against the committed snapshot fixture."""
+    snapshot_root = data_file("digest_snapshots/outputs")
+    out = validate_digestion_output(snapshot_root)
+    assert out.stats["datasets_checked"] == 3
+    assert out.stats["records_checked"] == 5
+    assert out.errors == [], f"snapshot has errors: {out.errors}"
+
+
+def test_validate_digestion_output_strict_promotes_warnings(tmp_path: Path):
+    """Unknown-source triggers a warning in non-strict mode."""
+    ds_dir = tmp_path / "ds_synth"
+    ds_dir.mkdir()
+    dataset = _minimal_valid_dataset()
+    dataset["dataset_id"] = "ds_synth"
+    dataset["source"] = "made_up_source"
+    (ds_dir / "ds_synth_dataset.json").write_text(json.dumps(dataset))
+
+    non_strict = validate_digestion_output(tmp_path, strict=False)
+    assert non_strict.stats["invalid_source"] == 1
+    assert any(w.get("field") == "source" for w in non_strict.warnings)
+
+
+# ─── Integration: storage URL rejection across all known sources ──────────
+
+
+@pytest.mark.parametrize(
+    ("source", "wrong_url"),
+    [
+        ("openneuro", "s3://nemar/wrong"),
+        ("nemar", "s3://openneuro.org/wrong"),
+        ("zenodo", "https://figshare.com/wrong"),
+        ("figshare", "https://zenodo.org/wrong"),
+        ("osf", "s3://openneuro.org/wrong"),
+        ("scidb", "https://files.osf.io/wrong"),
+        ("datarn", "https://scidb.cn/wrong"),
+        ("gin", "s3://nemar/wrong"),
+    ],
+)
+def test_validate_record_rejects_cross_source_storage_urls(source: str, wrong_url: str):
+    result = ValidationResult()
+    rec = _minimal_valid_record()
+    rec["storage"]["base"] = wrong_url
+
+    validate_record(rec, "ds-test", source, result)
+    assert result.stats["storage_errors"] == 1, (
+        f"{source} should have rejected {wrong_url} but didn't"
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "url"),
+    [
+        ("openneuro", "s3://openneuro.org/ds002893"),
+        ("openneuro", "s3://openneuro.org/ds002893/sub-01/eeg/file.edf"),
+        ("nemar", "s3://nemar/nm000176"),
+        ("nemar", "s3://nmdatasets/nm000176"),
+        ("osf", "https://files.osf.io/v1/resources/abc/providers/osfstorage/"),
+        ("figshare", "https://figshare.com/ndownloader/files/12345"),
+        ("figshare", "https://ndownloader.figshare.com/files/12345"),
+        ("figshare", "https://mydomain.figshare.com/articles/12345"),
+        ("zenodo", "https://zenodo.org/record/12345"),
+        ("zenodo", "https://zenodo.org/records/12345"),
+        ("scidb", "https://scidb.cn/dataset/abc"),
+        ("scidb", "https://www.scidb.cn/dataset/abc"),
+        ("datarn", "https://webdav.data.ru.nl/test/path"),
+        ("gin", "https://gin.g-node.org/EEGManyLabs/study"),
+    ],
+)
+def test_storage_url_accepts_canonical_per_source(source: str, url: str):
+    ok, msg = validate_storage_url(source, url)
+    assert ok is True, f"{source=} {url=} → {msg=}"
+    assert msg == ""
+
+
+@pytest.mark.parametrize(
+    ("source", "wrong_url"),
+    [
+        ("nemar", "s3://openneuro.org/nm000176"),
+        ("openneuro", "s3://nemar/ds002893"),
+        ("figshare", "https://zenodo.org/record/12345"),
+        ("zenodo", "https://files.osf.io/v1/abc"),
+        ("openneuro", "https://example.com/ds002893"),
+        ("zenodo", "s3://nemar/12345"),
+    ],
+)
+def test_storage_url_rejects_cross_source_mismatch(source: str, wrong_url: str):
+    ok, msg = validate_storage_url(source, wrong_url)
+    assert ok is False
+    assert source in msg
+    assert wrong_url in msg
+
+
+def test_storage_url_unknown_source_passes_through():
+    ok, msg = validate_storage_url("brand_new_source", "https://example.com/")
+    assert ok is True
+    assert msg == ""
+
+
+def test_storage_url_must_match_at_start():
+    ok, _msg = validate_storage_url("openneuro", "garbage_s3://openneuro.org/ds123")
+    assert ok is False
+
+
+# ─── Constant-set invariants ──────────────────────────────────────────────
+
+
+def test_valid_sources_includes_canonical():
+    expected = {
+        "openneuro",
+        "nemar",
+        "gin",
+        "figshare",
+        "zenodo",
+        "osf",
+        "scidb",
+        "datarn",
+    }
+    assert expected.issubset(VALID_SOURCES)
+
+
+def test_valid_storage_patterns_cover_all_valid_sources_except_hbn():
+    sources_with_patterns = set(VALID_STORAGE_PATTERNS.keys())
+    sources_without_patterns = VALID_SOURCES - sources_with_patterns
+    assert sources_without_patterns <= {"hbn"}
+
+
+def test_neuro_extensions_includes_canonical_formats():
+    expected = {".edf", ".bdf", ".vhdr", ".set", ".fif", ".snirf"}
+    assert expected.issubset(NEURO_EXTENSIONS)
+
+
+def test_data_quality_fields_match_record_schema():
+    assert "nchans" in DATA_QUALITY_FIELDS
+    assert "sampling_frequency" in DATA_QUALITY_FIELDS
+
+
+def test_storage_patterns_compile():
+    for source, pattern in VALID_STORAGE_PATTERNS.items():
+        try:
+            re.compile(pattern)
+        except re.error as e:
+            pytest.fail(f"VALID_STORAGE_PATTERNS[{source!r}] = {pattern!r} fails: {e}")
+
+
+# ─── ValidationResult ──────────────────────────────────────────────────────
+
+
+def test_validation_result_initialises_empty():
+    r = ValidationResult()
+    assert r.errors == []
+    assert r.warnings == []
+    assert r.stats["datasets_checked"] == 0
+    assert r.stats["records_checked"] == 0
+    assert r.stats["storage_errors"] == 0
+
+
+def test_validation_result_stats_keys_are_stable():
+    r = ValidationResult()
+    expected_keys = {
+        "datasets_checked",
+        "records_checked",
+        "storage_errors",
+        "missing_mandatory",
+        "missing_recommended",
+        "empty_datasets",
+        "invalid_source",
+        "zip_placeholders",
+        "missing_nchans",
+        "missing_sampling_frequency",
+    }
+    assert set(r.stats.keys()) == expected_keys


### PR DESCRIPTION
**Stack PR D of 4.** Depends on PR B (configs). Replaces the old PR #357 along with stacked PR E.

## Summary
Library side of the ingestion refactor — abstractions without consumers. PR E (#TBD) lands the consumer-side scripts that wire into the new modules.

**New modules:**
- `_format_parser_registry` — Protocol + registry of FormatParsers.
- `_metadata_cascade` — 5-step cascade (mne_bids → modality_sidecar → channels_tsv → binary_parser → mne_fallback) with per-field provenance.
- `record_enumerator` — RecordEnumerator Seam (BIDSFilesystem + Manifest Adapters + factory).
- `source_adapter` — Per-Source ingest behaviour (OpenNeuro / NEMAR / Default Adapters).
- `digest_telemetry` — NDJSON event emitter with NullEmitter default.
- `_inject_plan` — Injection planning extracted from 5_inject.

**Modified helpers (PEP-8 import-lift + small fixes):** `_bids`, `_constants`, `_file_utils`, `_fingerprint`, `_github`, `_http`, `_keywords`, `_serialize`, `_parser_utils`, `_montage`; parser modules `_set_parser`, `_snirf_parser`, `_mef3_parser`, `_vhdr_parser`.

**Tests:** `tests/unit/*`, `tests/parsers/*`, `tests/github/*` (501 pass).
**Dev/CI:** builders.py, dev/audit_*.py, CI workflows for benchmarks/lint/mutmut/schema-dryrun.

## Test plan
- [x] 501 unit + parser + github tests pass locally
- [x] Ruff + format clean
- [ ] PR E (consumer side) lands on top to bring in the 3_digest/2_clone/5_inject refactor

Note: `test_montage.py` lives in PR E because its integration tests call `digest._attach_montage_to_record` which lives in 3_digest.py.