### PR TITLE
[Claude + Human] Support compiled regex in keyword query filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `build_query_from_kwargs` (and therefore `EEGDashDataset`/`EEGChallengeDataset` keyword filters) accept a compiled `re.Pattern`, translated into a MongoDB `$regex` query with `IGNORECASE`/`MULTILINE`/`DOTALL` flags mapped onto `$options` (#135)
+
 ## [0.8.2] - 2026-05-30
 
 ### Changed

--- a/eegdash/bids_metadata.py
+++ b/eegdash/bids_metadata.py
@@ -187,7 +187,12 @@ def build_query_from_kwargs(
 
     Converts user-friendly keyword arguments into a valid MongoDB query
     dictionary. Scalar values become exact matches; list-like values
-    become ``$in`` queries.
+    become ``$in`` queries; a compiled :class:`re.Pattern` becomes a
+    ``$regex`` query (with Python ``IGNORECASE``/``MULTILINE``/``DOTALL``
+    flags mapped onto ``$options``). For example
+    ``build_query_from_kwargs(dataset="ds002718",
+    task=re.compile("rest", re.IGNORECASE))`` matches any task containing
+    "rest" case-insensitively.
 
     Entity fields (subject, task, session, run) are queried at the top
     level since the inject script flattens these from nested entities.
@@ -248,6 +253,32 @@ def build_query_from_kwargs(
         paths = list(spec.get("paths") or [key])
         operator = spec.get("operator")
         value_aliases = spec.get("value_aliases")
+
+        if isinstance(value, re.Pattern):
+            # Regex support (#135): a compiled pattern is translated into a
+            # MongoDB ``$regex`` clause. Python flags map onto ``$options``.
+            if len(paths) > 1 or operator or value_aliases:
+                raise ValueError(
+                    f"Field '{key}' was given a compiled regex, which is only "
+                    "supported for plain single-path fields (no operator, "
+                    "value_aliases, or multi-path specs)."
+                )
+            if not value.pattern:
+                raise ValueError(f"Received an empty regex for query field '{key}'.")
+            regex_clause: dict[str, Any] = {"$regex": value.pattern}
+            options = "".join(
+                flag
+                for bit, flag in (
+                    (re.IGNORECASE, "i"),
+                    (re.MULTILINE, "m"),
+                    (re.DOTALL, "s"),
+                )
+                if value.flags & bit
+            )
+            if options:
+                regex_clause["$options"] = options
+            query[paths[0]] = regex_clause
+            continue
 
         if isinstance(value, (list, tuple, set)):
             # List values keep the legacy $in semantics; specs that try

--- a/tests/unit_tests/test_query_regex.py
+++ b/tests/unit_tests/test_query_regex.py
@@ -1,0 +1,39 @@
+# Authors: The EEGDash contributors.
+# License: BSD-3-Clause
+# Copyright the EEGDash contributors.
+
+"""Tests for compiled-regex support in build_query_from_kwargs (#135)."""
+
+import re
+
+import pytest
+
+from eegdash.bids_metadata import build_query_from_kwargs
+
+
+def test_regex_pattern_with_ignorecase():
+    query = build_query_from_kwargs(
+        dataset="ds002718", task=re.compile("rest", re.IGNORECASE)
+    )
+    assert query == {
+        "dataset": "ds002718",
+        "task": {"$regex": "rest", "$options": "i"},
+    }
+
+
+def test_regex_pattern_without_flags():
+    assert build_query_from_kwargs(task=re.compile("rest")) == {
+        "task": {"$regex": "rest"}
+    }
+
+
+def test_regex_pattern_maps_multiple_flags():
+    query = build_query_from_kwargs(
+        task=re.compile("rest", re.IGNORECASE | re.MULTILINE | re.DOTALL)
+    )
+    assert query == {"task": {"$regex": "rest", "$options": "ims"}}
+
+
+def test_empty_regex_raises():
+    with pytest.raises(ValueError, match="empty regex"):
+        build_query_from_kwargs(task=re.compile(""))


### PR DESCRIPTION
## Summary
- `build_query_from_kwargs` now accepts a compiled `re.Pattern` for a field and translates it into a MongoDB `$regex` clause.
- Python `IGNORECASE`/`MULTILINE`/`DOTALL` flags are mapped onto `$options`.
- This flows through to `EEGDashDataset` / `EEGChallengeDataset` keyword filters, e.g. `task=re.compile("rest", re.IGNORECASE)`.

## Impact
- Enables substring / case-insensitive matching on query fields without hand-writing a raw MongoDB query.
- Scalar (exact) and list (`$in`) behaviour is unchanged; regex is purely additive. An empty pattern raises a clear `ValueError`.

## Validation
- `ruff check` + `ruff format --check` clean on changed files
- `pytest tests/unit_tests/test_query_regex.py tests/unit_tests/test_bids_metadata.py` → 38 passed
- New `tests/unit_tests/test_query_regex.py` covers flag mapping and the empty-pattern error

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)