### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-31
+
+### Changed
+- Require `braindecode[hub]>=1.8.0`.
+
 ## [0.8.5] - 2026-08-31
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,7 @@ abstract: >-
   datasets are annotated with Hierarchical Event Descriptors (HED) for
   cross-study aggregation.
 type: software
-version: 0.8.5
+version: 0.9.0
 license: BSD-3-Clause
 repository-code: "https://github.com/eegdash/EEGDash"
 url: "https://eegdash.org"

--- a/codemeta.json
+++ b/codemeta.json
@@ -15,8 +15,8 @@
     "https://data.eegdash.org/openapi.json"
   ],
   "license": "https://spdx.org/licenses/BSD-3-Clause",
-  "version": "0.8.5",
-  "softwareVersion": "0.8.5",
+  "version": "0.9.0",
+  "softwareVersion": "0.9.0",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "Python",
@@ -176,7 +176,7 @@
   ],
   "softwareRequirements": [
     "Python >= 3.11",
-    "braindecode >= 1.4.0",
+    "braindecode >= 1.8.0",
     "mne >= 1.11.0",
     "mne_bids >= 0.18.0",
     "numpy",

--- a/eegdash/__init__.py
+++ b/eegdash/__init__.py
@@ -9,7 +9,7 @@ EEG datasets. It integrates with cloud storage and REST APIs to streamline EEG r
 workflows.
 """
 
-__version__ = "0.8.5"
+__version__ = "0.9.0"
 
 # NOTE: Keep the top-level import lightweight to avoid importing heavy optional
 # dependencies (e.g., braindecode/torch) when users only need small utilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "braindecode[hub]>=1.4.0",
+  "braindecode[hub]>=1.8.0",
   "eeglabio",
   "mne>=1.11.0",
   "mne_bids>=0.19.0",
@@ -144,7 +144,7 @@ docs = [
   "neuralfetch>=0.2",
   "neuralset>=0.2",
   # eegprep 0.3.0 (2026-08-12) dropped the top-level ``utils`` module, but
-  # braindecode 1.7.0 -- the newest release -- still calls
+  # Braindecode still calls
   # ``eegprep.utils.round_mat`` in preprocessing/eegprep_preprocess.py, so the
   # docs gallery dies with "module 'eegprep' has no attribute 'utils'".
   # Floor at the newest 0.2.x and cap until a braindecode release supports 0.3.


### PR DESCRIPTION
## Summary
- require `braindecode[hub]>=1.8.0`
- prepare the v0.9.0 package release
- synchronize package, citation, and CodeMeta versions

## Validation
- resolver selects `braindecode==1.8.0`
- `python -m build --wheel --sdist`
- `twine check dist/*`