### PR TITLE
fix: replace s3fs with boto3 to unpin botocore (#397)

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -1015,9 +1015,8 @@ class EEGDashRaw(RawDataset):
                 filesystem = downloader.get_s3_filesystem(
                     max_concurrency=self._max_concurrency
                 )
-                # Strip protocol prefix for s3fs operations
-                s3_prefix = re.sub(r"^s3://", "", self._raw_uri)
-                remote_files = filesystem.ls(s3_prefix, detail=False)
+                # ls accepts bucket/key or s3://bucket/key; pass the prefix as-is.
+                remote_files = filesystem.ls(self._raw_uri, detail=False)
                 pairs = []
                 for remote in remote_files:
                     fname = Path(remote).name

--- a/eegdash/downloader.py
+++ b/eegdash/downloader.py
@@ -7,49 +7,129 @@
 This module provides functions for downloading EEG data files and BIDS dependencies from
 AWS S3 storage, with support for caching and progress tracking. It handles the communication
 between the EEGDash metadata database and the actual EEG data stored in the cloud.
+
+It talks to S3 through a plain synchronous ``boto3`` client rather than ``s3fs``.
+``s3fs`` transitively pulls in ``aiobotocore``, which hard-pins ``botocore`` to a
+narrow range and makes any environment that also needs ``boto3`` (moabb, awscli,
+neuralbench, …) effectively unsolvable. All access here is anonymous, read-only,
+and limited to a handful of operations (HEAD, GET, LIST), so ``boto3`` covers it
+directly. See https://github.com/eegdash/EEGDash/issues/397.
 """
 
+import re
 from pathlib import Path
 from typing import Iterable, Sequence
 
+import boto3
 import rich.progress
-import s3fs
-from fsspec.callbacks import Callback, TqdmCallback
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
 from rich.console import Console
+from tqdm.auto import tqdm
 
 from .logging import logger
+
+
+def _split_s3_uri(uri: str) -> tuple[str, str]:
+    """Split an ``s3://bucket/key`` (or ``bucket/key``) string into (bucket, key)."""
+    without_scheme = re.sub(r"^s3://", "", str(uri)).lstrip("/")
+    bucket, _, key = without_scheme.partition("/")
+    return bucket, key
+
+
+class S3Client:
+    """Minimal, anonymous S3 accessor with an ``s3fs``-compatible surface.
+
+    Exposes just the operations EEGDash needs — :meth:`info`, :meth:`get_file`,
+    :meth:`ls`, :meth:`du` — backed by a synchronous ``boto3`` client configured
+    for unsigned (anonymous) access to public buckets. Paths may be given as
+    ``s3://bucket/key`` or ``bucket/key``.
+    """
+
+    def __init__(self, *, region: str = "us-east-2", max_concurrency: int = 20):
+        self._client = boto3.client(
+            "s3",
+            region_name=region,
+            config=Config(
+                signature_version=UNSIGNED,
+                max_pool_connections=max_concurrency,
+                retries={"max_attempts": 5, "mode": "standard"},
+            ),
+        )
+
+    def info(self, path: str) -> dict:
+        """Return object metadata (``{"size": <bytes>}``) via a HEAD request."""
+        bucket, key = _split_s3_uri(path)
+        resp = self._client.head_object(Bucket=bucket, Key=key)
+        return {"size": resp["ContentLength"]}
+
+    def get_file(self, rpath: str, lpath: str, *, callback=None) -> None:
+        """Download a single object with one unsigned GET (no HEAD, no LIST).
+
+        Streams the body to disk, feeding each chunk's byte count to
+        ``callback`` (a ``callback(nbytes)`` callable) for progress. A missing
+        key is normalised to :class:`FileNotFoundError` so callers can treat it
+        the way they did under ``s3fs``.
+        """
+        bucket, key = _split_s3_uri(rpath)
+        try:
+            body = self._client.get_object(Bucket=bucket, Key=key)["Body"]
+            with open(lpath, "wb") as fh:
+                for chunk in body.iter_chunks(chunk_size=1024 * 1024):
+                    fh.write(chunk)
+                    if callback is not None:
+                        callback(len(chunk))
+        except ClientError as e:
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            code = str(e.response.get("Error", {}).get("Code"))
+            if status == 404 or code in ("NoSuchKey", "NoSuchBucket"):
+                raise FileNotFoundError(rpath) from e
+            raise
+
+    def _iter_objects(self, path: str):
+        """Yield each object dict under a prefix via paginated ListObjectsV2."""
+        bucket, key = _split_s3_uri(path)
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=key):
+            yield from page.get("Contents", [])
+
+    def ls(self, path: str, detail: bool = False):
+        """List objects under a prefix, returning ``bucket/key`` strings."""
+        bucket, _ = _split_s3_uri(path)
+        names = [f"{bucket}/{obj['Key']}" for obj in self._iter_objects(path)]
+        if detail:
+            return [{"name": n, "type": "file"} for n in names]
+        return names
+
+    def du(self, path: str) -> int:
+        """Sum the size in bytes of every object under a prefix."""
+        return sum(obj["Size"] for obj in self._iter_objects(path))
 
 
 def get_s3_filesystem(
     *,
     max_concurrency: int = 20,
     region: str = "us-east-2",
-) -> s3fs.S3FileSystem:
-    """Get an anonymous S3 filesystem object.
-
-    Initializes and returns an ``s3fs.S3FileSystem`` for anonymous access
-    to public S3 buckets.
+) -> S3Client:
+    """Get an anonymous S3 accessor for public buckets.
 
     Parameters
     ----------
     max_concurrency : int
-        Maximum number of parallel transfer connections (default 20).
+        Size of the underlying connection pool (default 20).
     region : str
         AWS region for the S3 endpoint (default ``"us-east-2"``).
 
     Returns
     -------
-    s3fs.S3FileSystem
-        An S3 filesystem object.
+    S3Client
+        An anonymous S3 accessor with an ``s3fs``-compatible surface.
 
     """
     if max_concurrency < 1:
         raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
-    return s3fs.S3FileSystem(
-        anon=True,
-        max_concurrency=max_concurrency,
-        client_kwargs={"region_name": region},
-    )
+    return S3Client(region=region, max_concurrency=max_concurrency)
 
 
 def get_s3path(s3_bucket: str, filepath: str) -> str:
@@ -74,7 +154,7 @@ def get_s3path(s3_bucket: str, filepath: str) -> str:
 
 
 def download_s3_file(
-    s3_path: str, local_path: Path, *, filesystem: s3fs.S3FileSystem | None = None
+    s3_path: str, local_path: Path, *, filesystem: S3Client | None = None
 ) -> Path:
     """Download a single file from S3 to a local path.
 
@@ -87,8 +167,8 @@ def download_s3_file(
         The full S3 URI of the file to download.
     local_path : pathlib.Path
         The local file path where the downloaded file will be saved.
-    filesystem : s3fs.S3FileSystem | None
-        Optional pre-created filesystem to reuse across multiple downloads.
+    filesystem : S3Client | None
+        Optional pre-created accessor to reuse across multiple downloads.
 
     Returns
     -------
@@ -123,7 +203,7 @@ def download_s3_file(
 def download_files(
     files: Sequence[tuple[str, Path]] | Iterable[tuple[str, Path]],
     *,
-    filesystem: s3fs.S3FileSystem | None = None,
+    filesystem: S3Client | None = None,
     skip_existing: bool = True,
     skip_missing: bool = False,
 ) -> list[Path]:
@@ -133,8 +213,8 @@ def download_files(
     ----------
     files : iterable of (str, Path)
         Pairs of (S3 URI, local destination path).
-    filesystem : s3fs.S3FileSystem | None
-        Optional pre-created filesystem to reuse across multiple downloads.
+    filesystem : S3Client | None
+        Optional pre-created accessor to reuse across multiple downloads.
     skip_existing : bool
         If True, do not download files that already exist locally.
     skip_missing : bool
@@ -174,7 +254,7 @@ def download_files(
     return downloaded
 
 
-def _remote_size(filesystem: s3fs.S3FileSystem, s3path: str) -> int | None:
+def _remote_size(filesystem: S3Client, s3path: str) -> int | None:
     try:
         info = filesystem.info(s3path)
     except Exception:
@@ -188,8 +268,8 @@ def _remote_size(filesystem: s3fs.S3FileSystem, s3path: str) -> int | None:
         return None
 
 
-class RichCallback(Callback):
-    """FSSpec callback using Rich Progress."""
+class RichCallback:
+    """Progress callback rendering with Rich; callable for ``boto3`` transfers."""
 
     def __init__(self, size: int | None = None, description: str = ""):
         self.progress = rich.progress.Progress(
@@ -212,26 +292,53 @@ class RichCallback(Callback):
     def relative_update(self, inc=1):
         self.progress.update(self.task_id, advance=inc)
 
+    def __call__(self, inc):
+        # boto3 invokes the callback with the number of bytes just transferred.
+        self.relative_update(inc)
+
     def close(self):
         self.progress.stop()
 
 
+class TqdmCallback:
+    """Progress callback rendering with tqdm; callable for ``boto3`` transfers."""
+
+    def __init__(self, size: int | None = None, description: str = ""):
+        self.bar = tqdm(
+            total=size,
+            desc=description,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            dynamic_ncols=True,
+            leave=True,
+            mininterval=0.2,
+            smoothing=0.1,
+            miniters=1,
+            bar_format="{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} "
+            "[{elapsed}<{remaining}, {rate_fmt}]",
+        )
+
+    def __call__(self, inc):
+        self.bar.update(inc)
+
+    def close(self):
+        self.bar.close()
+
+
 def _filesystem_get(
-    filesystem: s3fs.S3FileSystem,
+    filesystem: S3Client,
     s3path: str,
     filepath: Path,
     *,
     size: int | None = None,
 ) -> Path:
-    """Perform the file download using fsspec with a progress bar.
-
-    Internal helper function that wraps the ``filesystem.get`` call to include
-    a progress bar (Rich if available/console, else TQDM).
+    """Perform the file download with a progress bar (Rich if a TTY, else tqdm).
 
     Parameters
     ----------
-    filesystem : s3fs.S3FileSystem
-        The filesystem object to use for the download.
+    filesystem : S3Client
+        The accessor to use for the download.
     s3path : str
         The full S3 URI of the source file.
     filepath : pathlib.Path
@@ -261,31 +368,14 @@ def _filesystem_get(
     if use_rich:
         callback = RichCallback(size=size, description=description)
     else:
-        callback = TqdmCallback(
-            size=size,
-            tqdm_kwargs=dict(
-                desc=description,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                dynamic_ncols=True,
-                leave=True,
-                mininterval=0.2,
-                smoothing=0.1,
-                miniters=1,
-                bar_format="{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} "
-                "[{elapsed}<{remaining}, {rate_fmt}]",
-            ),
-        )
+        callback = TqdmCallback(size=size, description=description)
 
     try:
-        # NEMAR denies anonymous ListBucket but allows GetObject. Both
-        # ``filesystem.get`` and ``filesystem.get(..., recursive=True)`` call
-        # ``_isdir`` / ``_lsdir`` (ListObjectsV2) before issuing GetObject and
-        # 403 on those buckets. ``get_file`` is the single-object primitive
-        # (HEAD + GET only), and all callers here pass single object URIs —
-        # the CTF directory case in base.py pre-expands via ``filesystem.ls``
-        # into per-file pairs.
+        # NEMAR denies anonymous ListBucket but allows GetObject. ``get_file``
+        # issues a single GetObject — no HeadObject, no ListObjectsV2 — so it
+        # works on those buckets. All callers here pass single object URIs; the
+        # CTF directory case in base.py pre-expands via ``S3Client.ls`` into
+        # per-file pairs.
         filesystem.get_file(s3path, str(filepath), callback=callback)
     finally:
         # Ensure callback is closed properly (important for Rich to clean up display)
@@ -300,4 +390,5 @@ __all__ = [
     "download_files",
     "get_s3path",
     "get_s3_filesystem",
+    "S3Client",
 ]

--- a/eegdash/downloader.py
+++ b/eegdash/downloader.py
@@ -67,43 +67,86 @@ class S3Client:
     def get_file(self, rpath: str, lpath: str, *, callback=None) -> None:
         """Download a single object with one unsigned GET (no HEAD, no LIST).
 
-        Streams the body to disk, feeding each chunk's byte count to
-        ``callback`` (a ``callback(nbytes)`` callable) for progress. A missing
-        key is normalised to :class:`FileNotFoundError` so callers can treat it
-        the way they did under ``s3fs``.
+        Streams the body to a ``.part`` sibling and atomically renames it into
+        place, so an interrupted transfer never leaves a truncated file at the
+        destination (which ``skip_existing`` would later mistake for complete).
+        Each chunk's byte count is fed to ``callback`` (a ``callback(nbytes)``
+        callable) for progress.
+
+        Error mapping matches the ``s3fs`` contract callers depend on: a missing
+        key raises :class:`FileNotFoundError`, and a 403 — how S3 reports a
+        missing object when anonymous ``ListBucket`` is denied, e.g. NEMAR —
+        raises :class:`PermissionError`.
         """
         bucket, key = _split_s3_uri(rpath)
         try:
-            body = self._client.get_object(Bucket=bucket, Key=key)["Body"]
-            with open(lpath, "wb") as fh:
-                for chunk in body.iter_chunks(chunk_size=1024 * 1024):
-                    fh.write(chunk)
-                    if callback is not None:
-                        callback(len(chunk))
+            resp = self._client.get_object(Bucket=bucket, Key=key)
         except ClientError as e:
             status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
             code = str(e.response.get("Error", {}).get("Code"))
             if status == 404 or code in ("NoSuchKey", "NoSuchBucket"):
                 raise FileNotFoundError(rpath) from e
+            if status == 403 or code in ("AccessDenied", "Forbidden"):
+                raise PermissionError(rpath) from e
             raise
 
-    def _iter_objects(self, path: str):
-        """Yield each object dict under a prefix via paginated ListObjectsV2."""
+        body = resp["Body"]
+        # Prefer the GET response's own size for the progress total, so the bar
+        # is complete even if the caller's HEAD probe returned nothing.
+        if callback is not None and hasattr(callback, "set_size"):
+            length = resp.get("ContentLength")
+            if length is not None:
+                callback.set_size(length)
+
+        lpath = Path(lpath)
+        tmp = lpath.with_name(lpath.name + ".part")
+        try:
+            with open(tmp, "wb") as fh:
+                for chunk in body.iter_chunks(chunk_size=1024 * 1024):
+                    fh.write(chunk)
+                    if callback is not None:
+                        callback(len(chunk))
+            tmp.replace(lpath)
+        except BaseException:
+            # Interruption / mid-stream error: drop the partial so the next run
+            # re-downloads instead of trusting a truncated file.
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _iter_objects(self, path: str, *, delimiter: str | None = None):
+        """Yield each object dict under a prefix via paginated ListObjectsV2.
+
+        Pass ``delimiter="/"`` to list a single directory level (like
+        ``s3fs.ls``); omit it to walk the prefix recursively (for ``du``).
+        """
         bucket, key = _split_s3_uri(path)
         paginator = self._client.get_paginator("list_objects_v2")
-        for page in paginator.paginate(Bucket=bucket, Prefix=key):
+        kwargs = {"Bucket": bucket, "Prefix": key}
+        if delimiter:
+            kwargs["Delimiter"] = delimiter
+        for page in paginator.paginate(**kwargs):
             yield from page.get("Contents", [])
 
     def ls(self, path: str, detail: bool = False):
-        """List objects under a prefix, returning ``bucket/key`` strings."""
+        """List the immediate objects under a prefix as ``bucket/key`` strings.
+
+        Lists one directory level (``Delimiter="/"``), like ``s3fs.ls`` — a
+        recursive walk would let a nested subdirectory's keys be flattened into
+        the parent by callers that take ``Path(name)`` (e.g. CTF ``.ds`` dirs
+        with a nested ``hz.ds``).
+        """
         bucket, _ = _split_s3_uri(path)
-        names = [f"{bucket}/{obj['Key']}" for obj in self._iter_objects(path)]
+        prefix = path if path.endswith("/") else path + "/"
+        names = [
+            f"{bucket}/{obj['Key']}"
+            for obj in self._iter_objects(prefix, delimiter="/")
+        ]
         if detail:
             return [{"name": n, "type": "file"} for n in names]
         return names
 
     def du(self, path: str) -> int:
-        """Sum the size in bytes of every object under a prefix."""
+        """Sum the size in bytes of every object under a prefix (recursive)."""
         return sum(obj["Size"] for obj in self._iter_objects(path))
 
 
@@ -259,7 +302,11 @@ def _remote_size(filesystem: S3Client, s3path: str) -> int | None:
         info = filesystem.info(s3path)
     except Exception:
         return None
-    size = info.get("size") or info.get("Size")
+    # Not `size or Size`: a legitimate 0-byte object is falsy and must not be
+    # treated as "unknown" (that would skip size verification for empty keys).
+    size = info.get("size")
+    if size is None:
+        size = info.get("Size")
     if size is None:
         return None
     try:
@@ -318,6 +365,10 @@ class TqdmCallback:
             bar_format="{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} "
             "[{elapsed}<{remaining}, {rate_fmt}]",
         )
+
+    def set_size(self, size):
+        self.bar.total = size
+        self.bar.refresh()
 
     def __call__(self, inc):
         self.bar.update(inc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
   "rich",
   # boto3 (sync SDK) instead of s3fs: s3fs drags in aiobotocore, which hard-pins
   # botocore and breaks any env that also needs boto3. See issue #397.
-  "boto3",
+  "boto3>=1.34",
   "tqdm",
   "eegdash[features]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ dependencies = [
   "pymatreader",
   "requests>=2.25.0",
   "rich",
-  "s3fs",
+  # boto3 (sync SDK) instead of s3fs: s3fs drags in aiobotocore, which hard-pins
+  # botocore and breaks any env that also needs boto3. See issue #397.
+  "boto3",
   "tqdm",
   "eegdash[features]",
 ]

--- a/scripts/create_metadata.py
+++ b/scripts/create_metadata.py
@@ -6,29 +6,29 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-from s3fs import S3FileSystem
+from eegdash.downloader import S3Client, get_s3_filesystem
 
 
 # Initialize anonymous S3 client for the OpenNeuro public bucket
-def get_s3_dataset_info(dataset: str, fs: S3FileSystem | None = None) -> dict:
+def get_s3_dataset_info(dataset: str, fs: S3Client | None = None) -> dict:
     """Fetch dataset information from S3 (OpenNeuro public bucket).
 
     Returns dict with keys:
       - total_size: total bytes under the dataset prefix
     """
     # Reuse a provided filesystem when running in parallel to avoid extra overhead
-    local_fs = fs or S3FileSystem(anon=True, client_kwargs={"region_name": "us-east-2"})
+    local_fs = fs or get_s3_filesystem()
     prefix = "s3://openneuro.org"
     path = f"{prefix}/{dataset}"
 
     try:
-        total_size = int(local_fs.du(path, total=True) or 0)
+        total_size = int(local_fs.du(path) or 0)
     except Exception:
         total_size = 0
     return {"total_size": total_size}
 
 
-def _s3_size_worker(ds: str, fs: S3FileSystem) -> tuple[str, dict]:
+def _s3_size_worker(ds: str, fs: S3Client) -> tuple[str, dict]:
     """Worker function for parallel S3 size queries."""
     return ds, get_s3_dataset_info(ds, fs=fs)
 
@@ -326,7 +326,7 @@ def enrich_with_s3_size(
     if not dataset_json:
         return dataset_json
 
-    fs = S3FileSystem(anon=True, client_kwargs={"region_name": "us-east-2"})
+    fs = get_s3_filesystem()
 
     datasets = list(dataset_json.keys())
     # Bound workers to avoid overwhelming the network

--- a/tests/unit_tests/test_downloader.py
+++ b/tests/unit_tests/test_downloader.py
@@ -324,12 +324,10 @@ def test_remote_size_invalid_size_type():
 
 
 def test_downloader_get_s3_util():
-    import s3fs
-
     from eegdash import downloader
 
     fs = downloader.get_s3_filesystem()
-    assert isinstance(fs, s3fs.S3FileSystem)
+    assert isinstance(fs, downloader.S3Client)
     assert downloader.get_s3path("s3://bucket", "file") == "s3://bucket/file"
     assert downloader.get_s3path("s3://bucket", "/file") == "s3://bucket/file"
     assert downloader.get_s3path("s3://bucket", "") == "s3://bucket"

--- a/tests/unit_tests/test_downloader.py
+++ b/tests/unit_tests/test_downloader.py
@@ -588,3 +588,85 @@ def test_download_s3_file_replaces_mismatched_local(tmp_path):
         result = download_s3_file("s3://b/f", local_file, filesystem=mock_fs)
         assert result == local_file
         assert local_file.stat().st_size == 10
+
+
+def _bare_s3client():
+    """An S3Client whose boto3 client is a mock (skips real client creation)."""
+    from eegdash.downloader import S3Client
+
+    c = S3Client.__new__(S3Client)
+    c._client = MagicMock()
+    return c
+
+
+def _client_error(code, status):
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        "GetObject",
+    )
+
+
+def test_get_file_maps_404_to_file_not_found(tmp_path):
+    """A missing key (NoSuchKey / 404) surfaces as FileNotFoundError."""
+    c = _bare_s3client()
+    c._client.get_object.side_effect = _client_error("NoSuchKey", 404)
+    with pytest.raises(FileNotFoundError):
+        c.get_file("s3://bucket/key", str(tmp_path / "out.bin"))
+
+
+def test_get_file_maps_403_to_permission_error(tmp_path):
+    """A 403 AccessDenied (how NEMAR reports a missing key with ListBucket denied)
+    must surface as PermissionError, which base.py catches to raise a friendly
+    DataIntegrityError instead of leaking a raw ClientError.
+    """
+    c = _bare_s3client()
+    c._client.get_object.side_effect = _client_error("AccessDenied", 403)
+    with pytest.raises(PermissionError):
+        c.get_file("s3://bucket/key", str(tmp_path / "out.bin"))
+    # No stray .part file left behind on the error path.
+    assert not (tmp_path / "out.bin.part").exists()
+
+
+def test_get_file_atomic_success(tmp_path):
+    """Successful download renames the .part temp into place; no temp remains."""
+    c = _bare_s3client()
+    body = MagicMock()
+    body.iter_chunks.return_value = [b"ab", b"cd"]
+    c._client.get_object.return_value = {"Body": body, "ContentLength": 4}
+    dest = tmp_path / "out.bin"
+    c.get_file("s3://bucket/key", str(dest))
+    assert dest.read_bytes() == b"abcd"
+    assert not (tmp_path / "out.bin.part").exists()
+
+
+def test_get_file_leaves_no_partial_on_stream_error(tmp_path):
+    """A mid-stream failure must not leave a truncated file at the destination
+    (skip_existing would otherwise trust it as complete).
+    """
+    c = _bare_s3client()
+
+    def broken_chunks(**_):
+        yield b"partial"
+        raise ConnectionError("dropped mid-stream")
+
+    body = MagicMock()
+    body.iter_chunks.side_effect = broken_chunks
+    c._client.get_object.return_value = {"Body": body, "ContentLength": 999}
+    dest = tmp_path / "out.bin"
+    with pytest.raises(ConnectionError):
+        c.get_file("s3://bucket/key", str(dest))
+    assert not dest.exists()
+    assert not (tmp_path / "out.bin.part").exists()
+
+
+def test_remote_size_zero_byte_object_is_zero_not_none():
+    """A legitimate 0-byte object must report size 0, not None (which would
+    disable size verification for empty keys).
+    """
+    from eegdash.downloader import _remote_size
+
+    mock_fs = MagicMock()
+    mock_fs.info.return_value = {"size": 0}
+    assert _remote_size(mock_fs, "s3://bucket/empty") == 0


### PR DESCRIPTION
Closes #397 (eegdash side).

## Problem
`eegdash` declares `s3fs`, which pulls in **`aiobotocore`** → a hard pin on a narrow `botocore` range. Any environment that also needs **`boto3`** (moabb's NEMAR/S3 downloaders, `neuralbench`, `awscli`, …) becomes unsolvable: `aiobotocore` and `boto3` want different `botocore` versions, so one always breaks at import.

## Fix
`eegdash` only ever *downloads* from anonymous public buckets, using a handful of ops (HEAD, GET, LIST). Those map 1:1 to plain `boto3`, which has a lighter, non-conflicting dep tree.

- Drop `s3fs` → add `boto3`.
- `downloader.py` now uses a thin anonymous `boto3` client (`S3Client`, `signature_version=UNSIGNED`) that keeps the same `info` / `get_file` / `ls` / `du` surface, so callers in `dataset/base.py`, `dataset/dataset.py`, `scripts/create_metadata.py`, and the ~20 mock tests are unchanged.
- `get_file` streams a single unsigned **`get_object`** to disk (per-chunk progress via the existing Rich/tqdm callbacks) — one GET, no `HeadObject`, no `ListBucket`. This matches the old s3fs behavior (1 size-probe HEAD + 1 GET) and works on NEMAR-style public-read/private-list buckets.

## Testing
- `tests/unit_tests/test_downloader.py`: **29 passed** (incl. live anonymous downloads from OpenNeuro + `nmdatasets`).
- `dataset` / `base` / `hbn` suites: **all passed** (incl. live challenge-dataset downloads).
- `ruff` clean on changed files.

## Note on the full fix
This removes s3fs from *eegdash's own* deps. The botocore pin can still re-enter transitively via **`nemar-py`**, which also declares `s3fs>=2024.1`. A companion PR drops s3fs there too (nemarOrg/nemar-py); both are needed to fully close #397 in a shared env.

## ⚠️ uv.lock
`uv.lock` still references `s3fs` — it needs `uv lock` regeneration. I couldn't do it locally: `uv lock` fails on a **pre-existing** numba cross-platform constraint (pyproject L99-104, unrelated to this change). Please regenerate via CI / your normal lock workflow.