### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 majors

### DIFF
--- a/.github/workflows/2-clone-digest.yml
+++ b/.github/workflows/2-clone-digest.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout EEGDash
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
@@ -51,7 +51,7 @@ jobs:
           path: eegdash
 
       - name: Checkout dataset listings repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: eegdash/eegdash-dataset-listings
           token: ${{ secrets.DATASET_LISTINGS_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           path: eegdash-dataset-listings
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -165,7 +165,7 @@ jobs:
           echo "- Records created: $RECORDS" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload digested artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.changed.outputs.changed == 'true'
         with:
           name: digested-${{ inputs.source_name }}

--- a/.github/workflows/3-inject.yml
+++ b/.github/workflows/3-inject.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout EEGDash
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
@@ -48,7 +48,7 @@ jobs:
           path: eegdash
 
       - name: Checkout dataset listings repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: eegdash/eegdash-dataset-listings
           token: ${{ secrets.DATASET_LISTINGS_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           path: eegdash-dataset-listings
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [ "ubuntu-latest" ]
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v5
         with:
@@ -64,7 +64,7 @@ jobs:
       - name: Restore Data Caches (pull_request)
         if: github.event_name == 'pull_request'
         id: cache-data-restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ steps.cache-paths.outputs.primary }}
@@ -86,7 +86,7 @@ jobs:
       - name: Create/Restore Data Caches (push)
         if: github.event_name != 'pull_request'
         id: cache-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ steps.cache-paths.outputs.primary }}
@@ -120,7 +120,7 @@ jobs:
 
       # Upload documentation as artifact for all builds
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation-html
           path: ./docs/_build/html
@@ -146,7 +146,7 @@ jobs:
       # Comment on PR with preview link
       - name: Comment PR with Preview Link
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const previewUrl = '${{ steps.deploy-preview.outputs.preview_url }}' || '';

--- a/.github/workflows/fetch-source.yml
+++ b/.github/workflows/fetch-source.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout EEGDash
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
@@ -48,7 +48,7 @@ jobs:
           path: eegdash
 
       - name: Checkout dataset listings repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: eegdash/eegdash-dataset-listings
           token: ${{ secrets.DATASET_LISTINGS_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           path: eegdash-dataset-listings
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/ingestions-bench.yml
+++ b/.github/workflows/ingestions-bench.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -38,7 +38,7 @@ jobs:
           pip install -e "scripts/ingestions[dev]"
 
       - name: Cache eegdash-testing-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/eegdash/testing-data
           key: eegdash-testing-data-v0.1.0
@@ -60,7 +60,7 @@ jobs:
             -ra --tb=short
 
       - name: Upload benchmark JSON as workflow artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ingestions-bench-${{ github.sha }}
           path: scripts/ingestions/.benchmarks/output.json

--- a/.github/workflows/ingestions-lint-and-test.yml
+++ b/.github/workflows/ingestions-lint-and-test.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -39,8 +39,8 @@ jobs:
     timeout-minutes: 15
     needs: lint
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -49,7 +49,7 @@ jobs:
           pip install -e .
           pip install -e "scripts/ingestions[dev]"
       - name: Cache eegdash-testing-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/eegdash/testing-data
           key: eegdash-testing-data-v0.1.0
@@ -103,7 +103,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ingestions-coverage
           path: |
@@ -120,8 +120,8 @@ jobs:
     # lint. The smoke is small (the snapshot fixture is ~50 KB) so
     # the cost is minimal.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -130,7 +130,7 @@ jobs:
           pip install -e .
           pip install -e "scripts/ingestions[dev]"
       - name: Cache eegdash-testing-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/eegdash/testing-data
           key: eegdash-testing-data-v0.1.0

--- a/.github/workflows/ingestions-mutmut-nightly.yml
+++ b/.github/workflows/ingestions-mutmut-nightly.yml
@@ -45,9 +45,9 @@ jobs:
           - _snirf_parser.py
           - _mef3_parser.py
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload mutmut cache as workflow artefact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutmut-cache-${{ matrix.parser }}-${{ github.run_id }}
           path: scripts/ingestions/.mutmut-cache

--- a/.github/workflows/ingestions-schema-dryrun.yml
+++ b/.github/workflows/ingestions-schema-dryrun.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -31,7 +31,7 @@ jobs:
           pip install -e .
           pip install -e "scripts/ingestions[dev]"
       - name: Cache eegdash-testing-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/eegdash/testing-data
           key: eegdash-testing-data-v0.1.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     ## Install Braindecode
     - name: Checking Out Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Configure dataset cache paths
       id: cache-paths
       shell: python
@@ -57,7 +57,7 @@ jobs:
     - name: Restore EEGDash Cache (pull_request)
       if: github.event_name == 'pull_request'
       id: cache-mne_data-restore
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.cache-paths.outputs.primary }}
@@ -79,7 +79,7 @@ jobs:
     - name: Create/Restore EEGDash Cache (push)
       if: github.event_name != 'pull_request'
       id: cache-mne_data
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.cache-paths.outputs.primary }}


### PR DESCRIPTION
## Bump deprecated Node 20 actions → Node 24

GitHub force-migrates Node 20 actions to Node 24 on the runners starting **2026-06-02** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Our `release.yaml` run already logged the deprecation warning for `actions/checkout` and `actions/setup-python`. This bumps all GitHub first-party actions to their latest stable **Node 24** majors.

| Action | Before | After | Node |
|--------|--------|-------|------|
| `actions/checkout` | `v4` (×16) | `v6` | 24 |
| `actions/setup-python` | `v5` (×11) | `v6` | 24 |
| `actions/upload-artifact` | `v4` (×5) | `v7` | 24 |
| `actions/cache` | `v4` (×8) | `v5` | 24 |
| `actions/github-script` | `v7` (×1) | `v9` | 24 |

**41 lines changed across 11 workflow files — pure version bumps, no behavior changes.**

### Why this is safe
- Verified every call site uses only stable inputs: `name`/`path`/`retention-days` (upload-artifact), `path`/`key` (cache).
- No `download-artifact` in the repo, so no upload/download major-version mismatch.
- `setup-python` v6's only behavior change (missing-cache-dir error → warning) is benign.
- `github-script` **v9** drops `require('@actions/github')` (ESM-only) — but our single script (`doc.yaml`) uses only the **injected** `github`/`context` objects, never `require()`, so it's unaffected.
- The actions used in PR-triggered CI (`checkout`, `setup-python`, `cache`, `upload-artifact`) are exercised by this PR's own run.

### Out of scope (left as-is)
Third-party actions (`astral-sh/setup-uv@v5`, `codecov/codecov-action@v5`, `peaceiris/actions-gh-pages@v4`, `pre-commit/action@v3.0.1`, `benchmark-action/github-action-benchmark@v1`, `pypa/gh-action-pypi-publish@release/v1`) — these aren't part of the GitHub Node 20 deprecation and major bumps carry breaking-change risk; can be a separate follow-up.
