### PR TITLE
a11y(docs): honor prefers-reduced-motion for all animations

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -3975,3 +3975,27 @@ html[data-theme="dark"] .hf-quickstart .highlight .cp,
 html[data-theme="dark"] .hf-quickstart .highlight .cs {
   color: #94a3b8 !important;
 }
+
+/* --------------------------------------------------------------------------
+   Accessibility — honor prefers-reduced-motion globally.
+   The targeted blocks earlier in this file cover a few reveal animations, but
+   several *infinite* animations were left running for motion-sensitive users:
+   the home-hero background (hero-pulse), the beta-badge pulses (badge-pulse /
+   badge-dot-pulse), and the dataset-table loading skeleton (dt-skel, defined
+   in the generated table fragment — reached here because custom.css loads on
+   that page and !important overrides the fragment's rule). This global reset
+   neutralises all animations, transitions, and smooth scrolling when the user
+   requests reduced motion — the standard, future-proof pattern that also
+   covers any animation added later. See WCAG 2.2 SC 2.3.3 (Animation from
+   Interactions); adapted from the neuroai landing-page a11y review.
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Adapted from an accessibility review of the neuroai landing page (facebookresearch/neuroai#92) — applying the same reduced-motion improvement to eegdash's docs.

## Problem
eegdash already guards a few reveal animations with `prefers-reduced-motion`, but several **infinite** animations kept playing for motion-sensitive users (a WCAG 2.2 SC 2.3.3 issue):
- `hero-pulse` — the home-hero background (15s, infinite)
- `badge-pulse` / `badge-dot-pulse` — the beta badge
- `dt-skel` — the dataset-table loading skeleton shimmer (added in the recent Scroller work)

## Fix
One global reduced-motion reset in `custom.css` that neutralises all animations, transitions and smooth-scroll when the OS requests reduced motion — the standard, future-proof pattern (covers new animations automatically, and reaches the table-fragment skeleton via `!important` since `custom.css` loads on that page). The existing targeted blocks remain (harmless).

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

## Verify
- CI docs build confirms it compiles/ships.
- Manually: enable "Reduce motion" in OS settings → home hero stops pulsing, beta badge is static, the table skeleton doesn't shimmer; normal motion unaffected without the setting.

(Note: eegdash already has `focus-visible` rings and aria handling, so those neuroai items were already covered — this PR is just the reduced-motion completeness gap.)