### PR TITLE
ci: pull CPU-only torch wheels on GPU-less runners

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -59,6 +59,11 @@ jobs:
                   output.write(f"{key}={path}\n")
 
       - name: Install dependencies
+        env:
+          # GPU-less runners: fetch CPU-only torch wheels (via braindecode) instead
+          # of the default CUDA builds (~5 GB of unused CUDA libs that also bloat the
+          # uv cache). Scoped to CI, not pyproject, so local/GPU installs are unaffected.
+          UV_TORCH_BACKEND: cpu
         run: uv pip install -e .[all]
 
       - name: Restore Data Caches (pull_request)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,11 @@ jobs:
     - name: Show Python Version
       run: python --version
     - name: Install EEGDash from Current Checkout
+      env:
+        # GPU-less runners: fetch CPU-only torch wheels (via braindecode) instead
+        # of the default CUDA builds (~5 GB of unused CUDA libs that also bloat the
+        # uv cache). Scoped to CI, not pyproject, so local/GPU installs are unaffected.
+        UV_TORCH_BACKEND: cpu
       run: uv pip install -e .[tests]
     # Show EEGDash Version
     - name: Show EEGDash Version


### PR DESCRIPTION
## What

Set `UV_TORCH_BACKEND: cpu` on the `uv pip install` steps in `tests.yml` and `doc.yaml` so CI installs CPU-only torch.

## Why

Both jobs install eegdash (`braindecode[hub]` → `torch`) via `uv` on GPU-less `ubuntu-latest` runners with no backend pin. uv resolves the **CUDA** builds and pulls ~5 GB of nvidia CUDA/cuDNN libraries that never run, paid on every install and again on every uv cache upload/restore.

## Test

Forcing the Linux platform uv resolves in CI:

```
# default (no flag)
torch==2.12.1
nvidia-cuda-cupti==13.0.85
nvidia-cuda-nvrtc==13.0.88
nvidia-cuda-runtime==13.0.96
nvidia-cudnn-cu13==9.20.0.48

# UV_TORCH_BACKEND=cpu
torch==2.12.1+cpu      # no nvidia-* packages
```

## Notes

Scoped to CI, not `pyproject.toml`, so local and GPU installs are unaffected. `UV_TORCH_BACKEND` needs `uv >= 0.6.0`; `setup-uv@v5` defaults to latest. YAML validated.

Ports facebookresearch/neuroai#163 to eegdash.