### PR TITLE
release: prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-28
+
 ### Added
 - New public APIs: `eegdash.splits` (subject-aware split utilities) and `EEGDashDataset.summary` / `preview` / `filter` / `search_datasets` for in-memory query and inspection
 - 22-tutorial sphinx-gallery rewrite plus HPC how-tos and concept pages

--- a/eegdash/__init__.py
+++ b/eegdash/__init__.py
@@ -9,7 +9,7 @@ EEG datasets. It integrates with cloud storage and REST APIs to streamline EEG r
 workflows.
 """
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 # NOTE: Keep the top-level import lightweight to avoid importing heavy optional
 # dependencies (e.g., braindecode/torch) when users only need small utilities.


### PR DESCRIPTION
Bumps `eegdash.__version__` 0.7.2 → 0.8.0 and converts the CHANGELOG `[Unreleased]` block to `[0.8.0] - 2026-05-28` (fresh empty `[Unreleased]` kept on top).

Minor bump per SemVer: this cycle adds new public APIs (`eegdash.splits`, `EEGDashDataset.summary`/`preview`/`filter`/`search_datasets`) on top of the loader-robustness, NEMAR/nemar-py, ingestion-refactor, and features work accumulated on develop since v0.7.2.

**Merge order:** land this into `develop` before merging #362 (develop → main) so `main` carries 0.8.0. PyPI publish happens once #362 reaches main.