### PR TITLE
ci(docs): skip PR preview comment on fork PRs (read-only token 403)

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -133,7 +133,9 @@ jobs:
 
       # Comment on PR with preview link
       - name: Comment PR with Preview Link
-        if: github.event_name == 'pull_request'
+        # Fork PRs get a read-only GITHUB_TOKEN, so commenting 403s. Only same-repo PRs can comment.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
Fork PRs run with a read-only GITHUB_TOKEN, so the docs preview `createComment` step 403s. Gate the comment step to same-repo PRs and add `continue-on-error`.