### PR TITLE
[Claude + Human] Validate target_name and raise on a misspelled name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `EEGDashDataset` validates `target_name`: the field is auto-added to `description_fields`, and a `ValueError` (listing the available fields) is raised when the target is missing for every recording — typically a misspelled name such as `"p-factor"` for `"p_factor"` (#21)
+
 ## [0.8.2] - 2026-05-30
 
 ### Changed

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 from docstring_inheritance import NumpyDocstringInheritanceInitMeta
 from joblib import Parallel, delayed
 from mne_bids.config import reader
@@ -139,6 +140,12 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         Session identifier(s) to filter by (e.g., ``"1"``).
     run : str | list[str]
         Run identifier(s) to filter by (e.g., ``"1"``).
+    target_name : str | list[str] | None
+        Name of the description field to expose as the braindecode prediction
+        target. The field is automatically added to ``description_fields`` so
+        the column is populated. A ``ValueError`` is raised (listing the
+        available fields) when the target is missing for every recording —
+        typically a misspelled name such as ``"p-factor"`` for ``"p_factor"``.
     description_fields : list[str]
         Fields to extract from each record and include in dataset descriptions
         (e.g., "subject", "session", "run", "task").
@@ -231,7 +238,18 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
         self.n_jobs = n_jobs
         self.max_concurrency = max_concurrency
         self.eeg_dash_instance = eeg_dash_instance
-        description_fields = description_fields or DEFAULT_DESCRIPTION_FIELDS
+
+        # ``target_name`` is forwarded to braindecode, but the target column
+        # must be present in each recording's description for it to work.
+        # Capture it so we can surface it as a description field and validate
+        # it once the datasets are built (#21).
+        self._target_name = kwargs.get("target_name")
+
+        # Copy so we never mutate the shared DEFAULT_DESCRIPTION_FIELDS list.
+        description_fields = list(description_fields or DEFAULT_DESCRIPTION_FIELDS)
+        for _target in self._target_field_names():
+            if _target not in description_fields:
+                description_fields.append(_target)
 
         self.cache_dir = Path(cache_dir or get_default_cache_dir())
         self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -350,7 +368,71 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
             except Exception:
                 pass
 
+        # Fail fast on a misspelled / unavailable target_name (#21).
+        self._validate_target_present(datasets)
+
         super().__init__(datasets, lazy=True)
+
+    def _target_field_names(self) -> list[str]:
+        """Return the configured ``target_name`` as a list of field names."""
+        target = getattr(self, "_target_name", None)
+        if target is None:
+            return []
+        if isinstance(target, (list, tuple)):
+            return [str(t) for t in target if t is not None]
+        return [str(target)]
+
+    @staticmethod
+    def _is_missing(value: Any) -> bool:
+        """True for None / NaN / pandas-NA scalars."""
+        if value is None:
+            return True
+        try:
+            return bool(pd.isna(value))
+        except (TypeError, ValueError):
+            return False
+
+    def _available_description_fields(self, datasets: list[EEGDashRaw]) -> set[str]:
+        """Collect description fields that carry at least one non-missing value."""
+        fields: set[str] = set()
+        for ds in datasets:
+            desc = getattr(ds, "description", None)
+            if desc is None:
+                continue
+            for key, value in desc.items():
+                if not self._is_missing(value):
+                    fields.add(key)
+        return fields
+
+    def _validate_target_present(self, datasets: list[EEGDashRaw]) -> None:
+        """Raise when ``target_name`` is missing for *every* recording.
+
+        This catches a misspelled ``target_name`` or one that is not an
+        available metadata field (e.g. ``"p-factor"`` instead of
+        ``"p_factor"``) instead of letting it fail later in braindecode.
+        """
+        targets = self._target_field_names()
+        if not targets or not datasets:
+            return
+
+        for target in targets:
+            has_value = any(
+                not self._is_missing(
+                    ds.description.get(target)
+                    if getattr(ds, "description", None) is not None
+                    else None
+                )
+                for ds in datasets
+            )
+            if not has_value:
+                available = sorted(self._available_description_fields(datasets))
+                raise ValueError(
+                    f"target_name={target!r} has no usable (non-missing) values "
+                    f"across all {len(datasets)} recording(s). This usually means "
+                    f"the target name is misspelled or is not an available "
+                    f"metadata field. Available description fields with values: "
+                    f"{available}."
+                )
 
     @property
     def cumulative_sizes(self) -> list[int]:

--- a/tests/unit_tests/dataset/test_target_name_validation.py
+++ b/tests/unit_tests/dataset/test_target_name_validation.py
@@ -1,0 +1,73 @@
+# Authors: The EEGDash contributors.
+# License: BSD-3-Clause
+# Copyright the EEGDash contributors.
+
+"""Validation of ``target_name`` at construction time (#21)."""
+
+import pytest
+
+from eegdash import EEGDashDataset
+
+
+def _record(tmp_path, *, task="rest", age=25, dataset="dsTest"):
+    record = {
+        "dataset": dataset,
+        "bids_relpath": f"sub-01/eeg/sub-01_task-{task}_eeg.set",
+        "bidspath": f"{dataset}/sub-01/eeg/sub-01_task-{task}_eeg.set",
+        "storage": {"backend": "local", "base": str(tmp_path)},
+        "entities_mne": {"subject": "01", "task": task},
+        "ntimes": 100,
+        "sampling_frequency": 100,
+    }
+    if age is not None:
+        record["age"] = age
+    return record
+
+
+def test_misspelled_target_name_raises(tmp_path):
+    records = [_record(tmp_path, age=25)]
+    with pytest.raises(ValueError, match="target_name='p-factor' has no usable"):
+        EEGDashDataset(
+            cache_dir=tmp_path,
+            dataset="dsTest",
+            records=records,
+            download=False,
+            target_name="p-factor",
+        )
+
+
+def test_all_missing_target_raises(tmp_path):
+    records = [_record(tmp_path, age=None), _record(tmp_path, age=None)]
+    with pytest.raises(ValueError, match="has no usable"):
+        EEGDashDataset(
+            cache_dir=tmp_path,
+            dataset="dsTest",
+            records=records,
+            download=False,
+            target_name="age",
+        )
+
+
+def test_valid_target_passes_and_populates_column(tmp_path):
+    records = [_record(tmp_path, age=25), _record(tmp_path, age=30)]
+    ds = EEGDashDataset(
+        cache_dir=tmp_path,
+        dataset="dsTest",
+        records=records,
+        download=False,
+        target_name="age",
+    )
+    assert len(ds.datasets) == 2
+    # target column is surfaced in each recording description
+    assert all("age" in d.description.index for d in ds.datasets)
+
+
+def test_no_target_name_is_noop(tmp_path):
+    records = [_record(tmp_path, age=None)]
+    ds = EEGDashDataset(
+        cache_dir=tmp_path,
+        dataset="dsTest",
+        records=records,
+        download=False,
+    )
+    assert len(ds.datasets) == 1


### PR DESCRIPTION
## Summary
- `target_name` is forwarded to braindecode, but the target column must be present in each recording's description for it to work.
- `EEGDashDataset` now auto-adds `target_name` to `description_fields` so the column is populated.
- A clear `ValueError` (listing the available description fields) is raised when the target is missing for **every** recording — typically a misspelled name, e.g. `target_name="p-factor"` instead of `"p_factor"`.

## Impact
- Replaces a late/cryptic braindecode failure with an explicit, actionable error at construction time.
- No change when `target_name` is unset or correct. Partial-NaN handling is intentionally out of scope here (see the companion `remove_nan_targets` PR for #22).

## Validation
- `ruff check` + `ruff format --check` clean on changed files
- `pytest tests/unit_tests/dataset/test_target_name_validation.py` → 4 passed
- Full `pytest tests/unit_tests/dataset -m "not network"` → 604 passed, 1 skipped (no regressions)

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)