### PR TITLE
[Claude + Human] Document keyword filter fields in dataset docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- `EEGDashDataset` and `EEGChallengeDataset` docstrings now enumerate the allowed keyword filters (`ALLOWED_QUERY_FIELDS`), document scalar/list (`$in`) usage, clarify that non-filter keywords such as `target_name` are forwarded to braindecode, and note that a misspelled filter name is silently forwarded rather than raising (#211)
+
 ## [0.8.2] - 2026-05-30
 
 ### Changed

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -139,6 +139,25 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         Session identifier(s) to filter by (e.g., ``"1"``).
     run : str | list[str]
         Run identifier(s) to filter by (e.g., ``"1"``).
+    modality : str | list[str]
+        Recording modality to filter by (e.g., ``"eeg"``).
+    sampling_frequency, nchans, ntimes : scalar
+        Additional numeric record fields that may be used as filters.
+
+        Every keyword filter above accepts a scalar (exact match) or a
+        list/tuple/set (``$in`` match). The complete set of filterable keys is
+        :data:`~eegdash.const.ALLOWED_QUERY_FIELDS`
+        (``dataset``, ``subject``, ``task``, ``session``, ``run``,
+        ``modality``, ``sampling_frequency``, ``nchans``, ``ntimes``,
+        ``data_name``). Any keyword that is **not** in that set is forwarded to
+        :class:`EEGDashRaw` (and on to braindecode) instead of being used as a
+        filter — for example ``target_name``. A keyword that is meant to be a
+        filter but is misspelled therefore silently becomes a forwarded option
+        rather than raising.
+    target_name : str | list[str] | None
+        Name of the description field to expose as the braindecode prediction
+        target. Forwarded to :class:`EEGDashRaw`; the named field must be one
+        of the recording's ``description_fields`` for indexing to succeed.
     description_fields : list[str]
         Fields to extract from each record and include in dataset descriptions
         (e.g., "subject", "session", "run", "task").
@@ -661,8 +680,12 @@ class EEGChallengeDataset(EEGDashDataset):
         The base S3 bucket URI where the challenge data is stored. Defaults to
         the official challenge bucket.
     **kwargs
-        Additional keyword arguments that are passed directly to the
-        :class:`~eegdash.api.EEGDashDataset` constructor.
+        Additional keyword arguments passed directly to the
+        :class:`~eegdash.api.EEGDashDataset` constructor. This includes the
+        keyword filters (``task``, ``subject``, ``session``, ``run``,
+        ``modality``, ...; see :data:`~eegdash.const.ALLOWED_QUERY_FIELDS`),
+        each accepting a scalar or a list (``$in``), as well as ``target_name``
+        which is forwarded to braindecode.
 
     Raises
     ------

--- a/tests/unit_tests/dataset/test_docstring_filters.py
+++ b/tests/unit_tests/dataset/test_docstring_filters.py
@@ -1,0 +1,28 @@
+# Authors: The EEGDash contributors.
+# License: BSD-3-Clause
+# Copyright the EEGDash contributors.
+
+"""The dataset docstrings should document the keyword filter fields (#211)."""
+
+import pytest
+
+from eegdash import EEGChallengeDataset, EEGDashDataset
+from eegdash.const import ALLOWED_QUERY_FIELDS
+
+
+@pytest.mark.parametrize("field", sorted(ALLOWED_QUERY_FIELDS - {"data_name"}))
+def test_eegdashdataset_docstring_mentions_filter_fields(field):
+    doc = EEGDashDataset.__doc__ or ""
+    assert field in doc, f"{field!r} missing from EEGDashDataset docstring"
+
+
+def test_eegdashdataset_docstring_mentions_allowed_query_fields_and_target():
+    doc = EEGDashDataset.__doc__ or ""
+    assert "ALLOWED_QUERY_FIELDS" in doc
+    assert "target_name" in doc
+
+
+def test_challenge_docstring_mentions_filters():
+    doc = EEGChallengeDataset.__doc__ or ""
+    assert "ALLOWED_QUERY_FIELDS" in doc
+    assert "target_name" in doc


### PR DESCRIPTION
## Summary
- Enumerate the `ALLOWED_QUERY_FIELDS` keyword filters in the `EEGDashDataset` docstring (`modality`, `sampling_frequency`, `nchans`, `ntimes`, `data_name` in addition to the already-documented entity fields).
- Document scalar / list (`$in`) usage for every filter.
- Clarify that keywords **not** in `ALLOWED_QUERY_FIELDS` (e.g. `target_name`) are forwarded to `EEGDashRaw`/braindecode rather than used as filters — so a misspelled filter name is silently forwarded.
- Add the same filter/`target_name` note to the `EEGChallengeDataset` docstring.

## Impact
- The keyword filters that work via `**kwargs` now appear in the rendered API docs; no behaviour change.

## Validation
- `ruff check` + `ruff format --check` clean on changed files
- `pytest tests/unit_tests/dataset/test_docstring_filters.py` → 11 passed
- New `tests/unit_tests/dataset/test_docstring_filters.py` asserts each `ALLOWED_QUERY_FIELDS` entry and `target_name` are present in the docstrings

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)