### PR TITLE
ci(ingestion): daily pipeline that actually injects to production

### DIFF
--- a/.github/workflows/1-fetch-all.yml
+++ b/.github/workflows/1-fetch-all.yml
@@ -2,8 +2,8 @@
 name: "1. Fetch: All Sources"
 
 on:
-  schedule:
-    - cron: '0 0 * * 1'  # Weekly on Monday at 00:00 UTC
+  # Scheduled fetching is now handled by full-pipeline.yml ("Daily Ingestion
+  # Pipeline"). This orchestrator is retained for manual use only.
   workflow_dispatch:
     inputs:
       sources:

--- a/.github/workflows/1-fetch-nemar.yml
+++ b/.github/workflows/1-fetch-nemar.yml
@@ -2,8 +2,8 @@
 name: "1. Fetch: NEMAR"
 
 on:
-  schedule:
-    - cron: '0 1 * * 1'  # Weekly on Monday, 1 hour after OpenNeuro
+  # Scheduled fetching is now handled by full-pipeline.yml ("Daily Ingestion
+  # Pipeline"). Kept for manual single-source runs.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/1-fetch-openneuro.yml
+++ b/.github/workflows/1-fetch-openneuro.yml
@@ -2,8 +2,8 @@
 name: "1. Fetch: OpenNeuro"
 
 on:
-  schedule:
-    - cron: '0 0 * * 1'  # Weekly on Monday
+  # Scheduled fetching is now handled by full-pipeline.yml ("Daily Ingestion
+  # Pipeline"). Kept for manual single-source runs.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/3-inject-all.yml
+++ b/.github/workflows/3-inject-all.yml
@@ -2,8 +2,10 @@
 name: "3. Inject: All to MongoDB"
 
 on:
-  schedule:
-    - cron: '0 6 * * 2'  # Weekly on Tuesday at 06:00 UTC (after Monday digests)
+  # Scheduled ingestion is now driven by full-pipeline.yml ("Daily Ingestion
+  # Pipeline"), which fetches + digests + injects to production daily. This
+  # workflow is kept for manual, inject-only runs (e.g. re-injecting an already
+  # digested set to a chosen database).
   workflow_dispatch:
     inputs:
       database:
@@ -30,7 +32,7 @@ jobs:
       dry_run: ${{ github.event.inputs.dry_run == 'true' || github.event_name == 'schedule' }}
     secrets:
       DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-      EEGDASH_ADMIN_TOKEN: ${{ secrets.EEGDASH_ADMIN_TOKEN }}
+      EEGDASH_ADMIN_TOKEN: ${{ secrets.EEGDASH_API_TOKEN }}
 
   summary:
     name: Summary

--- a/.github/workflows/3-inject.yml
+++ b/.github/workflows/3-inject.yml
@@ -83,7 +83,10 @@ jobs:
 
           ARGS="--input eegdash-dataset-listings/digested"
           ARGS="$ARGS --database ${{ inputs.database }}"
-          
+          # Recompute per-dataset stats after a real injection. The script only
+          # acts on this flag when NOT a dry run, so it is a safe no-op otherwise.
+          ARGS="$ARGS --compute-stats"
+
           if [ "${{ inputs.dry_run }}" == "true" ]; then
             ARGS="$ARGS --dry-run"
           fi

--- a/.github/workflows/fetch-source.yml
+++ b/.github/workflows/fetch-source.yml
@@ -34,8 +34,11 @@ jobs:
   fetch:
     name: Fetch ${{ inputs.source_name }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    # No elevated GITHUB_TOKEN permissions needed: the dataset-listings repo is
+    # pushed with DATASET_LISTINGS_TOKEN (persisted credentials), not GITHUB_TOKEN.
+    # Requesting `contents: write` here while the repo default token is read-only
+    # makes this reusable workflow request more than the caller grants, which GitHub
+    # rejects with a startup_failure.
     continue-on-error: ${{ inputs.continue_on_error }}
 
     steps:

--- a/.github/workflows/full-pipeline.yml
+++ b/.github/workflows/full-pipeline.yml
@@ -1,7 +1,18 @@
-# Full ingestion pipeline: Fetch → Clone/Digest → Inject
-name: "Full Pipeline: Ingestion"
+# Daily ingestion pipeline: Fetch -> Clone/Digest -> Inject (to production)
+#
+# This is the single scheduled driver for the ingestion pipeline. It chains the
+# three reusable workflows with `needs:` (robust) instead of `workflow_run`
+# (fragile). It calls `fetch-source.yml` directly because the per-source
+# `1-fetch-*.yml` wrappers do NOT expose a `workflow_call` trigger and therefore
+# cannot be used as reusable workflows.
+#
+# Schedule  -> targets production `eegdash`, performs a REAL write, recomputes stats.
+# Manual    -> defaults to `eegdash_staging` + dry-run so a hand-triggered run is safe.
+name: "Daily Ingestion Pipeline"
 
 on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 02:00 UTC
   workflow_dispatch:
     inputs:
       sources:
@@ -13,12 +24,6 @@ on:
           - all
           - openneuro
           - nemar
-          # - eegmanylabs
-          # - zenodo
-          # - figshare
-          # - osf
-          # - scidb
-          # - datarn
       database:
         description: 'Target database for injection'
         required: true
@@ -29,7 +34,7 @@ on:
           - eegdash
           - eegdash_v1
       dry_run:
-        description: 'Dry run injection (validate only)'
+        description: 'Dry run injection (validate only, no upload)'
         required: false
         default: true
         type: boolean
@@ -39,56 +44,44 @@ on:
         default: '0'
         type: string
 
+# Avoid overlapping ingestion runs writing to the same database concurrently.
+concurrency:
+  group: ingestion-pipeline
+  cancel-in-progress: false
+
 jobs:
   # ============================================================================
-  # Step 1: Fetch
+  # Step 1: Fetch  (calls fetch-source.yml directly; the 1-fetch-*.yml wrappers
+  #                 lack a workflow_call trigger and cannot be reused)
   # ============================================================================
   fetch-openneuro:
-    if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'openneuro' }}
-    uses: ./.github/workflows/1-fetch-openneuro.yml
-    secrets: inherit
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.sources == 'all' || github.event.inputs.sources == 'openneuro' }}
+    uses: ./.github/workflows/fetch-source.yml
+    with:
+      source_name: "OpenNeuro"
+      script_path: "scripts/ingestions/1_fetch_sources/openneuro.py"
+      output_file: "openneuro_datasets.json"
+      script_args: "--page-size 100"
+    secrets:
+      DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
 
   fetch-nemar:
-    if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'nemar' }}
-    uses: ./.github/workflows/1-fetch-nemar.yml
-    secrets: inherit
-
-  # fetch-eegmanylabs:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'eegmanylabs' }}
-  #   uses: ./.github/workflows/1-fetch-eegmanylabs.yml
-  #   secrets: inherit
-  #
-  # fetch-zenodo:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'zenodo' }}
-  #   uses: ./.github/workflows/1-fetch-zenodo.yml
-  #   secrets: inherit
-  #
-  # fetch-figshare:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'figshare' }}
-  #   uses: ./.github/workflows/1-fetch-figshare.yml
-  #   secrets: inherit
-  #
-  # fetch-osf:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'osf' }}
-  #   uses: ./.github/workflows/1-fetch-osf.yml
-  #   secrets: inherit
-  #
-  # fetch-scidb:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'scidb' }}
-  #   uses: ./.github/workflows/1-fetch-scidb.yml
-  #   secrets: inherit
-  #
-  # fetch-datarn:
-  #   if: ${{ github.event.inputs.sources == 'all' || github.event.inputs.sources == 'datarn' }}
-  #   uses: ./.github/workflows/1-fetch-datarn.yml
-  #   secrets: inherit
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.sources == 'all' || github.event.inputs.sources == 'nemar' }}
+    uses: ./.github/workflows/fetch-source.yml
+    with:
+      source_name: "NEMAR"
+      script_path: "scripts/ingestions/1_fetch_sources/nemar.py"
+      output_file: "nemar_datasets.json"
+      script_args: "--base-url https://data.nemar.org --id-prefixes nm,on"
+    secrets:
+      DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
 
   # ============================================================================
-  # Step 2: Clone & Digest (runs after fetch completes)
+  # Step 2: Clone & Digest (runs only if the matching fetch succeeded)
   # ============================================================================
   digest-openneuro:
     needs: [fetch-openneuro]
-    if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'openneuro') && needs.fetch-openneuro.result == 'success' }}
+    if: ${{ always() && needs.fetch-openneuro.result == 'success' }}
     uses: ./.github/workflows/2-clone-digest.yml
     with:
       source_name: "OpenNeuro"
@@ -99,7 +92,7 @@ jobs:
 
   digest-nemar:
     needs: [fetch-nemar]
-    if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'nemar') && needs.fetch-nemar.result == 'success' }}
+    if: ${{ always() && needs.fetch-nemar.result == 'success' }}
     uses: ./.github/workflows/2-clone-digest.yml
     with:
       source_name: "NEMAR"
@@ -108,74 +101,10 @@ jobs:
     secrets:
       DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
 
-  # digest-eegmanylabs:
-  #   needs: [fetch-eegmanylabs]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'eegmanylabs') && needs.fetch-eegmanylabs.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "EEGManyLabs"
-  #     consolidated_file: "eegmanylabs_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-  #
-  # digest-zenodo:
-  #   needs: [fetch-zenodo]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'zenodo') && needs.fetch-zenodo.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "Zenodo"
-  #     consolidated_file: "zenodo_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-  #
-  # digest-figshare:
-  #   needs: [fetch-figshare]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'figshare') && needs.fetch-figshare.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "Figshare"
-  #     consolidated_file: "figshare_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-  #
-  # digest-osf:
-  #   needs: [fetch-osf]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'osf') && needs.fetch-osf.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "OSF"
-  #     consolidated_file: "osf_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-  #
-  # digest-scidb:
-  #   needs: [fetch-scidb]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'scidb') && needs.fetch-scidb.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "SciDB"
-  #     consolidated_file: "scidb_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-  #
-  # digest-datarn:
-  #   needs: [fetch-datarn]
-  #   if: ${{ always() && (github.event.inputs.sources == 'all' || github.event.inputs.sources == 'datarn') && needs.fetch-datarn.result == 'success' }}
-  #   uses: ./.github/workflows/2-clone-digest.yml
-  #   with:
-  #     source_name: "datarn"
-  #     consolidated_file: "datarn_datasets.json"
-  #     max_datasets: ${{ fromJSON(github.event.inputs.max_datasets || '0') }}
-  #   secrets:
-  #     DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-
   # ============================================================================
-  # Step 3: Inject to MongoDB (after all digests complete)
+  # Step 3: Inject to MongoDB (after all digests settle)
+  #   schedule -> database=eegdash (prod), dry_run=false  (real write + stats)
+  #   manual   -> database=<input>,        dry_run=<input> (default staging+dry)
   # ============================================================================
   inject:
     needs: [digest-openneuro, digest-nemar]
@@ -183,35 +112,38 @@ jobs:
     uses: ./.github/workflows/3-inject.yml
     with:
       source_name: "all"
-      database: ${{ github.event.inputs.database }}
+      database: ${{ github.event.inputs.database || 'eegdash' }}
       dry_run: ${{ github.event.inputs.dry_run == 'true' }}
     secrets:
       DATASET_LISTINGS_TOKEN: ${{ secrets.DATASET_LISTINGS_TOKEN }}
-      EEGDASH_ADMIN_TOKEN: ${{ secrets.EEGDASH_ADMIN_TOKEN }}
+      EEGDASH_ADMIN_TOKEN: ${{ secrets.EEGDASH_API_TOKEN }}
 
   # ============================================================================
   # Summary
   # ============================================================================
   summary:
     name: Pipeline Summary
-    needs: [inject]
+    needs: [fetch-openneuro, fetch-nemar, digest-openneuro, digest-nemar, inject]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Generate summary
         run: |
-          echo "## 🚀 Full Ingestion Pipeline Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Configuration" >> $GITHUB_STEP_SUMMARY
-          echo "- Sources: \`${{ github.event.inputs.sources }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Database: \`${{ github.event.inputs.database }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Dry Run: \`${{ github.event.inputs.dry_run }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Results" >> $GITHUB_STEP_SUMMARY
-          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Injection | ${{ needs.inject.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
-            echo "⚠️ **DRY RUN** - No data was uploaded to MongoDB" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Daily Ingestion Pipeline Summary"
+            echo ""
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- Database: \`${{ github.event.inputs.database || 'eegdash' }}\`"
+            echo "- Dry run: \`${{ github.event.inputs.dry_run || 'false' }}\`"
+            echo ""
+            echo "| Step | Status |"
+            echo "|------|--------|"
+            echo "| Fetch OpenNeuro | ${{ needs.fetch-openneuro.result }} |"
+            echo "| Fetch NEMAR | ${{ needs.fetch-nemar.result }} |"
+            echo "| Digest OpenNeuro | ${{ needs.digest-openneuro.result }} |"
+            echo "| Digest NEMAR | ${{ needs.digest-nemar.result }} |"
+            echo "| Inject | ${{ needs.inject.result }} |"
+            echo ""
+            echo "- Datasets injected: ${{ needs.inject.outputs.datasets_injected || 'N/A' }}"
+            echo "- Records injected: ${{ needs.inject.outputs.records_injected || 'N/A' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ digestion = [
   "tenacity",
   "hishel",
   "pydantic>=2",
+  "pydantic-settings>=2",
   "PyGithub>=2",
 ]
 


### PR DESCRIPTION
## Problem

The automated ingestion was **not increasing the database**. The cron fired and the weekly inject job went green, but nothing reached MongoDB. Three independent breakages:

1. **Fetch never ran.** `1. Fetch: OpenNeuro` / `NEMAR` ended in `startup_failure` every week; `1. Fetch: All` failed because it `uses:` per-source files that have no `workflow_call` trigger.
2. **Digest never ran.** It triggers on `workflow_run` *when fetch succeeds* — which never happened.
3. **Inject was a no-op.** The weekly `3. Inject: All` targeted `eegdash_staging`, forced `dry_run=true` on schedule, and logged `No digested datasets available, skipping injection`. It also referenced a secret (`EEGDASH_ADMIN_TOKEN`) that doesn't exist.

### Verified root causes
- **`startup_failure`:** `fetch-source.yml` requested `permissions: contents: write`, but the repo's default `GITHUB_TOKEN` is read-only. A reusable workflow can't request more permission than the caller grants → GitHub rejects it at startup. The write was unnecessary anyway — the listings repo is pushed with `DATASET_LISTINGS_TOKEN`.
- **`digest` would fail even once reached:** the `digestion` optional-deps group was missing `pydantic-settings` (only `tests` had it), so `2_clone.py`/`3_digest.py`/`5_inject.py` died with `ModuleNotFoundError: No module named 'pydantic_settings'`.

## Changes

- **`full-pipeline.yml` → "Daily Ingestion Pipeline"**: single daily driver (`cron: 0 2 * * *`). Chains fetch → digest → inject with `needs:` (not fragile `workflow_run`). Calls `fetch-source.yml` directly. On **schedule**: production `eegdash`, real write, `--compute-stats`. On **manual dispatch**: defaults to `eegdash_staging` + dry-run. Adds a `concurrency` guard.
- **`fetch-source.yml`**: drop the unneeded `permissions: contents: write` (fixes the startup_failure for the daily pipeline *and* the manual single-source fetch workflows).
- **`pyproject.toml`**: add `pydantic-settings>=2` to the `digestion` extra.
- **`3-inject.yml`**: add `--compute-stats` (safe no-op on dry-run); token sourced from `EEGDASH_API_TOKEN` via callers.
- **`3-inject-all.yml`**: repoint token → `EEGDASH_API_TOKEN`; remove the weekly schedule (kept for manual inject-only runs).
- **`1-fetch-all/openneuro/nemar.yml`**: remove the `startup_failure`-only weekly schedules (kept for manual dispatch).

## Validation

Dispatched on this branch with `database=eegdash_staging, dry_run=true, max_datasets=2` — full chain green:

| Stage | Result |
|------|--------|
| Fetch OpenNeuro / NEMAR | ✅ success |
| Digest OpenNeuro / NEMAR | ✅ success |
| Inject (dry-run, staging) | ✅ success |

Inject log (dry-run): `Validation PASSED … Loaded 2 datasets, 4658 records, 2 montages … [DRY RUN] Would inject: 2 datasets, 4658 records to eegdash_staging`.

## Notes for reviewer
- **Daily schedule activates only after merge** (cron runs from the default branch).
- The dry-run validated everything **except the authenticated write to prod**. Recommend one manual run with `database=eegdash, dry_run=false` (or watch the first scheduled run) to confirm `EEGDASH_API_TOKEN` is accepted as the admin token.
- The DB grows when upstream sources publish new datasets; the digest change-guard skips unchanged consolidated files, so daily runs are cheap when nothing is new.
- Other per-source fetchers (zenodo/osf/figshare/scidb/datarn/eegmanylabs) still have weekly schedules and are out of scope here; `1-fetch-all.yml` remains structurally broken (manual-only) and can be deleted in a follow-up.