### PR TITLE
Download NEMAR session scans metadata

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -833,6 +833,22 @@ class EEGDashRaw(RawDataset):
                         e,
                     )
 
+    def _fetch_nemar_session_metadata(self, filesystem) -> None:
+        """Fetch the BIDS ``scans.tsv`` beside this recording's session."""
+        parts = PurePosixPath(self.record["bids_relpath"]).parts
+        if (
+            len(parts) < 3
+            or not parts[0].startswith("sub-")
+            or not parts[1].startswith("ses-")
+        ):
+            return
+        relpath = str(
+            PurePosixPath(parts[0], parts[1], f"{parts[0]}_{parts[1]}_scans.tsv")
+        )
+        path = self.bids_root / relpath
+        if not path.exists():
+            self._fetch_nemar_companion(path, relpath, filesystem)
+
     def _download_companion_files(self, filesystem) -> None:
         """Download companion files for formats that require them.
 

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -620,19 +620,28 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         if not targets:
             self._download_dataset_files()
-        elif n_jobs == 1:
-            for ds in targets:
-                ds._download_required_files()
         else:
-            Parallel(n_jobs=n_jobs, prefer="threads")(
-                delayed(EEGDashRaw._download_required_files)(ds) for ds in targets
-            )
+            if n_jobs == 1:
+                for ds in targets:
+                    ds._download_required_files()
+            else:
+                Parallel(n_jobs=n_jobs, prefer="threads")(
+                    delayed(EEGDashRaw._download_required_files)(ds) for ds in targets
+                )
 
-        # Download global dataset files (participants.tsv, etc.)
-        self._download_dataset_files()
-        filesystem = downloader.get_s3_filesystem(max_concurrency=self.max_concurrency)
-        for ds in self.datasets:
-            if ds._storage_backend == "nemar":
+            # Download global dataset files (participants.tsv, etc.)
+            self._download_dataset_files()
+        nemar = [
+            ds
+            for ds in self.datasets
+            if getattr(ds, "_storage_backend", None) == "nemar"
+            and hasattr(ds, "_fetch_nemar_session_metadata")
+        ]
+        if nemar:
+            filesystem = downloader.get_s3_filesystem(
+                max_concurrency=self.max_concurrency
+            )
+            for ds in nemar:
                 ds._fetch_nemar_session_metadata(filesystem)
 
     def _download_dataset_files(self) -> None:

--- a/eegdash/dataset/dataset.py
+++ b/eegdash/dataset/dataset.py
@@ -620,9 +620,7 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         if not targets:
             self._download_dataset_files()
-            return
-
-        if n_jobs == 1:
+        elif n_jobs == 1:
             for ds in targets:
                 ds._download_required_files()
         else:
@@ -632,6 +630,10 @@ class EEGDashDataset(BaseConcatDataset, metaclass=NumpyDocstringInheritanceInitM
 
         # Download global dataset files (participants.tsv, etc.)
         self._download_dataset_files()
+        filesystem = downloader.get_s3_filesystem(max_concurrency=self.max_concurrency)
+        for ds in self.datasets:
+            if ds._storage_backend == "nemar":
+                ds._fetch_nemar_session_metadata(filesystem)
 
     def _download_dataset_files(self) -> None:
         """Download global dataset files defined in dataset metadata."""

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -114,6 +114,36 @@ def test_nemar_download_required_files_uses_annex_object_uri(tmp_path):
     )
 
 
+def test_nemar_download_fetches_session_scans(tmp_path):
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.schemas import create_record
+
+    record = create_record(
+        dataset="nm000104",
+        storage_base="s3://nemar/nm000104",
+        storage_backend="nemar",
+        bids_relpath="sub-01/ses-02/emg/sub-01_ses-02_task-typing_emg.edf",
+        subject="01",
+        session="02",
+        task="typing",
+        datatype="emg",
+        suffix="emg",
+        sampling_frequency=1000.0,
+        ntimes=1000,
+    )
+    ds = EEGDashRaw(record=record, cache_dir=tmp_path)
+    filesystem = MagicMock()
+
+    with patch.object(ds, "_fetch_nemar_companion") as fetch:
+        ds._fetch_nemar_session_metadata(filesystem)
+
+    fetch.assert_called_once_with(
+        tmp_path / "nm000104" / "sub-01/ses-02/sub-01_ses-02_scans.tsv",
+        "sub-01/ses-02/sub-01_ses-02_scans.tsv",
+        filesystem,
+    )
+
+
 def test_nemar_download_required_files_falls_back_to_data_portal(tmp_path):
     """After an S3 403 on the original URI, eegdash must delegate to
     ``nemar-py`` (NEMARClient + download_one) for the recovery path.


### PR DESCRIPTION
Fetch each required BIDS session scans.tsv after NEMAR recording downloads. This makes query-scoped downloads usable by consumers that read recording metadata from scans.tsv.