### PR TITLE
fix(nemar): stop inlining sidecars; fetch on demand from data.nemar.org

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -400,6 +400,35 @@ def _resolve_nemar_uris(
     return raw_uri, dep_uris
 
 
+def _download_via_nemar(dataset_id: str, relpath: str, local_path: Path) -> bool:
+    """Download *relpath* from data.nemar.org via ``nemar-py``.
+
+    nemar-py resolves the dataset index → version manifest → file mapping
+    and streams the bytes (version-pinned, with retries and checksum
+    verification), so this is the canonical NEMAR sidecar/companion path.
+    Returns ``True`` once the file is on disk (including already-present),
+    ``False`` when the dataset/file isn't served by data.nemar.org (callers
+    then fall back to the GitHub-raw pointer).
+    """
+    if not (dataset_id and relpath):
+        return False
+    if local_path.exists():
+        return True
+    manifest = _fetch_nemar_manifest(dataset_id)
+    if manifest is None:
+        return False
+    target = relpath.lstrip("/")
+    if target not in manifest:
+        return False
+    try:
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        nemar.download_one(manifest.file(target), local_path)
+    except Exception as exc:
+        logger.warning("NEMAR download failed for %s/%s: %s", dataset_id, relpath, exc)
+        return False
+    return True
+
+
 def _resolve_one_nemar_entry(
     *,
     dataset_id: str,
@@ -432,6 +461,15 @@ def _resolve_one_nemar_entry(
             tmp.replace(dest)
         return None
 
+    # No digest-time fast path: fetch from data.nemar.org via nemar-py
+    # (version-pinned manifest, retries + checksum verification) — the
+    # canonical NEMAR path — rather than a raw GitHub ``HEAD`` read that
+    # drifts as the dataset evolves.
+    if _download_via_nemar(dataset_id, relpath, dest):
+        return None
+
+    # Legacy fallback for datasets not yet served by data.nemar.org:
+    # resolve the git-annex pointer from GitHub raw.
     try:
         annex_key, payload = _resolve_nemar_pointer(dataset_id, relpath)
     except urllib.error.URLError as e:
@@ -727,31 +765,14 @@ class EEGDashRaw(RawDataset):
         self.filenames = [self.filecache]
 
     def _download_nemar_data_file(self, relpath: str, local_path: Path) -> bool:
-        """Resolve *relpath* via ``nemar-py`` and stream its bytes.
+        """Resolve *relpath* via ``nemar-py`` (data.nemar.org) and stream it.
 
         Safety net for records whose pre-computed ``annex_keys`` don't
-        cover *relpath*. ``nemar-py`` handles ID validation, manifest
-        parsing, the BIDS-path → file mapping, and the actual transfer
-        (with retries + checksum verification). Returns ``True`` on
-        success.
+        cover *relpath*. Delegates to :func:`_download_via_nemar`, which
+        handles ID/version resolution, the BIDS-path → file mapping, and
+        the transfer (retries + checksum verification).
         """
-        dataset_id = self.record.get("dataset", "")
-        if not (dataset_id and relpath):
-            return False
-        manifest = _fetch_nemar_manifest(dataset_id)
-        if manifest is None:
-            return False
-        target = relpath.lstrip("/")
-        if target not in manifest:
-            return False
-        try:
-            nemar.download_one(manifest.file(target), local_path)
-        except Exception as exc:
-            logger.warning(
-                "NEMAR fallback failed for %s/%s: %s", dataset_id, relpath, exc
-            )
-            return False
-        return True
+        return _download_via_nemar(self.record.get("dataset", ""), relpath, local_path)
 
     # BIDS root files not enumerated in dep_keys but expected by mne-bids /
     # braindecode. All are direct-git on NEMAR (excluded from annex).

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -645,6 +645,17 @@ class EEGDashRaw(RawDataset):
         bids_filename = PurePosixPath(self.record["bids_relpath"]).name
         return uri.rsplit("/", 1)[0] + "/" + bids_filename
 
+    @property
+    def _is_remote(self) -> bool:
+        """Whether the recording must be fetched from a remote source.
+
+        ``s3``/``https`` set ``_raw_uri`` up front; ``nemar`` leaves it
+        ``None`` until it is resolved lazily in :meth:`_download_required_files`
+        (its BIDS path is a git-annex symlink, not a fetchable object);
+        ``local`` needs no download.
+        """
+        return self._raw_uri is not None or self._storage_backend == "nemar"
+
     def _download_required_files(self) -> None:
         # NEMAR records carry a logical ``s3://nemar/<id>/<bids_relpath>``
         # base, but actual fetching has to go through the SHA-keyed

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -463,7 +463,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         targets: list[EEGDashRaw] = []
         for ds in self.datasets:
-            if getattr(ds, "_raw_uri", None) is None:
+            if not ds._is_remote:
                 continue
             if not ds.filecache.exists() or any(
                 not path.exists() for path in getattr(ds, "_dep_paths", [])

--- a/scripts/ingestions/_record_extractor.py
+++ b/scripts/ingestions/_record_extractor.py
@@ -386,7 +386,6 @@ def extract_record(
     dataset_id: str,
     source: str,
     digested_at: str,
-    apex_sidecar_inline: dict[str, str] | None = None,
     source_adapter: SourceAdapter | None = None,
 ) -> dict[str, Any]:
     """Extract Record metadata for a single BIDS file."""
@@ -452,19 +451,17 @@ def extract_record(
         provenance=metadata_provenance,
     )
 
-    # TODO(scale): apex sidecars (dataset_description.json, README, etc.) are duplicated
-    # across every record. Move into a per-dataset side-collection when >100 MB inline
-    # payload or >500 KB participants.tsv is encountered.
     if source_adapter is None:
         source_adapter = get_source_adapter(source, dataset_id, bids_dataset.bidsdir)
     bids_root_path = bids_dataset.bidsdir
     dep_paths = [bids_root_path / dep for dep in dep_keys]
-    annex_keys, sidecar_inline = source_adapter.resolve_storage_extensions(
+    # Sidecar contents are no longer inlined: a digest-time copy bloated every
+    # record (typing events.tsv ~230 KB; dataset-level files duplicated across
+    # records) and drifted as NEMAR datasets evolve. The runtime fetches them
+    # from the NEMAR GitHub mirror on demand, so only annex SHA keys are kept.
+    annex_keys, _ = source_adapter.resolve_storage_extensions(
         Path(bids_file), dep_paths
     )
-    if apex_sidecar_inline:
-        for k, v in apex_sidecar_inline.items():
-            sidecar_inline.setdefault(k, v)
 
     record = create_record(
         dataset=dataset_id,
@@ -486,7 +483,7 @@ def extract_record(
         ntimes=ntimes,
         digested_at=digested_at,
         annex_keys=annex_keys or None,
-        sidecar_inline=sidecar_inline or None,
+        sidecar_inline=None,
     )
 
     participant_tsv = bids_dataset.subject_participant_tsv(bids_file)

--- a/scripts/ingestions/source_adapter.py
+++ b/scripts/ingestions/source_adapter.py
@@ -18,9 +18,8 @@ import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from _file_utils import get_annex_file_key, read_inline_sidecar
+from _file_utils import get_annex_file_key
 from eegdash.dataset._source_inference import DEFAULT_STORAGE_CONFIG, STORAGE_CONFIGS
-from eegdash.schemas import NEMAR_ROOT_METADATA_FILES
 
 logger = logging.getLogger(__name__)
 
@@ -92,19 +91,21 @@ class OpenNeuroAdapter(SourceAdapter):
 
 
 class NEMARAdapter(SourceAdapter):
-    """NEMAR Source — git-annex SHA addressing + apex sidecar prefetch.
+    """NEMAR Source — git-annex SHA addressing.
 
     NEMAR's S3 bucket has ``s3:ListBucket`` closed by design; all file
     addresses are SHA-resolved via git-annex on the cloned filesystem.
     The ``backend="nemar"`` marker signals downstream consumers not to
-    attempt a public S3 fetch.  :data:`NEMAR_ROOT_METADATA_FILES` are
-    read once (lazily, into ``_apex_cache``) and reused across every
-    Record to avoid repeated filesystem round-trips.
-    """
+    attempt a public S3 fetch.
 
-    def __init__(self, dataset_id: str, bids_root: Path | None = None) -> None:
-        super().__init__(dataset_id, bids_root)
-        self._apex_cache: dict[str, str] | None = None
+    Sidecar *contents* are intentionally NOT inlined into records. A
+    digest-time inline copy bloats every record (a single typing
+    ``events.tsv`` is ~230 KB, and dataset-level apex files duplicate
+    across every record) and goes stale as the dataset evolves. The
+    runtime fetches sidecars on demand from the NEMAR GitHub mirror
+    (``HEAD``, always current) instead, so only annex SHA keys — the
+    binary recordings on S3 — are resolved here.
+    """
 
     @property
     def source_name(self) -> str:
@@ -114,65 +115,33 @@ class NEMARAdapter(SourceAdapter):
         """NEMAR DataExplorer landing page."""
         return f"https://nemar.org/dataexplorer/detail/{self.dataset_id}"
 
-    def _ensure_apex_cache(self) -> dict[str, str]:
-        """Lazy-build the apex sidecar inline cache (once per Adapter)."""
-        if self._apex_cache is not None:
-            return self._apex_cache
-        cache: dict[str, str] = {}
-        if self.bids_root is None:
-            self._apex_cache = cache
-            return cache
-        for root_name in NEMAR_ROOT_METADATA_FILES:
-            inline = read_inline_sidecar(self.bids_root / root_name)
-            if inline is not None:
-                cache[root_name] = inline
-        self._apex_cache = cache
-        return cache
+    def _annex_relpath(self, path: Path) -> str:
+        """BIDS-relative key for *path* (annex keys are stored by relpath)."""
+        if self.bids_root is not None:
+            try:
+                return str(path.relative_to(self.bids_root))
+            except ValueError:
+                pass
+        return str(path)
 
     def resolve_storage_extensions(
         self,
         record_path: Path,
         dep_paths: list[Path],
     ) -> tuple[dict[str, str], dict[str, str]]:
-        """Resolve annex keys and inline sidecars for one Record."""
+        """Resolve git-annex SHA keys for one Record (no sidecar inlining)."""
         annex_keys: dict[str, str] = {}
-        sidecar_inline: dict[str, str] = dict(self._ensure_apex_cache())
 
-        # The recording itself
         raw_key = get_annex_file_key(record_path)
         if raw_key is not None:
-            # NEMAR annex keys are stored against the BIDS relative path
-            # — preserve the convention 3_digest used before this refactor.
-            if self.bids_root is not None:
-                try:
-                    rel = str(record_path.relative_to(self.bids_root))
-                except ValueError:
-                    rel = str(record_path)
-            else:
-                rel = str(record_path)
-            annex_keys[rel] = raw_key
+            annex_keys[self._annex_relpath(record_path)] = raw_key
 
-        # Each dep file: annex key OR inlined text
         for dep_path in dep_paths:
-            if self.bids_root is not None:
-                try:
-                    dep_relpath = str(dep_path.relative_to(self.bids_root))
-                except ValueError:
-                    dep_relpath = str(dep_path)
-            else:
-                dep_relpath = str(dep_path)
-
             dep_key = get_annex_file_key(dep_path)
             if dep_key is not None:
-                annex_keys[dep_relpath] = dep_key
-                continue
-            if dep_relpath in sidecar_inline:
-                continue  # already covered by apex cache
-            inline = read_inline_sidecar(dep_path)
-            if inline is not None:
-                sidecar_inline[dep_relpath] = inline
+                annex_keys[self._annex_relpath(dep_path)] = dep_key
 
-        return annex_keys, sidecar_inline
+        return annex_keys, {}
 
 
 class DefaultAdapter(SourceAdapter):

--- a/scripts/ingestions/tests/digest/test_source_adapter.py
+++ b/scripts/ingestions/tests/digest/test_source_adapter.py
@@ -100,37 +100,36 @@ def test_nemar_dataset_url_points_at_dataexplorer():
     assert adapter.dataset_url() == "https://nemar.org/dataexplorer/detail/nm000176"
 
 
-def test_nemar_apex_cache_built_lazily_from_bids_root(tmp_path: Path):
-    """First call to resolve_storage_extensions reads NEMAR_ROOT_METADATA_FILES."""
-    # Create a small NEMAR-shaped tree with one apex sidecar
+def test_nemar_does_not_inline_apex_sidecars(tmp_path: Path):
+    """Apex sidecars (dataset_description, participants, ...) are NOT inlined.
+
+    They bloated every record and drifted as datasets evolved; the runtime
+    now fetches them from the NEMAR GitHub mirror on demand.
+    """
     bids_root = tmp_path / "nm000176"
     bids_root.mkdir()
-    participants = bids_root / "participants.tsv"
-    participants.write_text("participant_id\tage\nsub-01\t30\n")
-    dataset_desc = bids_root / "dataset_description.json"
-    dataset_desc.write_text('{"Name": "Test Dataset", "BIDSVersion": "1.7.0"}\n')
+    (bids_root / "participants.tsv").write_text("participant_id\tage\nsub-01\t30\n")
+    (bids_root / "dataset_description.json").write_text(
+        '{"Name": "Test Dataset", "BIDSVersion": "1.7.0"}\n'
+    )
 
     adapter = NEMARAdapter("nm000176", bids_root=bids_root)
-    # Trigger cache build with a no-op call
     _annex, inline = adapter.resolve_storage_extensions(
         bids_root / "sub-01/eeg/sub-01_eeg.edf", []
     )
-    # Apex files should be inlined
-    assert "participants.tsv" in inline
-    assert "sub-01\t30" in inline["participants.tsv"]
-    assert "dataset_description.json" in inline
+    assert inline == {}
 
 
-def test_nemar_apex_cache_returns_empty_when_bids_root_is_none():
-    """No bids_root means no filesystem reads; cache stays empty."""
+def test_nemar_resolve_returns_empty_inline_when_bids_root_is_none():
+    """No bids_root, no inlining; annex resolution yields an empty map."""
     adapter = NEMARAdapter("nm000176", bids_root=None)
     annex, inline = adapter.resolve_storage_extensions(Path("/tmp/x.edf"), [])
     assert annex == {}
     assert inline == {}
 
 
-def test_nemar_resolve_dep_inlines_small_sidecars(tmp_path: Path):
-    """Sidecar files that aren't annex-tracked get inlined."""
+def test_nemar_does_not_inline_dep_sidecars(tmp_path: Path):
+    """Non-annex dep sidecars are not inlined (fetched from GitHub at runtime)."""
     bids_root = tmp_path / "nm000176"
     eeg_dir = bids_root / "sub-01" / "eeg"
     eeg_dir.mkdir(parents=True)
@@ -141,9 +140,8 @@ def test_nemar_resolve_dep_inlines_small_sidecars(tmp_path: Path):
     record_path = eeg_dir / "sub-01_task-rest_eeg.edf"
     record_path.touch()
 
-    _, inline = adapter.resolve_storage_extensions(record_path, [channels_tsv])
-    assert "sub-01/eeg/sub-01_task-rest_channels.tsv" in inline
-    assert "Fp1\tEEG" in inline["sub-01/eeg/sub-01_task-rest_channels.tsv"]
+    _annex, inline = adapter.resolve_storage_extensions(record_path, [channels_tsv])
+    assert inline == {}
 
 
 # ─── DefaultAdapter — table-driven fallback ───────────────────────────────

--- a/tests/unit_tests/dataset/test_dataset.py
+++ b/tests/unit_tests/dataset/test_dataset.py
@@ -625,6 +625,41 @@ def test_dataset_download_all_njobs(tmp_path):
                 assert mock_dl.call_count == 1
 
 
+def test_dataset_download_all_includes_nemar(tmp_path):
+    """download_all must fetch NEMAR recordings.
+
+    Regression: NEMAR records carry ``_raw_uri = None`` until it is resolved
+    lazily inside ``_download_required_files`` (the BIDS-named path is a
+    git-annex symlink, not a fetchable object), so they were wrongly skipped
+    by the ``_raw_uri is None`` guard and ``download_all`` never fetched them.
+    """
+    from unittest.mock import patch
+
+    from eegdash.dataset.dataset import EEGDashDataset, EEGDashRaw
+
+    record = {
+        "dataset": "nm000999",
+        "data_name": "nm000999_sub-01_task-x_eeg.edf",
+        "bidspath": "nm000999/sub-01/eeg/sub-01_task-x_eeg.edf",
+        "bids_relpath": "sub-01/eeg/sub-01_task-x_eeg.edf",
+        "storage": {
+            "base": "s3://nemar/nm000999",
+            "backend": "nemar",
+            "raw_key": "sub-01/eeg/sub-01_task-x_eeg.edf",
+            "annex_keys": {"sub-01/eeg/sub-01_task-x_eeg.edf": "MD5E-s1--abc.edf"},
+        },
+    }
+
+    ds = EEGDashDataset(cache_dir=str(tmp_path), records=[record], download=True)
+    # Precondition: NEMAR raw URI is unset until resolution.
+    assert ds.datasets[0]._raw_uri is None
+    assert ds.datasets[0]._storage_backend == "nemar"
+
+    with patch.object(EEGDashRaw, "_download_required_files") as mock_dl:
+        ds.download_all(n_jobs=1)
+        assert mock_dl.call_count == 1
+
+
 def test_dataset_offline_enrichment(tmp_path):
     # Coverage for lines 284-298 in dataset.py (Offline mode enrichment)
     from unittest.mock import patch


### PR DESCRIPTION
## Problem

NEMAR records embedded git-tracked sidecar **contents** in `storage.sidecar_inline` at digest time. For datasets like `nm000104` (emg2qwerty / typing) a single `events.tsv` is ~230 KB, so:

- each record reached **~250 KB** (vs ~1.5 KB without it), and
- a `limit=1000` `/records` page ballooned to **~258 MB**, which the API reverse proxy could not write to clients before its timeout — surfacing as `ChunkedEncodingError` / `IncompleteRead` / SSL resets on `python-requests` clients (e.g. `EEGDashDataset(...).find()`).

The inline copy was also a **frozen snapshot** that drifts as NEMAR datasets evolve.

## Fix

**Digest (`scripts/ingestions/`)** — stop inlining:
- `NEMARAdapter.resolve_storage_extensions` resolves git-annex SHA keys only (apex cache + per-dep inlining removed).
- `_record_extractor` no longer forwards/merges `sidecar_inline`.

**Runtime (`eegdash/dataset/base.py`)** — fetch on demand from data.nemar.org:
- New `_download_via_nemar()` downloads a relpath from **data.nemar.org via `nemar-py`** (version-pinned manifest, retries + checksum verification).
- `_resolve_one_nemar_entry` uses this path for sidecars/companions, keeping the GitHub-raw pointer only as a **legacy fallback** for datasets not yet served by data.nemar.org.
- `_download_nemar_data_file` delegates to the new helper.

`sidecar_inline` **schema support is unchanged** — backward compatible: pre-existing records and older clients still resolve (older clients fall back to the GitHub-raw path that already existed).

## Why data.nemar.org

It's the canonical NEMAR access path and is **version-pinned** (e.g. `v2.0.0`) rather than a drifting `HEAD`, with checksum verification — so sidecars stay consistent as datasets evolve.

## Verification

- `tests/unit_tests/dataset/test_base*.py` — 151 pass.
- `scripts/ingestions/tests/digest` — 281 pass; adapter tests updated.
- End-to-end (1 `nm000104` recording): raw `.edf` (117,384,448 B) from S3 + all sidecars/root metadata from `data.nemar.org/nm000104/v2.0.0`, no `sidecar_inline` required.

## Out of scope (handled separately on the API deployment)

- The API now projects `storage.sidecar_inline` out of `/records` responses, and the field was `$unset` from the `eegdash` Mongo collection (46,825 records) — both deployed to the data.eegdash.org server.
