### PR TITLE
ci(docs): remove surge.sh PR preview deploy

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -126,23 +126,6 @@ jobs:
           path: ./docs/_build/html
           retention-days: 14
 
-      # Deploy PR preview to surge.sh (optional - requires SURGE_TOKEN secret)
-      - name: Deploy PR Preview
-        if: github.event_name == 'pull_request'
-        id: deploy-preview
-        continue-on-error: true
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: |
-          if [ -z "$SURGE_TOKEN" ]; then
-            echo "SURGE_TOKEN not configured, skipping live preview deployment"
-            exit 0
-          fi
-          npm install -g surge
-          DEPLOY_DOMAIN="eegdash-pr-${{ github.event.pull_request.number }}.surge.sh"
-          surge ./docs/_build/html $DEPLOY_DOMAIN --token $SURGE_TOKEN
-          echo "preview_url=https://$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
-
       # Comment on PR with preview link
       - name: Comment PR with Preview Link
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Removes the `Deploy PR Preview` (surge.sh) step from the docs workflow, which was failing on PRs.

The PR-comment step still works: with no surge deployment, `surgeSuccess` is false so it posts the download-artifact comment instead.