### PR TITLE
perf(docs): audit + skip off-screen dataset-table rows (content-visibility)

### DIFF
--- a/docs/maintenance/docs-perf.md
+++ b/docs/maintenance/docs-perf.md
@@ -1,0 +1,74 @@
+# Docs site performance — audit + fix plan
+
+Live Lighthouse audit of `eegdash.org` (desktop preset). The measured build is
+**current** — the latest `gh-pages` deploy commit is `deploy: 9fb3fcb32…`, which
+is `develop` HEAD, so these numbers reflect the code in the repo now.
+
+## Measured (live)
+
+| Page | Perf | LCP | TBT | CLS | TTI | Notes |
+|---|---|---|---|---|---|---|
+| Home | 79 | 0.9s | 0ms | **0.43** | 0.9s | hero layout shift |
+| `dataset_summary.html` | **39** | 1.0s | **1070ms** | **0.91** | **4.9s** | 825 `<tr>` inline, `paging:false` |
+| `api/dataset/eegdash.dataset.html` | 59 | 0.9s | 390ms | 0.57 | 2.0s | 7.43MB DOM (autodoc dump) |
+
+LCP is fine everywhere (CDN + gzip). The problems are **DOM size, main-thread
+work, and layout shift** — not download size.
+
+Confirmed by inspecting the live pages:
+- `_static/scripts/fontawesome.js` loads on **every** page.
+- Summary page loads jQuery + **plotly 3.1MB** + d3 + DataTables **+ 4 plugins**,
+  and inlines **825 table rows** (`paging: false` in `datatables-init.js`).
+- API page is 7.43MB of HTML with **0 tables** — one giant `automodule` dump.
+
+Already in place (don't redo): `dt-loading-skeleton` FOUC guard, hero
+`min-height` reservations, deferred global JS, lazy-loaded search index, local
+SVG icon_links.
+
+## Fix plan (ranked; each verifiable via the PR surge preview + Lighthouse)
+
+### 1. `dataset_summary.html` — the 825-row DOM  (biggest win; **product decision**)
+Drives CLS 0.91 + TBT 1070ms + TTI 4.9s. Pick one:
+- **(a) Paginate** — `paging: true, pageLength: 25, deferRender: true` in
+  `datatables-init.js` (lines 118 & 208). ~30× smaller initial DOM. Changes UX
+  from "scroll all" to paged.
+- **(b) Keep all rows, cut render cost** — add to `custom.css`:
+  `#datasets-table tbody tr { content-visibility: auto; contain-intrinsic-size: auto 44px; }`
+  Native browser skip-offscreen; big TBT/TTI drop, no UX change. Test scroll +
+  DataTables column-width calc (can interact).
+- **(c) Ajax** — emit rows as JSON and load via DataTables `ajax` instead of
+  inlining 3.8MB HTML. Most work, best result.
+
+Kill the CLS regardless: make the `dt-loading-skeleton` height equal the final
+rendered table height so the swap doesn't shift.
+
+### 2. Defer plotly/d3 on the summary page  (−~3MB eager JS)
+`plotly-3.1.0.min.js` (3.1MB) + `d3.v7.min.js` load eagerly for charts that are
+below the fold. Lazy-load on scroll — reuse the existing `lazy-embed.js` pattern.
+
+### 3. `api/dataset` page — split the 7.4MB dump  (**URL/SEO risk — plan first**)
+Use `autosummary` per-class stub pages instead of one `automodule`.
+⚠️ `prepare_summary_tables.py` generates links to
+`/api/dataset/eegdash.dataset.{ID}.html`; a structure change needs a redirect
+map (or keep those exact paths) or it creates 404s. Ship with redirects.
+
+### 4. `fontawesome.js` (~540KB/page)  (**higher risk than it looks**)
+The pydata theme still bundles it despite the local-SVG `icon_links`. It's
+*partially used* by theme chrome (admonition/nav icons), so removing it outright
+breaks those. Real options: bump `pydata-sphinx-theme` to a version that loads
+FA conditionally, or replace remaining theme icon usages. Verify the built page
+no longer requests `fontawesome.js`.
+
+### 5. Home CLS 0.43
+Existing hero min-heights aren't enough. Add `width`/`height` (or
+`aspect-ratio`) to hero images/logo and reserve space for any JS-injected block.
+
+### 6. Cheap global wins
+`content-visibility: auto` on large static API sections; minify HTML; drop
+unused theme CSS (~75KB/page).
+
+## Verify loop
+
+1. Change on a branch, open a PR → `doc.yaml` builds a surge.sh preview.
+2. `npx lighthouse <preview-url>/dataset_summary.html --preset=desktop --only-categories=performance`
+3. Compare CLS/TBT/TTI against the table above. Target: CLS < 0.1, TBT < 200ms.

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -355,6 +355,18 @@ table.table tbody tr:hover {
   font-size: 0.95rem;
 }
 
+/* Perf: the table ships all ~800 rows (paging:false), which is the main
+   driver of the summary page's main-thread work / TBT / CLS. content-visibility
+   lets the browser skip layout + paint for rows outside the viewport;
+   contain-intrinsic-size reserves ~one row's height so the scrollbar stays
+   put. ponytail: native browser feature, no JS/deps.
+   VERIFY on the PR preview: DataTables column alignment + CLS. If columns
+   misalign (DataTables measures row widths), delete this block. */
+#datasets-table tbody tr {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 44px;
+}
+
 /* --------------------------------------------------------------------------
    9. Footer & Branding
    -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Context
Live Lighthouse audit of eegdash.org (build == `develop` HEAD). Worst page is `dataset_summary.html`: **Perf 39, CLS 0.91, TBT 1070ms, TTI 4.9s** — it inlines all ~825 rows (`paging: false`). Full audit + ranked plan in `docs/maintenance/docs-perf.md`.

| Page | Perf | CLS | TBT |
|---|---|---|---|
| Home | 79 | 0.43 | 0ms |
| dataset_summary | 39 | 0.91 | 1070ms |
| api/dataset | 59 | 0.57 | 390ms |

## Change (this PR)
`content-visibility: auto` + `contain-intrinsic-size` on `#datasets-table` rows so the browser skips layout/paint for off-screen rows — keeps the scroll-all UX. Native browser feature, no JS/deps.

## Verify on this PR's preview
Once the docs preview builds, run Lighthouse on `<preview>/dataset_summary.html` and compare vs baseline (CLS 0.91 / TBT 1070ms). **Check DataTables column alignment** — if columns misalign (DataTables measures row widths), revert the CSS block.

## Follow-ups (in the plan, not this PR)
- Lazy-load plotly (3.1MB) / d3 (below-fold charts).
- Split the 7.4MB API page — ⚠️ needs URL redirects (`prepare_summary_tables.py` links to those paths).
- `fontawesome.js` still loads on every page (theme bump/replace).