### PR TITLE
test(ingest): golden safety net (InjectionPlan/ValidationReport/montage) + DDD-lite glossary & ADRs

### DIFF
--- a/scripts/ingestions/CONTEXT.md
+++ b/scripts/ingestions/CONTEXT.md
@@ -1,0 +1,57 @@
+# Ingestion pipeline — domain map
+
+`scripts/ingestions/` turns datasets discovered on remote repositories into
+validated documents written to the EEGDash API/database. It is a **data-processing
+pipeline**, not a rich behavioural domain — so we use *DDD-lite* (shared vocabulary
++ explicit stage boundaries) rather than full Domain-Driven Design. See
+[`docs/adr/0001-evolutionary-typed-pipeline.md`](docs/adr/0001-evolutionary-typed-pipeline.md).
+
+The canonical vocabulary lives in [`models.py`](models.py) (a glossary + re-export
+surface; the entity contracts themselves are owned by `eegdash.schemas`).
+
+## Stages
+
+Each stage has one input artifact, one output artifact, and owns exactly one I/O
+boundary. Stages are wired through `record_enumerator` (digest) and the numbered
+entry scripts; they never reach across each other's boundaries.
+
+| # | Stage | Entry script | Input → Output artifact | I/O boundary it owns |
+|---|-------|--------------|-------------------------|----------------------|
+| 1 | Fetch sources | `1_fetch_sources/*.py` | (query) → **SourceListing** / `manifest.json` | remote repo HTTP (Zenodo/OSF/OpenNeuro/Figshare/SciDB/DataRN/NEMAR) |
+| 2 | Clone | `2_clone.py` | **CloneManifest** → **LocalDataset** (on disk) | filesystem / git-annex / S3 |
+| 3 | Digest | `3_digest.py` | **LocalDataset** → **DigestBundle** (`*_dataset.json` + `*_records.json` + `*_montages.json`) | filesystem reads + BIDS/format parsing |
+| 4 | Validate | `4_validate_output.py` | **DigestBundle** → **ValidationReport** | filesystem reads only (pure) |
+| 5 | Inject | `5_inject.py` | **DigestBundle** + remote state → **InjectionPlan** → API writes | EEGDash API / MongoDB |
+
+## Where each artifact lives today
+
+- **DigestBundle** → `record_enumerator.EnumerationResult` (canonical name: `DigestBundle`)
+- **ValidationReport** → `_validate.ValidationResult` (canonical name: `ValidationReport`)
+- **InjectionPlan** → `_inject_plan.InjectionPlan`
+- **entities** (`Dataset`, `Record`, `Montage`) + `create_dataset`/`create_record` → `eegdash.schemas`
+
+## Module layout (intentionally flat — see ADR 0002)
+
+```
+3_digest.py          thin stage-3 orchestrator (was 2804 lines, now ~520)
+  _digest_runner     multiprocessing watchdog (subprocess isolation + timeouts)
+  record_enumerator  dispatches BIDS-filesystem vs manifest digest (the Seam)
+  _bids_digest       BIDS-filesystem record synthesis
+  _manifest_digest   manifest (API-only) record synthesis
+  _record_extractor  per-record BIDS extraction
+  _dataset_metadata  dataset-level metadata extraction
+  _bids_path         pure BIDS path-parsing / file classification
+  _source_id         dataset-id → source inference
+parsers              _vhdr_parser, _set_parser, _snirf_parser, _mef3_parser, _format_parser_registry, _montage
+foundations          _http, _parser_utils, _file_utils, _fingerprint, _constants, digest_telemetry
+configs              _digest_config, _clone_config, _inject_config, _validate_config (pydantic-settings)
+```
+
+## Testing safety net
+
+- **Golden masters** freeze current behaviour before any refactor:
+  `tests/digest/test_snapshot.py` (byte-level digest output, incl. the montage path),
+  `tests/inject/test_inject_plan_golden.py` (the create/update/skip decision),
+  `tests/unit/test_validate.py` (full validation report).
+- **Idempotency / fingerprint** stability: `tests/acceptance/`.
+- **Megafunction canary**: `tests/digest/test_helpers.py` (LOC ceilings/floors).

--- a/scripts/ingestions/docs/adr/0001-evolutionary-typed-pipeline.md
+++ b/scripts/ingestions/docs/adr/0001-evolutionary-typed-pipeline.md
@@ -1,0 +1,55 @@
+# ADR 0001 — Evolutionary, typed pipeline (DDD-lite + functional core / imperative shell)
+
+- **Status:** Accepted
+- **Scope:** `scripts/ingestions/`
+- **Date:** 2026-05
+
+## Context
+
+`scripts/ingestions/` is a five-stage data-processing pipeline (fetch → clone →
+digest → validate → inject), historically dominated by a 2,804-line `3_digest.py`
+with mixed concerns. We need it maintainable and hard to break, but it is **not** a
+rich behavioural domain: there are few competing domain rules, mostly transformations
+of dataset metadata. Full Domain-Driven Design (aggregates, repositories, entities,
+domain services everywhere) would add enterprise ceremony without payoff.
+
+## Decision
+
+Adopt **"Evolutionary, typed pipeline refactor using DDD-lite + functional core /
+imperative shell"**, with four governing rules:
+
+1. **DDD-lite, not full DDD.** Keep the strategic part — *ubiquitous language* and
+   explicit *stage boundaries* (see [`../../CONTEXT.md`](../../CONTEXT.md) and
+   [`../../models.py`](../../models.py)) — and drop tactical patterns (heavy
+   aggregates, repository/service classes, ABC-everywhere). Prefer small free
+   functions and `typing.Protocol` seams over inheritance.
+2. **TypedDict for construction, Pydantic for boundaries.** `eegdash.schemas`
+   deliberately co-defines TypedDicts (`Dataset`, `Record`, `Montage`) for cheap
+   construction/loading of millions of records, Pydantic models
+   (`DatasetModel`, `RecordModel`, `ManifestModel`) for the validation gate, and
+   `create_dataset`/`create_record` factories as the single construction path. Do
+   not Pydantic-ify every in-memory artifact; reserve it for real boundaries
+   (config, the three core entities, the manifest, the inject write boundary).
+3. **Validation returns a report, it does not throw.** `_validate.ValidationResult`
+   accumulates errors/warnings/stats; normal validation failures are data, not
+   exceptions. (A future `IngestionError`/`Recoverable`/`Fatal` hierarchy will
+   distinguish dataset-level from config/infra failures — see roadmap.)
+4. **Golden-master first.** Freeze current behaviour with characterization tests
+   *before* refactoring it. New behaviour-touching work must keep the golden
+   masters green or update them visibly in the same commit.
+
+## Consequences
+
+- Refactors proceed as Strangler-Fig / Branch-by-Abstraction increments, each
+  releasable, each guarded by golden tests — never a big-bang rewrite.
+- The codebase stays "boring, typed, explicit, testable": `config = Config.from_cli();
+  bundles = [digest_dataset(ds, config) for ds in datasets]; reports = [validate(b) …]`.
+- Some artifacts keep current names (`EnumerationResult`, `ValidationResult`) and
+  will gain glossary aliases (`DigestBundle`, `ValidationReport`) with back-compat.
+
+## Roadmap (deepening, not greenfield — most structure already exists)
+
+P0 glossary + ADRs → **P1 complete golden net** → P2 converge vocabulary + tighten
+inter-stage types → P3 isolate I/O behind injectable `Protocol`s + split pure cores
+→ P4 `IngestionError` hierarchy → P5 (optional) scoped packages + sampled write-boundary
+validation. See ADR 0002 for why P5 is scoped/optional.

--- a/scripts/ingestions/docs/adr/0002-keep-flat-ingestions-layout.md
+++ b/scripts/ingestions/docs/adr/0002-keep-flat-ingestions-layout.md
@@ -1,0 +1,57 @@
+# ADR 0002 — Keep the flat `scripts/ingestions/` layout
+
+- **Status:** Accepted
+- **Scope:** `scripts/ingestions/`
+- **Date:** 2026-05
+
+## Context
+
+The methodology that informs ADR 0001 sketches an idealized package layout:
+
+```
+cli/  models.py  config.py  pipeline/  adapters/  parsers/  io/  tests/{golden,unit,integration}
+```
+
+It is tempting to chase that literal structure. We evaluated it against the current
+flat layout (all modules at `scripts/ingestions/` top level, leading-underscore
+naming for internals, digit-prefixed entry scripts).
+
+## Decision
+
+**Keep the flat layout.** Realize the *intent* of the target structure — clear seams,
+isolated per-stage config, concern-split tests, a shared glossary — through naming
+and module boundaries, **not** through `cli/pipeline/adapters/io/` subpackages.
+
+Reasons:
+
+1. **The entry scripts are not importable modules.** `2_clone.py`, `3_digest.py`,
+   `4_validate_output.py`, `5_inject.py` start with a digit (not valid Python
+   identifiers) and are loaded via `importlib` by `tests/_helpers` and
+   `record_enumerator`. Moving them into a `cli/` package breaks those loaders.
+   If named entry points are ever wanted, add `[project.scripts]` console-scripts
+   that import the underscore modules, leaving the digit-prefixed files as thin
+   wrappers.
+2. **A big-bang move risks re-introducing import cycles.** The de-circularization
+   that made the digest graph a DAG depends on lazy imports and a flat namespace;
+   eager package `__init__.py` imports would re-create cycles.
+3. **30+ flat `from _x import …` call sites** would need re-pointing or re-export
+   shims; the cost/benefit is poor while the flat layout already reads clearly
+   (see [`../../CONTEXT.md`](../../CONTEXT.md)).
+4. **The intent is already met:** per-stage `pydantic-settings` configs, a `models.py`
+   glossary, and concern-split `tests/{unit,digest,inject,parsers,acceptance,pipeline}`.
+
+## When to revisit (scoped, optional — roadmap P5)
+
+If navigation pain is real, migrate **only** the two genuinely cohesive clusters,
+via Strangler-Fig with top-level re-export shims and **lazy** `__init__.py`:
+
+- `parsers/` ← `_set_parser`, `_snirf_parser`, `_vhdr_parser`, `_mef3_parser`, `_format_parser_registry`
+- `adapters/` ← `source_adapter`, `record_enumerator`, `_http`, `_github`
+
+Run `tests/digest/test_snapshot.py` after each file move. Do **not** move the
+digit-prefixed entry scripts.
+
+## Consequences
+
+- The flat layout is a deliberate, documented choice — not drift.
+- Reviewers seeing "why isn't this in `pipeline/`?" are answered by this ADR.

--- a/scripts/ingestions/models.py
+++ b/scripts/ingestions/models.py
@@ -1,0 +1,62 @@
+"""Ingestion domain glossary — the ubiquitous language + one import surface.
+
+This module defines **no new types**. It pins the canonical vocabulary for the
+ingestion pipeline (so code, tests, and docs share one language) and re-exports
+the existing artifact types. The Pydantic models and the ``create_dataset`` /
+``create_record`` factories remain the single source of truth in
+``eegdash.schemas`` — do not duplicate them here.
+
+Stage vocabulary (the pipeline, left to right):
+
+    SourceListing     stage 1  files discovered at a remote source (Zenodo / OSF /
+                               OpenNeuro / Figshare / SciDB / DataRN / NEMAR)
+    CloneManifest     stage 2  ``manifest.json`` describing a clonable/materialized
+                               dataset (validated by ``ManifestModel``)
+    LocalDataset      stage 2  a dataset present on disk (id + dir + source)
+    DigestBundle      stage 3  one dataset's dataset-doc + records + montages
+                               (currently produced as ``EnumerationResult``)
+    ValidationReport  stage 4  structured errors / warnings / stats
+                               (currently ``ValidationResult``)
+    InjectionPlan     stage 5  the create / update / skip decision for the API
+
+Naming convergence (see docs/adr/0001): the canonical names are ``DigestBundle``
+and ``ValidationReport``; ``EnumerationResult`` / ``ValidationResult`` are the
+current implementations and will gain back-compat aliases in a later phase. The
+single database write boundary is the *EegdashApi* (today: the inline calls in
+``5_inject.py`` and ``_inject_plan.fetch_existing_dataset``).
+"""
+
+from __future__ import annotations
+
+# Stage artifacts owned by the ingestion package.
+from _inject_plan import InjectionPlan
+from _validate import ValidationResult
+
+# Core entity contracts — single source of truth lives in eegdash.schemas.
+from eegdash.schemas import (
+    Dataset,
+    DatasetModel,
+    ManifestModel,
+    Montage,
+    Record,
+    RecordModel,
+    create_dataset,
+    create_record,
+)
+from record_enumerator import EnumerationResult
+
+__all__ = [
+    # entities / contracts (from eegdash.schemas)
+    "Dataset",
+    "DatasetModel",
+    # stage artifacts
+    "EnumerationResult",  # DigestBundle (stage 3)
+    "InjectionPlan",  # stage 5
+    "ManifestModel",
+    "Montage",
+    "Record",
+    "RecordModel",
+    "ValidationResult",  # ValidationReport (stage 4)
+    "create_dataset",
+    "create_record",
+]

--- a/scripts/ingestions/tests/digest/test_snapshot.py
+++ b/scripts/ingestions/tests/digest/test_snapshot.py
@@ -29,7 +29,7 @@ def _sanitize_for_snapshot(obj: Any, *, dataset_id: str) -> Any:
     if isinstance(obj, dict):
         out: dict[str, Any] = {}
         for k, v in obj.items():
-            if k == "digested_at":
+            if k in {"digested_at", "first_seen"}:
                 out[k] = "<TIMESTAMP>"
             elif k in {"dataset_file", "records_file", "montages_file"}:
                 # Keep just the basename for path stability across runs.
@@ -76,6 +76,27 @@ def fresh_manifest_digest_output(tmp_path_factory) -> Path:
     )
     assert summary["status"] == "success", (
         f"manifest snapshot fixture digestion failed: {summary}"
+    )
+    return tmp_output
+
+
+@pytest.fixture(scope="module")
+def fresh_eeg_montage_digest_output(tmp_path_factory) -> Path:
+    """Run ``digest_dataset`` against the montage-bearing BIDS-fs fixture; module-scoped.
+
+    ``ds_snapshot_eeg_montage`` is the only fixture that emits a non-empty
+    ``montages.json``, so it is the one that actually byte-freezes the montage
+    extraction path (electrodes/coordsystem -> sensors + hash).
+    """
+    digest_mod = load_digest()
+    tmp_output = tmp_path_factory.mktemp("eeg_montage_snapshot_run")
+    summary = digest_mod.digest_dataset(
+        "ds_snapshot_eeg_montage",
+        INPUTS_DIR,
+        tmp_output,
+    )
+    assert summary["status"] == "success", (
+        f"eeg-montage snapshot fixture digestion failed: {summary}"
     )
     return tmp_output
 
@@ -196,3 +217,50 @@ def test_manifest_snapshot_total_files_in_summary(
     assert "total_files" in summary
     snapshot_summary = _read_snapshot(dataset_id, "summary")
     assert summary["total_files"] == snapshot_summary["total_files"]
+
+
+# ─── Montage-bearing path: the only fixture that emits real montages ──────
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    ["dataset", "records", "montages", "summary"],
+)
+def test_eeg_montage_digest_output_matches_snapshot(
+    fresh_eeg_montage_digest_output: Path,
+    suffix: str,
+) -> None:
+    """Byte-freeze the montage-bearing dataset (the only one with a non-empty
+    ``montages.json``); ``first_seen`` is redacted like ``digested_at``."""
+    dataset_id = "ds_snapshot_eeg_montage"
+    fresh_path = (
+        fresh_eeg_montage_digest_output / dataset_id / f"{dataset_id}_{suffix}.json"
+    )
+    assert fresh_path.exists(), f"digest didn't produce {fresh_path.name}"
+
+    fresh = json.loads(fresh_path.read_text())
+    snapshot = _read_snapshot(dataset_id, suffix)
+
+    fresh_sanitized = _sanitize_for_snapshot(fresh, dataset_id=dataset_id)
+    snapshot_sanitized = _sanitize_for_snapshot(snapshot, dataset_id=dataset_id)
+
+    assert fresh_sanitized == snapshot_sanitized, (
+        f"\n{suffix}.json drifted from the committed snapshot. "
+        f"If this is INTENTIONAL, update the snapshot file in the same commit:\n"
+        f"  cp {fresh_path} {SNAPSHOT_OUTPUTS_DIR / dataset_id / fresh_path.name}\n"
+    )
+
+
+def test_eeg_montage_snapshot_has_nonempty_montages(
+    fresh_eeg_montage_digest_output: Path,
+) -> None:
+    """Guard the guard: this fixture MUST keep emitting a montage, else the
+    montage byte-freeze above silently degrades to comparing empty lists."""
+    dataset_id = "ds_snapshot_eeg_montage"
+    montages = json.loads(
+        (
+            fresh_eeg_montage_digest_output / dataset_id / f"{dataset_id}_montages.json"
+        ).read_text()
+    )
+    docs = montages["montages"] if isinstance(montages, dict) else montages
+    assert len(docs) >= 1, "eeg-montage fixture stopped emitting montages"

--- a/scripts/ingestions/tests/inject/test_inject_plan_golden.py
+++ b/scripts/ingestions/tests/inject/test_inject_plan_golden.py
@@ -1,0 +1,118 @@
+"""Golden-master tests for the Stage-5 InjectionPlan decision logic.
+
+``build_injection_plan`` / ``InjectionPlan`` (the create / update / skip decision,
+fingerprint comparison, and montage de-duplication) previously had ZERO test
+coverage — the richest behavior in the pipeline was unfrozen. These tests freeze
+that decision against the committed digest-snapshot corpus with the EEGDash API
+stubbed (no network), so any drift fails here before it can ship.
+"""
+
+from __future__ import annotations
+
+import _inject_plan
+from _inject_plan import build_injection_plan, find_digested_datasets
+from eegdash.testing import data_file
+
+# All three committed snapshot datasets (one carries a montage).
+ALL_IDS = ["ds_snapshot_eeg_montage", "ds_snapshot_manifest", "ds_snapshot_vhdr"]
+
+
+def _corpus_dirs():
+    return find_digested_datasets(data_file("digest_snapshots/outputs"))
+
+
+def _build(**overrides):
+    kw = {
+        "want_datasets": True,
+        "want_records": True,
+        "want_montages": True,
+        "force": False,
+        "only_montages": False,
+        "api_url": "http://stub",
+        "database": "test",
+    }
+    kw.update(overrides)
+    return build_injection_plan(_corpus_dirs(), **kw)
+
+
+def _no_api(*args, **kwargs):
+    """Stub asserting the EEGDash API is never consulted (force / only_montages paths)."""
+    raise AssertionError("the EEGDash API must not be called on this path")
+
+
+def _summary(plan) -> dict:
+    """Sanitized decision artifact — the behaviorally-rich part of the plan."""
+    return {
+        "changed_ids": sorted(plan.changed_ids),
+        "skipped_ids": sorted(plan.skipped_ids),
+        "n_datasets": len(plan.datasets),
+        "n_records": len(plan.records),
+        "n_montages": len(plan.montages),
+        "duplicate_montage_sightings": plan.duplicate_montage_sightings,
+        "errors": plan.errors,
+    }
+
+
+def test_injection_plan_all_new_golden(monkeypatch):
+    """Nothing exists remotely -> every dataset is 'changed'. Frozen decision artifact."""
+    monkeypatch.setattr(_inject_plan, "fetch_existing_dataset", lambda *a, **k: None)
+    assert _summary(_build()) == {
+        "changed_ids": ALL_IDS,
+        "skipped_ids": [],
+        "n_datasets": 3,
+        "n_records": 5,
+        "n_montages": 1,
+        "duplicate_montage_sightings": 0,
+        "errors": [],
+    }
+
+
+def test_injection_plan_skips_when_fingerprints_match(monkeypatch):
+    """Remote fingerprint == local fingerprint -> the dataset is skipped (round-trip)."""
+    # force=True bypasses the API and stamps the fingerprints the plan would compute.
+    fp_table = {
+        d["dataset_id"]: d["ingestion_fingerprint"] for d in _build(force=True).datasets
+    }
+    assert set(fp_table) == set(ALL_IDS)
+    assert all(fp_table.values())
+
+    monkeypatch.setattr(
+        _inject_plan,
+        "fetch_existing_dataset",
+        lambda api, db, did: {"ingestion_fingerprint": fp_table.get(did)},
+    )
+    plan = _build()
+    assert sorted(plan.skipped_ids) == ALL_IDS
+    assert plan.changed_ids == []
+    assert plan.datasets == []
+    assert plan.records == []
+
+
+def test_injection_plan_changes_when_fingerprint_differs(monkeypatch):
+    """Remote fingerprint differs -> the dataset is re-upserted (changed)."""
+    monkeypatch.setattr(
+        _inject_plan,
+        "fetch_existing_dataset",
+        lambda api, db, did: {"ingestion_fingerprint": "STALE"},
+    )
+    plan = _build()
+    assert sorted(plan.changed_ids) == ALL_IDS
+    assert plan.skipped_ids == []
+
+
+def test_injection_plan_force_bypasses_api(monkeypatch):
+    """force=True must not consult the API and marks everything changed."""
+    monkeypatch.setattr(_inject_plan, "fetch_existing_dataset", _no_api)
+    plan = _build(force=True)
+    assert sorted(plan.changed_ids) == ALL_IDS
+    assert plan.skipped_ids == []
+    assert len(plan.datasets) == 3
+    assert len(plan.records) == 5
+
+
+def test_injection_plan_only_montages_skips_api_and_collects_montages(monkeypatch):
+    """only_montages=True must not consult the API; montages are still collected."""
+    monkeypatch.setattr(_inject_plan, "fetch_existing_dataset", _no_api)
+    plan = _build(only_montages=True)
+    assert plan.skipped_ids == []
+    assert len(plan.montages) == 1

--- a/scripts/ingestions/tests/unit/test_validate.py
+++ b/scripts/ingestions/tests/unit/test_validate.py
@@ -244,6 +244,62 @@ def test_validate_digestion_output_accepts_snapshot_fixture():
     assert out.errors == [], f"snapshot has errors: {out.errors}"
 
 
+def test_validate_digestion_output_full_report_golden():
+    """Freeze the COMPLETE validation report against the committed corpus.
+
+    The count-only pin above lets the warnings list, every stats counter, the
+    source/modality distributions, and the data-quality issues drift silently.
+    This freezes all of them so any change in validation behavior fails here.
+    """
+    out = validate_digestion_output(data_file("digest_snapshots/outputs"))
+    report = {
+        "errors": out.errors,
+        "warnings": sorted(
+            out.warnings, key=lambda w: (w["dataset"], w["field"] or "", w["message"])
+        ),
+        "stats": out.stats,
+        "source_distribution": out.source_distribution,
+        "modality_distribution": out.modality_distribution,
+        "empty_datasets": sorted(out.empty_datasets),
+        "zip_placeholder_datasets": sorted(out.zip_placeholder_datasets),
+        "data_quality_issues": sorted(out.data_quality_issues),
+    }
+    assert report == {
+        "errors": [],
+        "warnings": [
+            {
+                "dataset": "ds_snapshot_eeg_montage",
+                "field": "source",
+                "message": "Unknown source: unknown",
+            },
+            {
+                "dataset": "ds_snapshot_vhdr",
+                "field": "source",
+                "message": "Unknown source: unknown",
+            },
+        ],
+        "stats": {
+            "datasets_checked": 3,
+            "records_checked": 5,
+            "storage_errors": 0,
+            "missing_mandatory": 0,
+            "missing_recommended": 0,
+            "empty_datasets": 0,
+            "invalid_source": 2,
+            "zip_placeholders": 0,
+            "missing_nchans": 3,
+            "missing_sampling_frequency": 3,
+        },
+        "source_distribution": {"unknown": 2, "zenodo": 1},
+        "modality_distribution": {"eeg": 5},
+        "empty_datasets": [],
+        "zip_placeholder_datasets": [],
+        "data_quality_issues": [
+            "ds_snapshot_manifest (zenodo): missing nchans, sampling_frequency"
+        ],
+    }
+
+
 def test_validate_digestion_output_strict_promotes_warnings(tmp_path: Path):
     """Unknown-source triggers a warning in non-strict mode."""
     ds_dir = tmp_path / "ds_synth"


### PR DESCRIPTION
## Summary
Phases **P0 + P1** of the evolutionary-typed-pipeline roadmap (see the new `docs/adr/0001`). This is the *characterization-first* groundwork: it **freezes the highest-value unfrozen behavior** so every later deepening step (vocabulary convergence, injectable I/O ports, functional-core splits, error model) becomes a provably-non-breaking change. **Purely additive — no production code changed.**

### Golden masters (the safety net)
- **Stage-5 `InjectionPlan`** (create/update/skip decision, fingerprint compare, montage de-dup) had **ZERO test coverage** — the richest logic in the pipeline was unfrozen. `tests/inject/test_inject_plan_golden.py` freezes it: all-new, fingerprint-match **skip** (round-trip), fingerprint-differs, `force`, `only_montages`. EEGDash API stubbed → **no network**.
- **Full `ValidationReport`** frozen (warnings + every stats counter + source/modality distributions + data-quality issues), not just counts: `tests/unit/test_validate.py`.
- **Montage byte-freeze**: `ds_snapshot_eeg_montage` is the only fixture emitting a montage; added it to the byte-level snapshot (`tests/digest/test_snapshot.py`, redacting `first_seen` like `digested_at`) + a guard that it keeps emitting one.

### DDD-lite vocabulary
- `models.py`: a **glossary + re-export surface** — `eegdash.schemas` stays the single source of truth (no duplication).
- `CONTEXT.md`: stage→artifact→I/O-boundary domain map. `docs/adr/0001` (governing decisions: DDD-lite, TypedDict+Pydantic split, validation-returns-reports, golden-first) and `0002` (why the flat layout is kept intentionally).

### Verification
984 passed, 0 failures; `ruff` clean. No production module touched (one redaction line in the test sanitizer aside).

> Context: follows up the #362 `3_digest.py` decomposition. A full pillar-by-pillar assessment produced the P0–P5 roadmap; this PR lands P0+P1, the precondition for the rest.
