### PR TITLE
Floor numba to fix eegdash co-install (#170)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,12 @@ Chat          = "https://discord.gg/8jd7nVKwsc"
 
 [project.optional-dependencies]
 features = [
-  "numba<0.61; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-  "numba;      sys_platform != 'darwin' or platform_machine != 'x86_64'",
+  # Floor numba so the resolver can't backtrack to ancient releases (e.g.
+  # numba 0.53.1 → llvmlite 0.36, which won't build on Python >=3.10). When a
+  # co-installed package pushes numpy past numba's ceiling, the floor forces
+  # numpy down to numba's supported range instead. See eegdash/EEGDash#170.
+  "numba>=0.60,<0.61; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+  "numba>=0.61;       sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "safetensors",
 ]
 tests = [


### PR DESCRIPTION
Fixes the numba/llvmlite co-install conflict (eegdash/EEGDash#170) at its root. **Default install is unchanged** — `pip install eegdash` still includes the feature dependencies.

## Why

eegdash pulls `numba` (via the feature deps). With `numba` unbounded, a co-installed package that declares `numpy>=2.1` lets the resolver pick the newest `numpy`, which no `numba` release supports — so it backtracks `numba` to `0.53.1` (the only release with no numpy ceiling) → `llvmlite 0.36.0`, which refuses to build on Python ≥3.10:

```
RuntimeError: Cannot install on Python version 3.12.13; only versions >=3.6,<3.10 are supported.
hint: llvmlite (v0.36.0) ... eegdash depends on numba (v0.53.1) which depends on llvmlite
```

## Fix

Floor `numba` so the resolver can no longer drop below a release that caps `numpy`:

```toml
"numba>=0.60,<0.61; sys_platform == 'darwin' and platform_machine == 'x86_64'",  # Intel Mac
"numba>=0.61;       sys_platform != 'darwin' or platform_machine != 'x86_64'",
```

This delegates the `numpy` ceiling to numba's own metadata instead of hardcoding a `numpy` cap in eegdash — when numba supports a newer numpy, the cap lifts automatically.

## Verification (uv, Python 3.12, `--resolution highest`)

| scenario | before | after |
|---|---|---|
| co-install forcing `numpy==2.5.0` | `numba 0.53.1` / `llvmlite 0.36.0` (build fails) | clean "unsatisfiable" error |
| co-install with `numpy>=2.1` (the real case) | risk of 0.53.1 | **`numba 0.65.1` / `llvmlite 0.47.0` / `numpy 2.4.6`** |
| `pip install eegdash` alone | — | unchanged, resolves cleanly |

Metadata-only; no code change. All pre-commit hooks pass.