### PR TITLE
Add EEG2026 challenge tutorial gallery

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,6 +10,12 @@ APIDIR := $(SOURCEDIR)/api
 # Shared cache so tutorials find data regardless of sphinx CWD (mirrors CI's EEGDASH_CACHE_DIR).
 EEGDASH_CACHE_DIR ?= $(CURDIR)/../.eegdash_cache
 
+ifeq ($(shell uname -s),Darwin)
+# Keep CodeCarbon from prompting for sudo; override for the local CPU if needed.
+CODECARBON_FORCE_CPU_POWER ?= 12
+export CODECARBON_FORCE_CPU_POWER
+endif
+
 .PHONY: help clean apidoc llms-txt html html-noplot html-fast markdown
 
 help:

--- a/docs/source/_extensions/auto_examples_index.py
+++ b/docs/source/_extensions/auto_examples_index.py
@@ -1,7 +1,8 @@
 """Sphinx extension: aggregate sphinx-gallery leaf indexes into one page.
 
 Sphinx-gallery is configured with multiple gallery roots (one per
-tutorial category, plus how-to / applied / eeg2025 / hpc / dev_scripts).
+tutorial category, plus how-to / applied / eeg2025 / eeg2026 / hpc /
+dev_scripts).
 Each emits its own ``index.rst`` with a card grid of tutorial thumbnails.
 This extension stitches those per-leaf indexes into a single parent
 ``generated/auto_examples/index.rst`` aggregator page that mimics the
@@ -87,7 +88,8 @@ def _write_auto_examples_root_index(app):
     """Write a top-level ``generated/auto_examples/index.rst`` aggregator.
 
     Sphinx-gallery is configured with multiple gallery roots (one per
-    tutorial category, plus how-to / applied / eeg2025 / hpc / dev_scripts).
+    tutorial category, plus how-to / applied / eeg2025 / eeg2026 / hpc /
+    dev_scripts).
     Each emits its own ``index.rst`` containing a card grid of tutorial
     thumbnails. This hook reads those per-leaf indexes and stitches them
     into a single parent page that mimics the SPDLearn theory aggregator:
@@ -206,6 +208,15 @@ def _write_auto_examples_root_index(app):
             "tutorial.",
         ),
         (
+            "eeg2026",
+            "EEG/EMG Foundation Challenge 2026",
+            "Runnable EEGDash companions for the four announced 2026 "
+            "tracks: EEG-to-image retrieval, cross-session BCI decoding, "
+            "sleep-onset regression, and cross-user EMG-to-text. Each "
+            "tutorial uses a deterministic offline analogue and points to "
+            "NeuralBench for official execution and scoring.",
+        ),
+        (
             "hpc",
             "High-performance computing",
             "Reference setup for running EEGDash on shared HPC clusters: "
@@ -233,8 +244,8 @@ def _write_auto_examples_root_index(app):
         "The intended path: read the curated **Tutorials** in order, dip "
         "into **How-to recipes** when you have a specific question, then "
         "scale up using the **Applied research projects**, the **EEG2025 "
-        "Foundation Challenge** pipelines, and the **High-performance "
-        "computing** track.",
+        "and EEG2026 Foundation Challenges** pipelines, and the "
+        "**High-performance computing** track.",
         "",
         ".. admonition:: How to read this gallery",
         "   :class: tip eegdash-gallery-howto",
@@ -283,6 +294,9 @@ def _write_auto_examples_root_index(app):
         "   * - **Join EEG2025**",
         "     - :doc:`tutorials/70_transfer_foundation/index`",
         "     - :doc:`eeg2025/index`",
+        "   * - **Prepare for EEG/EMG 2026**",
+        "     - :doc:`eeg2026/index`",
+        "     - `Official NeuralBench guides <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/index.html>`__",
         "",
         ".. grid:: 1 2 2 4",
         "   :gutter: 3",
@@ -305,11 +319,11 @@ def _write_auto_examples_root_index(app):
         "",
         "      Move from local scripts to cluster-wide jobs.",
         "",
-        "   .. grid-item-card:: 🏆 Join EEG2025",
-        "      :link: eeg2025/index",
+        "   .. grid-item-card:: 🏆 Prepare for EEG/EMG 2026",
+        "      :link: eeg2026/index",
         "      :link-type: doc",
         "",
-        "      Enter the official Foundation Challenge.",
+        "      Run the four announced track companions.",
         "",
     ]
     for rel, title, intro in tutorial_sections:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,6 +203,7 @@ html_theme_options = {
         "alt_text": "EEG Dash Logo",
     },
     "external_links": [
+        {"name": "EEG2026", "url": "https://neural-interfaces26.github.io/"},
         {"name": "EEG2025", "url": "https://eeg2025.github.io/"},
     ],
     # Local SVG icons instead of FontAwesome for these brand links. Note:
@@ -247,6 +248,7 @@ html_sidebars = {
     "generated/auto_examples/how_to/*": [],
     "generated/auto_examples/dev_scripts/*": [],
     "generated/auto_examples/eeg2025/*": [],
+    "generated/auto_examples/eeg2026/*": [],
     "generated/auto_examples/hpc/*": [],
 }
 
@@ -337,7 +339,8 @@ EX_DIR = "../../examples"  # relative to docs/source
 # subdirs like ``00_start_here/`` rather than ``plot_*.py`` files at the
 # top), so we list each tutorial category as its own gallery root and pair
 # it with a matching `gallery_dirs` entry. Same pattern for the leaf-only
-# directories (`how_to`, `applied`, `eeg2025`, `hpc`, `dev_scripts`).
+# directories (`how_to`, `applied`, `eeg2025`, `eeg2026`, `hpc`,
+# `dev_scripts`).
 TUTORIAL_SUBDIRS = [
     "00_start_here",
     "10_core_workflow",
@@ -347,7 +350,7 @@ TUTORIAL_SUBDIRS = [
     "50_evaluation",
     "70_transfer_foundation",
 ]
-LEAF_DIRS = ["how_to", "applied", "eeg2025", "hpc", "dev_scripts"]
+LEAF_DIRS = ["how_to", "applied", "eeg2025", "eeg2026", "hpc", "dev_scripts"]
 EX_DIRS = [f"{EX_DIR}/tutorials/{name}" for name in TUTORIAL_SUBDIRS] + [
     f"{EX_DIR}/{name}" for name in LEAF_DIRS
 ]

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -12,6 +12,7 @@ Categories:
 - **how_to/**: Task-focused recipes for specific operational questions.
 - **applied/**: Real-world research case studies (age, sex, p-factor).
 - **eeg2025/**: Official Foundation Challenge starter kits.
+- **eeg2026/**: Offline companions for the four announced EEG/EMG tracks.
 - **hpc/**: Scaling EEGDash on shared clusters and SLURM.
 - **core/**: Minimal, linear scripts for rapid prototyping.
 

--- a/examples/eeg2026/README.txt
+++ b/examples/eeg2026/README.txt
@@ -1,0 +1,27 @@
+EEG/EMG Foundation Challenge 2026
+=================================
+
+Runnable EEGDash companions for the four announced 2026 competition tracks.
+Each tutorial shows the seed-corpus query, the held-out evaluation axis, and
+the track metric on a deterministic synthetic analogue that builds offline.
+
+The synthetic scores are teaching checks, not leaderboard baselines. Use the
+official NeuralBench evaluator for competition results:
+https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/index.html
+
+What you will learn:
+
+- Track 1: map EEG to image embeddings and measure top-5 retrieval accuracy
+  on unseen stimuli.
+- Track 2: decode BCI commands across sessions with balanced accuracy.
+- Track 3: predict sleep-onset latency across held-out subjects and devices,
+  and understand the official weighted, binned error metric.
+- Track 4: decode EMG keystrokes across users and measure character error
+  rate.
+
+Run the tutorials:
+
+1. ``tutorial_track_1_eeg_to_image.py`` -- cross-stimulus EEG-to-image.
+2. ``tutorial_track_2_bci.py`` -- cross-session BCI commands.
+3. ``tutorial_track_3_sleep_onset.py`` -- cross-subject onset regression.
+4. ``tutorial_track_4_emg_to_text.py`` -- cross-user EMG-to-text.

--- a/examples/eeg2026/tutorial_track_1_eeg_to_image.py
+++ b/examples/eeg2026/tutorial_track_1_eeg_to_image.py
@@ -1,0 +1,114 @@
+"""Track 1: EEG-to-image retrieval
+=================================
+
+**Difficulty 2** | **Runtime: <5s** | **Compute: CPU**
+
+Track 1 maps an EEG response to the embedding of the viewed image. The
+competition holds stimuli out, so repeated trials of one image must never
+appear on both sides of the split. The official score is top-5 retrieval
+accuracy. See the `competition site <https://neural-interfaces26.github.io/>`_
+and the `NeuralBench guide <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/plot_track1_eeg_to_image.html>`_.
+
+This offline example uses a small synthetic embedding problem. Its score is a
+pipeline check, not an official baseline.
+
+Keywords: EEG2026, retrieval, vision
+"""
+
+# %% [markdown]
+# Seed data in EEGDash
+# --------------------
+# THINGS-EEG2 and the Alljoined corpora are already catalogued by EEGDash.
+# Open recordings already present in a local cache without network access:
+#
+# .. code-block:: python
+#
+#    from eegdash import EEGDashDataset
+#
+#    things = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000232", download=False
+#    )
+#    things.plot(0)
+#    alljoined = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000134", download=False
+#    )
+#
+# Remove ``download=False`` when you are ready to fetch missing recordings.
+# ``plot(0)`` opens the first cached recording in the Braindecode notebook
+# viewer before preprocessing.
+# The official NeuralBench task owns preprocessing, splits, and submission
+# files. EEGDash supplies the BIDS-first recording layer.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.linear_model import Ridge
+
+from eegdash.viz import use_eegdash_style
+
+use_eegdash_style()
+rng = np.random.default_rng(2026)
+
+# %% [markdown]
+# Build an embedding-shaped analogue
+# ----------------------------------
+# Each stimulus has a fixed image embedding and six noisy EEG repetitions.
+# A linear sensor map turns the embedding into EEG features; ridge regression
+# learns the inverse map from training stimuli only.
+
+# %%
+n_stimuli, repetitions = 30, 6
+embedding_dim, eeg_features = 12, 36
+image_embeddings = rng.normal(size=(n_stimuli, embedding_dim))
+image_embeddings /= np.linalg.norm(image_embeddings, axis=1, keepdims=True)
+sensor_map = rng.normal(size=(embedding_dim, eeg_features))
+
+stimulus = np.repeat(np.arange(n_stimuli), repetitions)
+X = image_embeddings[stimulus] @ sensor_map
+X += rng.normal(scale=0.45, size=X.shape)
+y = image_embeddings[stimulus]
+
+# %% [markdown]
+# Hold out stimuli, then retrieve
+# -------------------------------
+# The first 20 stimuli train the decoder; the last 10 are unseen. Candidate
+# retrieval uses all 30 image embeddings, so chance top-5 accuracy is 5/30.
+
+# %%
+train_stimuli = set(range(20))
+test_stimuli = set(range(20, n_stimuli))
+split_overlap = train_stimuli & test_stimuli
+assert not split_overlap
+
+train = np.isin(stimulus, list(train_stimuli))
+test = ~train
+decoder = Ridge(alpha=1.0).fit(X[train], y[train])
+predicted = decoder.predict(X[test])
+predicted /= np.linalg.norm(predicted, axis=1, keepdims=True)
+
+similarity = predicted @ image_embeddings.T
+top_five = np.argpartition(similarity, -5, axis=1)[:, -5:]
+score = float(np.mean([target in row for target, row in zip(stimulus[test], top_five)]))
+metric_name = "top-5 accuracy"
+held_out_axis = "stimulus"
+print(f"{metric_name}: {score:.3f} | stimulus overlap: {len(split_overlap)}")
+
+# %% [markdown]
+# Read the result
+# ---------------
+# The left panel shows one test trial's candidate similarities. The right
+# panel compares the tutorial score with retrieval chance. Use NeuralBench,
+# not this synthetic value, for any leaderboard claim.
+
+# %%
+fig, axes = plt.subplots(1, 2, figsize=(9, 3.4))
+trial = 0
+axes[0].bar(np.arange(n_stimuli), similarity[trial], color="#6B8E8E")
+axes[0].axvline(stimulus[test][trial], color="#C45A3C", label="true image")
+axes[0].set(xlabel="candidate stimulus", ylabel="cosine similarity")
+axes[0].legend()
+axes[1].bar(["chance", "ridge"], [5 / n_stimuli, score], color=["#B8B8B8", "#C45A3C"])
+axes[1].set(ylabel="top-5 accuracy", ylim=(0, 1))
+fig.suptitle("EEG2026 Track 1 — cross-stimulus retrieval")
+fig.tight_layout()
+plt.show()

--- a/examples/eeg2026/tutorial_track_2_bci.py
+++ b/examples/eeg2026/tutorial_track_2_bci.py
@@ -1,0 +1,122 @@
+"""Track 2: cross-session BCI decoding
+=====================================
+
+**Difficulty 2** | **Runtime: <5s** | **Compute: CPU**
+
+Track 2 decodes cued mental commands from short EEG windows. Training uses
+early sessions and evaluation uses later sessions from the same people, with
+no session recalibration. The official metric is balanced accuracy. See the
+`competition site <https://neural-interfaces26.github.io/>`_ and the
+`NeuralBench guide <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/plot_track2_eeg_to_bci.html>`_.
+
+Keywords: EEG2026, BCI, cross-session
+"""
+
+# %% [markdown]
+# Seed data in EEGDash
+# --------------------
+# Stieger2021 is a 62-participant, multi-session motor-imagery corpus. This
+# snippet opens recordings already present in ``./data``:
+#
+# .. code-block:: python
+#
+#    from eegdash import EEGDashDataset
+#
+#    stieger = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000339", download=False
+#    )
+#    stieger.plot(0)
+#
+# Remove ``download=False`` to fetch missing recordings.
+# ``plot(0)`` opens the first cached recording in the Braindecode notebook
+# viewer before preprocessing.
+# Use NeuralBench for the official preprocessing and frozen split. The small
+# analogue below makes the cross-session rule visible without downloading
+# hundreds of gigabytes.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import balanced_accuracy_score, confusion_matrix
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from eegdash.viz import use_eegdash_style
+
+use_eegdash_style()
+rng = np.random.default_rng(2026)
+
+# %% [markdown]
+# Simulate commands, people, and session drift
+# --------------------------------------------
+# Three class centres represent mental commands. Subject offsets preserve
+# individual anatomy; a session-specific drift shifts every later recording.
+
+# %%
+n_subjects, n_sessions = 8, 4
+commands = ("motor imagery", "mental calculation", "word association")
+n_commands = len(commands)
+trials_per_command, n_features = 12, 20
+centres = rng.normal(scale=1.4, size=(n_commands, n_features))
+subject_offset = rng.normal(scale=0.35, size=(n_subjects, n_features))
+session_drift = rng.normal(scale=0.25, size=(n_sessions, n_features))
+
+rows = []
+for subject in range(n_subjects):
+    for session in range(n_sessions):
+        for command in range(n_commands):
+            for _ in range(trials_per_command):
+                features = centres[command] + subject_offset[subject]
+                features = features + session_drift[session]
+                features = features + rng.normal(scale=1.0, size=n_features)
+                rows.append((features, command, subject, session))
+
+X = np.stack([row[0] for row in rows])
+y = np.asarray([row[1] for row in rows])
+subjects = np.asarray([row[2] for row in rows])
+sessions = np.asarray([row[3] for row in rows])
+
+# %% [markdown]
+# Train early, test late
+# ----------------------
+# Sessions 1-3 train the model and session 4 tests it. Subjects intentionally
+# occur on both sides; sessions must not.
+
+# %%
+train = sessions < 3
+test = sessions == 3
+split_overlap = set(sessions[train]) & set(sessions[test])
+subject_overlap = set(subjects[train]) & set(subjects[test])
+assert not split_overlap
+assert subject_overlap == set(range(n_subjects))
+
+model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=500))
+model.fit(X[train], y[train])
+predicted = model.predict(X[test])
+cell_scores = [
+    balanced_accuracy_score(
+        y[test][subjects[test] == subject], predicted[subjects[test] == subject]
+    )
+    for subject in sorted(subject_overlap)
+]
+score = float(np.mean(cell_scores))
+metric_name = "balanced accuracy"
+held_out_axis = "session"
+print(f"{metric_name}: {score:.3f} | session overlap: {len(split_overlap)}")
+
+# %%
+matrix = confusion_matrix(y[test], predicted, normalize="true")
+fig, axes = plt.subplots(1, 2, figsize=(8.6, 3.4))
+image = axes[0].imshow(matrix, vmin=0, vmax=1, cmap="Blues")
+axes[0].set(xlabel="predicted command", ylabel="true command")
+axes[0].set_xticks(range(n_commands), commands, rotation=25, ha="right")
+axes[0].set_yticks(range(n_commands), commands)
+fig.colorbar(image, ax=axes[0], label="row fraction")
+axes[1].bar(
+    ["chance", "logistic"], [1 / n_commands, score], color=["#B8B8B8", "#C45A3C"]
+)
+axes[1].set(ylabel="balanced accuracy", ylim=(0, 1))
+fig.suptitle("EEG2026 Track 2 — early sessions to later session")
+fig.tight_layout()
+plt.show()

--- a/examples/eeg2026/tutorial_track_3_sleep_onset.py
+++ b/examples/eeg2026/tutorial_track_3_sleep_onset.py
@@ -1,0 +1,118 @@
+"""Track 3: sleep-onset latency
+================================
+
+**Difficulty 2** | **Runtime: <5s** | **Compute: CPU**
+
+Track 3 predicts seconds from recording start to the first stable N2 epoch.
+The competition evaluates held-out subjects recorded with wearable EEG and
+uses weighted binned mean absolute error (W-bMAE). See the
+`competition site <https://neural-interfaces26.github.io/>`_ and the
+`NeuralBench guide <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/plot_track3_sleep_onset.html>`_.
+
+This tutorial reports a transparent balanced-bin MAE analogue. Only the
+official NeuralBench evaluator produces the competition W-bMAE.
+
+Keywords: EEG2026, sleep, regression
+"""
+
+# %% [markdown]
+# Seed data in EEGDash
+# --------------------
+# Sleep-EDF Expanded and the PhysioNet 2018 sleep challenge are available as
+# BIDS-first EEGDash records. These snippets open a pre-populated local cache:
+#
+# .. code-block:: python
+#
+#    from eegdash import EEGDashDataset
+#
+#    sleep_edf = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000185", download=False
+#    )
+#    sleep_edf.plot(0)
+#    physionet = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000225", download=False
+#    )
+#
+# Remove ``download=False`` to fetch missing recordings.
+# ``plot(0)`` opens the first cached recording in the Braindecode notebook
+# viewer before preprocessing.
+# NeuralBench defines the event annotation, wearable evaluation cohort, and
+# official scoring weights.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.linear_model import Ridge
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from eegdash.viz import use_eegdash_style
+
+use_eegdash_style()
+rng = np.random.default_rng(2026)
+
+# %% [markdown]
+# Build subject-level onset features
+# ----------------------------------
+# Each row is one person. Four spectral and behavioural proxies carry a noisy
+# onset signal. The last 15 subjects also receive a wearable-device shift.
+
+# %%
+n_subjects = 60
+subjects = np.asarray([f"sub-{index:03d}" for index in range(n_subjects)])
+devices = np.where(np.arange(n_subjects) < 45, "clinical", "wearable")
+onset = rng.uniform(120, 1800, size=n_subjects)
+X = np.column_stack(
+    [
+        onset / 600 + rng.normal(scale=0.25, size=n_subjects),
+        np.log1p(onset) + rng.normal(scale=0.15, size=n_subjects),
+        np.sqrt(onset) / 20 + rng.normal(scale=0.20, size=n_subjects),
+        rng.normal(size=n_subjects),
+    ]
+)
+X[45:] += np.array([0.35, -0.15, 0.20, 0.10])
+
+# %% [markdown]
+# Hold subjects out and balance onset ranges
+# ------------------------------------------
+# A plain MAE can be dominated by common onset ranges. This local analogue
+# computes MAE inside fixed latency bins and averages the non-empty bins. The
+# official evaluator has its own frozen bins and weights.
+
+# %%
+train = np.arange(n_subjects) < 45
+test = ~train
+subject_overlap = set(subjects[train]) & set(subjects[test])
+device_overlap = set(devices[train]) & set(devices[test])
+split_overlap = subject_overlap | device_overlap
+assert not split_overlap
+
+model = make_pipeline(StandardScaler(), Ridge(alpha=4.0))
+model.fit(X[train], onset[train])
+predicted = model.predict(X[test])
+
+bin_id = np.digitize(onset[test], bins=[300, 600, 900, 1200])
+bin_errors = np.asarray(
+    [
+        np.mean(np.abs(onset[test][bin_id == index] - predicted[bin_id == index]))
+        for index in np.unique(bin_id)
+    ]
+)
+score = float(np.mean(bin_errors))
+metric_name = "balanced-bin MAE (s)"
+held_out_axis = "subject + device"
+print(f"{metric_name}: {score:.1f} | split overlap: {len(split_overlap)}")
+
+# %%
+fig, axes = plt.subplots(1, 2, figsize=(8.8, 3.4))
+axes[0].scatter(onset[test], predicted, color="#6B8E8E")
+limits = [0, 1900]
+axes[0].plot(limits, limits, "--", color="#C45A3C")
+axes[0].set(
+    xlabel="true onset (s)", ylabel="predicted onset (s)", xlim=limits, ylim=limits
+)
+axes[1].bar(np.arange(len(bin_errors)), bin_errors, color="#C45A3C")
+axes[1].set(xlabel="occupied latency bin", ylabel="MAE (s)")
+fig.suptitle("EEG2026 Track 3 — held-out subjects and device shift")
+fig.tight_layout()
+plt.show()

--- a/examples/eeg2026/tutorial_track_4_emg_to_text.py
+++ b/examples/eeg2026/tutorial_track_4_emg_to_text.py
@@ -1,0 +1,142 @@
+"""Track 4: EMG-to-text decoding
+================================
+
+**Difficulty 2** | **Runtime: <5s** | **Compute: CPU**
+
+Track 4 decodes typed text from wrist surface EMG. Evaluation users are
+unseen during training, so anatomy, typing strategy, and sensor placement all
+shift. The official metric is character error rate (CER). See the
+`competition site <https://neural-interfaces26.github.io/>`_ and the
+`NeuralBench guide <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/plot_track4_emg_to_text.html>`_.
+
+Keywords: EEG2026, EMG, text
+"""
+
+# %% [markdown]
+# Seed data in EEGDash
+# --------------------
+# The public emg2qwerty corpus is catalogued as ``nm000104``. This snippet
+# opens recordings already present in a local cache:
+#
+# .. code-block:: python
+#
+#    from eegdash import EEGDashDataset
+#
+#    emg = EEGDashDataset(
+#        cache_dir="./data", dataset="nm000104", download=False
+#    )
+#    emg.plot(0)
+#
+# Remove ``download=False`` to fetch missing recordings.
+# ``plot(0)`` opens the first recording in the Braindecode notebook viewer;
+# when a ``*_desc-pose.json`` sidecar is present, it adds the synchronized
+# hand-pose panel beside the EMG traces.
+# EEGDash handles the recordings; NeuralBench owns sequence preparation,
+# frozen users, the official decoder interface, and submission scoring.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from eegdash.viz import use_eegdash_style
+
+use_eegdash_style()
+rng = np.random.default_rng(2026)
+
+
+def edit_distance(reference: str, hypothesis: str) -> int:
+    """Return Levenshtein distance using one rolling dynamic-programming row."""
+    previous = list(range(len(hypothesis) + 1))
+    for ref_index, ref_char in enumerate(reference, start=1):
+        current = [ref_index]
+        for hyp_index, hyp_char in enumerate(hypothesis, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[hyp_index] + 1,
+                    previous[hyp_index - 1] + (ref_char != hyp_char),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+# %% [markdown]
+# Build a cross-user typing analogue
+# ----------------------------------
+# Eight keys each have a latent EMG pattern. Every user adds an anatomical
+# offset and sensor-placement transform. Twelve users train the classifier;
+# six entirely new users test it.
+
+# %%
+alphabet = np.asarray(list("asdfjkl;"))
+phrase = "asdfjkl;" * 8
+n_users, n_features = 18, 24
+key_centres = rng.normal(scale=1.8, size=(len(alphabet), n_features))
+rows = []
+for user in range(n_users):
+    user_offset = rng.normal(scale=0.45, size=n_features)
+    user_scale = rng.normal(loc=1.0, scale=0.08, size=n_features)
+    for char in phrase:
+        label = int(np.flatnonzero(alphabet == char)[0])
+        features = key_centres[label] * user_scale + user_offset
+        features = features + rng.normal(scale=1.0, size=n_features)
+        rows.append((features, label, user))
+
+X = np.stack([row[0] for row in rows])
+y = np.asarray([row[1] for row in rows])
+users = np.asarray([row[2] for row in rows])
+train = users < 12
+test = ~train
+split_overlap = set(users[train]) & set(users[test])
+assert not split_overlap
+
+# %% [markdown]
+# Decode aligned characters, then compute CER
+# -------------------------------------------
+# The compact baseline predicts one character per fixed window. It therefore
+# demonstrates cross-user token classification, not the official variable-
+# length sequence-transduction model. The edit-distance CER calculation is
+# exact and remains valid when you replace the classifier with a sequence
+# decoder.
+#
+# CER is Levenshtein edits divided by reference length. Unlike accuracy, CER
+# can exceed 1 when a hypothesis contains many insertions; do not clamp it.
+
+# %%
+model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=500))
+model.fit(X[train], y[train])
+predicted = model.predict(X[test])
+
+references = []
+hypotheses = []
+for user in np.unique(users[test]):
+    user_mask = users[test] == user
+    references.append("".join(alphabet[y[test][user_mask]]))
+    hypotheses.append("".join(alphabet[predicted[user_mask]]))
+
+edits = sum(
+    edit_distance(reference, hypothesis)
+    for reference, hypothesis in zip(references, hypotheses)
+)
+n_reference_chars = sum(map(len, references))
+score = float(edits / n_reference_chars)
+metric_name = "character error rate"
+held_out_axis = "user"
+print(f"{metric_name}: {score:.3f} | user overlap: {len(split_overlap)}")
+
+# %%
+fig, axes = plt.subplots(1, 2, figsize=(9, 3.4))
+preview = 32
+axes[0].plot(np.arange(preview), y[test][:preview], "o-", label="reference")
+axes[0].plot(np.arange(preview), predicted[:preview], "x--", label="decoded")
+axes[0].set(xlabel="character position", ylabel="key index")
+axes[0].legend()
+axes[1].bar(["perfect", "logistic"], [0, score], color=["#B8B8B8", "#C45A3C"])
+axes[1].set(ylabel="character error rate", ylim=(0, max(0.2, score * 1.2)))
+fig.suptitle("EEG2026 Track 4 — cross-user EMG decoding")
+fig.tight_layout()
+plt.show()

--- a/tests/unit_tests/test_eeg2026_gallery.py
+++ b/tests/unit_tests/test_eeg2026_gallery.py
@@ -1,0 +1,73 @@
+import importlib
+import runpy
+import socket
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+plt = importlib.import_module("matplotlib.pyplot")
+
+ROOT = Path(__file__).parents[2]
+
+
+@pytest.mark.parametrize(
+    ("script", "metric_name", "held_out_axis", "upper_bound", "group_names"),
+    [
+        (
+            "tutorial_track_1_eeg_to_image.py",
+            "top-5 accuracy",
+            "stimulus",
+            1.0,
+            ("stimulus",),
+        ),
+        (
+            "tutorial_track_2_bci.py",
+            "balanced accuracy",
+            "session",
+            1.0,
+            ("sessions",),
+        ),
+        (
+            "tutorial_track_3_sleep_onset.py",
+            "balanced-bin MAE (s)",
+            "subject + device",
+            np.inf,
+            ("subjects", "devices"),
+        ),
+        (
+            "tutorial_track_4_emg_to_text.py",
+            "character error rate",
+            "user",
+            np.inf,
+            ("users",),
+        ),
+    ],
+)
+def test_eeg2026_tutorial_runs_offline_without_group_leakage(
+    script, metric_name, held_out_axis, upper_bound, group_names, monkeypatch
+):
+    def deny_network(*_args, **_kwargs):
+        raise AssertionError("tutorial attempted a network connection")
+
+    monkeypatch.setattr(socket.socket, "connect", deny_network)
+    namespace = runpy.run_path(ROOT / "examples" / "eeg2026" / script)
+    repeated = runpy.run_path(ROOT / "examples" / "eeg2026" / script)
+
+    assert namespace["metric_name"] == metric_name
+    assert namespace["held_out_axis"] == held_out_axis
+    score = float(namespace["score"])
+    assert np.isfinite(score)
+    assert 0.0 <= score <= upper_bound
+    assert namespace["score"] == repeated["score"]
+    assert not namespace["split_overlap"]
+    for group_name in group_names:
+        group = namespace[group_name]
+        assert not set(group[namespace["train"]]) & set(group[namespace["test"]])
+    if script == "tutorial_track_2_bci.py":
+        assert namespace["subject_overlap"] == set(range(8))
+    if script == "tutorial_track_4_emg_to_text.py":
+        assert namespace["edit_distance"]("kitten", "sitting") == 3
+    plt.close("all")


### PR DESCRIPTION
## Summary

- add four runnable EEG2026 Sphinx-Gallery tutorials for the announced challenge tracks
- demonstrate leakage-safe evaluation and track-aligned teaching metrics with deterministic offline analogues
- include the Braindecode dataset viewer pattern in every real-data snippet
- register the gallery in the documentation navigation and indexing
- avoid CodeCarbon sudo prompts during macOS documentation builds

## Testing

- `pytest` — 1130 passed, 10 skipped, 5 deselected
- `pre-commit run --files docs/source/_extensions/auto_examples_index.py examples/eeg2026/tutorial_track_2_bci.py tests/unit_tests/test_eeg2026_gallery.py`
- `PYTHONPATH=.. make html` — gallery executed 4/4 tutorials and built successfully
