### PR TITLE
release: prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-29
+
+### Fixed
+- Restored feature-extraction and dataset-IO work unintentionally removed by #359: feature decorators/extractors, the complexity/connectivity/signal feature banks, and `eegdash.dataset.io` (#365)
+
+### Added
+- Ingestion pipeline: golden-test safety net (InjectionPlan / ValidationReport / montage snapshots) plus a DDD-lite glossary and ADRs documenting the typed-pipeline design (#364)
+
 ## [0.8.0] - 2026-05-28
 
 ### Added

--- a/eegdash/__init__.py
+++ b/eegdash/__init__.py
@@ -9,7 +9,7 @@ EEG datasets. It integrates with cloud storage and REST APIs to streamline EEG r
 workflows.
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 # NOTE: Keep the top-level import lightweight to avoid importing heavy optional
 # dependencies (e.g., braindecode/torch) when users only need small utilities.


### PR DESCRIPTION
## Release prep: v0.8.1 (patch)

Bumps `eegdash.__version__` `0.8.0 → 0.8.1` and adds the `[0.8.1]` CHANGELOG section. Mirrors #363 (the v0.8.0 prep). Patch bump — no new public API since v0.8.0.

### Contents (everything on `develop` since the v0.8.0 tag)

**Fixed**
- Restored feature-extraction and dataset-IO work unintentionally removed by #359: feature decorators/extractors, the complexity/connectivity/signal feature banks, and `eegdash.dataset.io` (#365)

**Added**
- Ingestion pipeline (maintainer-internal, not shipped in the wheel): golden-test safety net (InjectionPlan / ValidationReport / montage snapshots) plus a DDD-lite glossary and ADRs documenting the typed-pipeline design (#364)

### Files changed
- `eegdash/__init__.py` — `__version__` `0.8.0 → 0.8.1`
- `CHANGELOG.md` — new `[0.8.1] - 2026-05-29` section

### After merge
- [ ] Create the annotated `v0.8.1` tag on the merge commit (matches the existing `v0.8.0`/`v0.7.x` annotated-tag pattern)
