### PR TITLE
ci(docs): deploy via Pages artifact to stop >450MB clone bloat

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -11,8 +11,10 @@ on:
     branches:
       - '*' # all branches, including forks
 
+# contents:read is enough now that docs deploy via the Pages artifact flow
+# (no branch push). pages/id-token live on the deploy-pages job below.
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -184,24 +186,20 @@ jobs:
                 body: body
               });
             }
-      # we are only deploying from develop for now onwards
-      # # Deploy the docs to the gh-pages branch (main and develop)
-      # - name: Deploy to GitHub Pages (main)
-      #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      #   uses: peaceiris/actions-gh-pages@v4
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./docs/_build/html
-      #     destination_dir: archive
-      #     keep_files: true
-
-      - name: Deploy to GitHub Pages (develop)
+      # Docs deploy via the GitHub Pages *artifact* flow (no gh-pages branch).
+      # The old peaceiris branch-push committed the whole site (incl. a 42MB
+      # llms-full.txt) on every deploy, so gh-pages history ballooned the clone
+      # size. The artifact is ephemeral, so clones no longer carry the site.
+      # One-time setup: repo Settings -> Pages -> Source = "GitHub Actions".
+      - name: Set custom domain (CNAME)
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        uses: peaceiris/actions-gh-pages@v4
+        run: echo "eegdash.org" > ./docs/_build/html/CNAME
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
-          cname: eegdash.org
+          path: ./docs/_build/html
 
       - name: Ping IndexNow (Bing + Yandex + friends)
         # IndexNow tells participating search engines about every deploy
@@ -230,3 +228,21 @@ jobs:
           curl -sS -X POST https://api.indexnow.org/indexnow \
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$payload" -o /dev/null -w "IndexNow HTTP %{http_code}\n"
+
+  # Publish the built docs to GitHub Pages from the artifact. No branch is
+  # written, so the site never lands in `git clone`. Runs only on push to
+  # develop, after the docs job uploads the artifact.
+  deploy-pages:
+    needs: docs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,9 @@ verification_report.md
 **/superpowers/
 **/superpowers/**
 *superpower*
+
+# Heavy scratch notebooks + generated data dumps. These (esp.
+# notebooks/scratch_features*.ipynb with saved outputs) bloated the git
+# history to >400MB. Keep them out. See docs/maintenance/repo-slimming.md.
+notebooks/scratch_*.ipynb
+consolidated/

--- a/docs/maintenance/repo-slimming.md
+++ b/docs/maintenance/repo-slimming.md
@@ -1,0 +1,69 @@
+# Repo slimming — keeping `git clone` small
+
+The repository grew to **>450 MB to clone**. This documents why, what changed to
+prevent it, and the one-time purge that shrinks it to a few MB.
+
+## What bloated it
+
+| Source | Where | History weight |
+|---|---|---|
+| `llms-full.txt` (42 MB) committed on every docs deploy (67×) | `gh-pages` branch | ~1.9 GB uncompressed |
+| whole docs site snapshot (incl. that file) | `gh-pages` (single commit) | 258 MB |
+| `notebooks/scratch_features*.ipynb` with saved outputs, committed 10+× | `develop` history | ~183 MB |
+| `consolidated/scidb_datasets.json`, `.verify_cache/*.snirf` | `develop` history | ~20 MB |
+
+`develop`'s **working tree is only ~8 MB** — everything above is dead weight in
+*history* (files already deleted from HEAD) plus the auto-generated `gh-pages`
+branch, which a default `git clone` fetches along with every other branch.
+
+## Prevention (already in this PR — no action needed)
+
+1. **Docs deploy no longer uses a branch.** `.github/workflows/doc.yaml` now
+   publishes via the GitHub Pages *artifact* flow (`actions/upload-pages-artifact`
+   + `actions/deploy-pages`) instead of `peaceiris/actions-gh-pages`. The site is
+   an ephemeral artifact, so it never lands in a clone again.
+2. **`.gitignore`** now blocks `notebooks/scratch_*.ipynb` and `consolidated/`.
+
+### One-time repo setting
+
+Set **Settings → Pages → Source = "GitHub Actions"** (was "Deploy from a branch").
+The custom domain (`eegdash.org`) is written into the artifact as a `CNAME` file
+by the workflow; you can also keep it set under Settings → Pages.
+
+## The purge (maintainer action — DESTRUCTIVE, requires admin)
+
+This rewrites every commit SHA. **Everyone must re-clone afterward and every open
+PR must be re-based.** Do it during a quiet window with team sign-off.
+
+```bash
+pipx install git-filter-repo         # once
+
+# 1. Dry run — mirrors the remote, purges, reports before/after size. No push.
+scripts/maintenance/slim-repo.sh https://github.com/eegdash/eegdash
+
+# 2. Lift branch protection on `develop` in repo settings (temporarily).
+
+# 3. Rewrite + force-push all branches, and drop gh-pages:
+scripts/maintenance/slim-repo.sh https://github.com/eegdash/eegdash --push
+
+# 4. Re-enable branch protection. Delete the gh-pages branch if it lingers:
+git push https://github.com/eegdash/eegdash --delete gh-pages
+```
+
+After the push, GitHub garbage-collects the unreachable objects; new clones are
+small immediately (they only receive objects reachable from the rewritten refs).
+
+### Expected result
+
+Measured on a full mirror of all 68 branches: **149 MB → ~19 MB** (~87% smaller;
+the local unpacked `.git` was ~450 MB). The gh-pages branch is gone and the dead
+notebook/cache/JSON history is stripped. The ~19 MB floor is legitimate
+source-file revision history — going lower would mean squashing away all git
+history/blame, which is not recommended.
+
+To also prune your own already-cloned copy without re-cloning:
+
+```bash
+git remote prune origin
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+```

--- a/scripts/maintenance/slim-repo.sh
+++ b/scripts/maintenance/slim-repo.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# slim-repo.sh — one-time git history purge to shrink clone size.
+#
+# WHY: the clone was >450MB because (a) the gh-pages branch committed the whole
+# docs site (incl. a 42MB llms-full.txt) on every deploy, and (b) develop's
+# history carried heavy scratch notebooks + generated data dumps that were later
+# deleted from HEAD but still live in history. See docs/maintenance/repo-slimming.md.
+#
+# WHAT IT DOES (on a fresh --mirror clone, never your working checkout):
+#   1. drops the gh-pages branch (docs now deploy via the Pages *artifact* flow)
+#   2. strips the proven dead-weight paths from ALL branch history
+#   3. repacks and reports before/after size
+#   4. force-pushes the rewritten history back  (only with --push)
+#
+# DESTRUCTIVE: this rewrites every commit SHA. After pushing, everyone must
+# re-clone and every open PR must be re-based. Run only with maintainer sign-off,
+# and temporarily lift branch protection on the default branch first.
+#
+# Usage:
+#   scripts/maintenance/slim-repo.sh <remote-url>            # dry run (inspect only)
+#   scripts/maintenance/slim-repo.sh <remote-url> --push     # rewrite + force-push
+#
+set -euo pipefail
+
+REMOTE="${1:?usage: slim-repo.sh <remote-url> [--push]}"
+PUSH="${2:-}"
+WORK="eegdash-slim.git"
+
+# Paths purged from history. All of these are already absent from HEAD; this
+# only reclaims their dead history. Add more here if new dead weight is found.
+PURGE_ARGS=(
+  --invert-paths
+  --path notebooks/          # scratch + tutorial notebooks w/ saved outputs (none in HEAD)
+  --path consolidated/       # generated dataset JSON dumps
+  --path .verify_cache/
+  --path .verify_cache_python/
+  --path .verify_cache_test/
+)
+
+if ! git filter-repo --version >/dev/null 2>&1; then
+  echo "ERROR: git-filter-repo not found. Install with: pipx install git-filter-repo" >&2
+  exit 1
+fi
+
+rm -rf "$WORK"
+echo ">> Mirroring $REMOTE into $WORK ..."
+git clone --mirror "$REMOTE" "$WORK"
+cd "$WORK"
+
+echo ">> Size BEFORE:"; du -sh .
+
+# Docs no longer live in a branch — drop gh-pages entirely.
+git update-ref -d refs/heads/gh-pages 2>/dev/null || true
+
+echo ">> Rewriting history (stripping dead-weight paths) ..."
+git filter-repo --force "${PURGE_ARGS[@]}"
+
+git reflog expire --expire=now --all
+git gc --prune=now --aggressive
+
+echo ">> Size AFTER:"; du -sh .
+
+if [ "$PUSH" = "--push" ]; then
+  echo ">> Force-pushing rewritten history (mirror) to $REMOTE ..."
+  git push --force --mirror "$REMOTE"
+  echo ">> Done. Tell everyone to re-clone; delete stale gh-pages if it lingers."
+else
+  echo ">> Dry run complete. Inspect $(pwd), then push with:"
+  echo "     git -C $(pwd) push --force --mirror $REMOTE"
+fi


### PR DESCRIPTION
## Problem
`git clone` pulls **>450MB**. Root cause: the `gh-pages` docs branch commits the whole built site (incl. a ~42MB `llms-full.txt`) on **every** deploy via `peaceiris/actions-gh-pages`, so its history is ~1.9GB uncompressed. `develop`'s working tree is only ~8MB — the rest is that branch (fetched by every clone) plus dead blobs in history (scratch notebooks, data dumps).

## Changes (safe, mergeable)
- **`doc.yaml`** — docs deploy via the GitHub Pages *artifact* flow (`upload-pages-artifact` + `deploy-pages`) instead of committing to `gh-pages`. The site is ephemeral → never enters a clone again. Drops `contents: write`.
- **`.gitignore`** — block `notebooks/scratch_*.ipynb` and `consolidated/`.
- **`scripts/maintenance/slim-repo.sh`** — one-time history purge (dry-run by default, `--push` to apply).
- **`docs/maintenance/repo-slimming.md`** — runbook.

## Result (proven)
Full 68-branch mirror: **149MB → 19MB** (~87%).

## Required admin steps after merge
1. **Settings → Pages → Source = "GitHub Actions"** (currently "Deploy from a branch").
2. Run the purge: `scripts/maintenance/slim-repo.sh https://github.com/eegdash/eegdash --push` (lift `develop` branch protection temporarily). ⚠️ Rewrites history — everyone re-clones, open PRs re-base.

See `docs/maintenance/repo-slimming.md`.