### PR TITLE
fix(nemar): pair each resolved dependency URI with its own destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- NEMAR downloads no longer write a recording's binary payload over one of its sidecars. `_resolve_nemar_uris` returned only the dependencies that still needed fetching — entries written to disk during resolution, or skipped after a resolution failure, contribute no URI — but the caller re-paired that filtered list against the full `_dep_paths` by position, under `zip(..., strict=False)`. Every dependency after the first omission was therefore downloaded to the wrong path. BrainVision iEEG datasets are the worst case, because only the `.eeg` annex object comes back as a URI while every sidecar is fetched inline: on `nm000182` the single surviving URI paired with dependency 0, so all 257 runs took a 50 MB `.eeg` payload on top of their `*_channels.tsv` and no `.eeg` was written at all. `skip_existing` did not protect the sidecar — it treats a size mismatch against the remote object as a stale local file and unlinks it — and the post-download size check passed, because the bytes did match the object that was requested. Resolution now returns `(uri, destination)` pairs so a URI can never be separated from its destination, and the two `zip` calls that pair keys with destinations are `strict=True`
+
 ## [0.9.0] - 2026-08-31
 
 ### Changed

--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -347,11 +347,22 @@ def _nemar_fast_paths(storage: dict, relpath: str) -> tuple[str | None, str | No
 
 def _resolve_nemar_uris(
     record: dict, raw_dest: Path, dep_keys: list[str], dep_dests: list[Path]
-) -> tuple[str | None, list[str]]:
+) -> tuple[str | None, list[tuple[str, Path]]]:
     """Resolve SHA-keyed S3 URIs for a NEMAR record.
 
     Per-entry resolution is delegated to ``_resolve_one_nemar_entry``
     which honors the digest-time fast paths.
+
+    Returns
+    -------
+    raw_uri : str or None
+        URI of the recording itself, ``None`` when it needs no download.
+    dep_downloads : list of (str, pathlib.Path)
+        One ``(uri, destination)`` pair per dependency that still needs
+        fetching. Dependencies already written to disk during resolution, and
+        those whose resolution failed, are absent: each surviving URI carries
+        its own destination so it can never be re-paired by position.
+
     """
     storage = record.get("storage") or {}
     base = (storage.get("base") or "").rstrip("/")
@@ -371,8 +382,8 @@ def _resolve_nemar_uris(
         is_required=True,
     )
 
-    dep_uris: list[str] = []
-    for dep_key, dep_dest in zip(dep_keys, dep_dests, strict=False):
+    dep_downloads: list[tuple[str, Path]] = []
+    for dep_key, dep_dest in zip(dep_keys, dep_dests, strict=True):
         dep_stored_key, dep_stored_sidecar = _nemar_fast_paths(storage, dep_key)
         try:
             uri = _resolve_one_nemar_entry(
@@ -395,9 +406,9 @@ def _resolve_nemar_uris(
             )
             continue
         if uri:
-            dep_uris.append(uri)
+            dep_downloads.append((uri, dep_dest))
 
-    return raw_uri, dep_uris
+    return raw_uri, dep_downloads
 
 
 def _download_via_nemar(dataset_id: str, relpath: str, local_path: Path) -> bool:
@@ -570,11 +581,18 @@ class EEGDashRaw(RawDataset):
         # Default: no remote URIs. The two backends below override.
         self._raw_uri: str | None = None
         self._dep_uris: list[str] = []
+        # (uri, destination) work list for the dependency download. The
+        # destination travels with its URI so a filtered list of URIs can never
+        # be re-paired against ``_dep_paths`` by position.
+        self._dep_downloads: list[tuple[str, Path]] = []
         self._storage_backend = backend
 
         if backend in ("s3", "https") and base and raw_key:
             self._raw_uri = f"{base}/{raw_key}"
             self._dep_uris = [f"{base}/{k}" for k in dep_keys]
+            self._dep_downloads = list(
+                zip(self._dep_uris, self._dep_paths, strict=True)
+            )
         elif backend == "local" and base:
             local_base = Path(base)
             self.bids_root = local_base
@@ -669,7 +687,7 @@ class EEGDashRaw(RawDataset):
             and not self.filecache.exists()
         ):
             dep_keys = (self.record.get("storage") or {}).get("dep_keys") or []
-            self._raw_uri, self._dep_uris = _resolve_nemar_uris(
+            self._raw_uri, self._dep_downloads = _resolve_nemar_uris(
                 self.record,
                 raw_dest=self.filecache,
                 dep_keys=list(dep_keys),
@@ -685,7 +703,7 @@ class EEGDashRaw(RawDataset):
             # skip_missing=True because dep_keys may include companion files
             # that don't exist on S3 (e.g., .fdt listed but never uploaded).
             downloader.download_files(
-                list(zip(self._dep_uris, self._dep_paths, strict=False)),
+                self._dep_downloads,
                 filesystem=filesystem,
                 skip_existing=True,
                 skip_missing=True,

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -114,6 +114,60 @@ def test_nemar_download_required_files_uses_annex_object_uri(tmp_path):
     )
 
 
+def test_nemar_download_pairs_annex_object_with_its_own_destination(tmp_path):
+    """Inlined sidecars must not shift the ``.eeg`` onto ``*_channels.tsv``.
+
+    Regression test for NEMAR BrainVision datasets such as ``nm000182``: every
+    sidecar is written to disk during resolution and only the ``.eeg`` annex
+    object comes back as a URI, so pairing the surviving URIs positionally
+    against the full destination list downloaded the binary over the first
+    dependency and left no ``.eeg`` on disk.
+    """
+    from eegdash.dataset.base import EEGDashRaw
+    from eegdash.schemas import create_record
+
+    stem = "sub-01/ieeg/sub-01_task-x_run-01"
+    bids_relpath = f"{stem}_ieeg.vhdr"
+    eeg_key = f"{stem}_ieeg.eeg"
+    record = create_record(
+        dataset="nm000182",
+        storage_base="s3://nemar/nm000182",
+        storage_backend="nemar",
+        bids_relpath=bids_relpath,
+        dep_keys=[
+            f"{stem}_channels.tsv",
+            f"{stem}_events.tsv",
+            eeg_key,
+            f"{stem}_ieeg.vmrk",
+        ],
+        annex_keys={bids_relpath: "SHA256E-s1--raw.vhdr", eeg_key: "SHA256E-s2--d.eeg"},
+        subject="01",
+        task="x",
+        datatype="ieeg",
+        suffix="ieeg",
+        sampling_frequency=5000.0,
+        ntimes=15000,
+    )
+
+    ds = EEGDashRaw(record=record, cache_dir=tmp_path)
+
+    with (
+        patch("eegdash.dataset.base.downloader.get_s3_filesystem"),
+        patch("eegdash.dataset.base.downloader.download_files") as mock_deps,
+        patch("eegdash.dataset.base.downloader.download_s3_file"),
+        patch("eegdash.dataset.base._download_via_nemar", return_value=True),
+        patch.object(ds, "_fetch_nemar_root_metadata"),
+    ):
+        ds._download_required_files()
+
+    assert list(mock_deps.call_args.args[0]) == [
+        (
+            "s3://nemar/nm000182/objects/SHA256E-s2--d.eeg",
+            tmp_path / "nm000182" / eeg_key,
+        )
+    ]
+
+
 def test_nemar_download_fetches_session_scans(tmp_path):
     from eegdash.dataset.base import EEGDashRaw
     from eegdash.schemas import create_record
@@ -416,6 +470,7 @@ def test_eegdashraw_backend_logic(tmp_path):
         ds = EEGDashRaw(record_s3, cache_dir=str(tmp_path))
         assert ds._raw_uri == "s3://bucket/raw"
         assert len(ds._dep_uris) == 1
+        assert ds._dep_downloads == [("s3://bucket/dep1", ds._dep_paths[0])]
 
 
 def test_eegdashraw_raw_setter(tmp_path):

--- a/tests/unit_tests/dataset/test_base_parametrized_helpers.py
+++ b/tests/unit_tests/dataset/test_base_parametrized_helpers.py
@@ -329,7 +329,7 @@ def test_resolve_nemar_uris_with_optional_sidecar_failure(monkeypatch, tmp_path)
 
     monkeypatch.setattr("eegdash.dataset.base._resolve_one_nemar_entry", _resolver)
 
-    raw_uri, dep_uris = _resolve_nemar_uris(
+    raw_uri, dep_downloads = _resolve_nemar_uris(
         record=record,
         raw_dest=tmp_path / "raw.fif",
         dep_keys=["sub/bad.tsv", "sub/good.tsv"],
@@ -337,7 +337,74 @@ def test_resolve_nemar_uris_with_optional_sidecar_failure(monkeypatch, tmp_path)
     )
 
     assert raw_uri == "s3://nemar/dsA/objects/SHA-RAW"
-    assert dep_uris == ["s3://nemar/dsA/objects/SHA-GOOD"]
+    # The surviving URI keeps its own destination: dropping "sub/bad.tsv" must
+    # not shift "sub/good.tsv" onto the destination of the entry before it.
+    assert dep_downloads == [("s3://nemar/dsA/objects/SHA-GOOD", tmp_path / "good.tsv")]
+
+
+def test_resolve_nemar_uris_pairs_each_uri_with_its_own_destination(
+    monkeypatch, tmp_path
+):
+    """Inlined dependencies must not shift the remaining URIs onto their paths.
+
+    Regression test for NEMAR BrainVision datasets (e.g. ``nm000182``), where
+    every sidecar is written to disk during resolution and only the ``.eeg``
+    annex object comes back as a URI. Pairing that single URI positionally
+    against the full destination list wrote the 50 MB binary over
+    ``*_channels.tsv`` and left no ``.eeg`` on disk at all.
+    """
+    dep_keys = [
+        "sub-01/ieeg/sub-01_task-x_run-01_channels.tsv",
+        "sub-01/ieeg/sub-01_task-x_run-01_events.tsv",
+        "sub-01/ieeg/sub-01_task-x_run-01_ieeg.eeg",
+    ]
+    eeg_key = dep_keys[-1]
+    record = {
+        "dataset": "nm000182",
+        "storage": {
+            "base": "s3://nemar/nm000182",
+            "raw_key": "sub-01/ieeg/sub-01_task-x_run-01_ieeg.vhdr",
+            "annex_keys": {eeg_key: "SHA-EEG"},
+        },
+    }
+
+    def _resolver(*, relpath, base, **kwargs):
+        if relpath == eeg_key:
+            return f"{base}/objects/SHA-EEG"
+        # Sidecars are fetched inline by ``_download_via_nemar``; no URI.
+        return None
+
+    monkeypatch.setattr("eegdash.dataset.base._resolve_one_nemar_entry", _resolver)
+
+    dep_dests = [tmp_path / key for key in dep_keys]
+    _, dep_downloads = _resolve_nemar_uris(
+        record=record,
+        raw_dest=tmp_path / "raw.vhdr",
+        dep_keys=dep_keys,
+        dep_dests=dep_dests,
+    )
+
+    assert dep_downloads == [("s3://nemar/nm000182/objects/SHA-EEG", dep_dests[-1])]
+
+
+def test_resolve_nemar_uris_rejects_misaligned_keys_and_dests(monkeypatch, tmp_path):
+    """A desynchronised key/destination pairing raises instead of shifting."""
+    record = {
+        "dataset": "dsA",
+        "storage": {"base": "s3://nemar/dsA", "raw_key": "sub/raw.fif"},
+    }
+    monkeypatch.setattr(
+        "eegdash.dataset.base._resolve_one_nemar_entry",
+        lambda **kwargs: None,
+    )
+
+    with pytest.raises(ValueError):
+        _resolve_nemar_uris(
+            record=record,
+            raw_dest=tmp_path / "raw.fif",
+            dep_keys=["sub/a.tsv", "sub/b.tsv"],
+            dep_dests=[tmp_path / "a.tsv"],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

NEMAR downloads can write a recording's binary payload over one of its own sidecars, leaving the recording itself absent.

`_resolve_nemar_uris` returns only the dependencies that still need fetching — entries written to disk during resolution (inline sidecars, and anything nemar-py already pulled through the manifest) and entries skipped after a resolution failure contribute no URI. The caller then re-paired that **filtered** list against the **full** `_dep_paths` by position:

```python
downloader.download_files(
    list(zip(self._dep_uris, self._dep_paths, strict=False)),
    ...
)
```

`strict=False` hides the length mismatch, so every dependency after the first omission is downloaded to the wrong path.

BrainVision iEEG datasets are the worst case, because only the `.eeg` annex object comes back as a URI while every sidecar is fetched inline. On `nm000182` (24 subjects, 257 runs) the record carries 7 `dep_keys` but a single dependency `annex_key`, so exactly one URI survives and pairs with dependency 0:

| | |
|---|---|
| `dep_keys` | channels.tsv, events.tsv, electrodes.tsv, coordsystem.json, ieeg.eeg, ieeg.vmrk, ieeg.dat |
| surviving `dep_uris` | 1 — `SHA256E-s50400000--6d0a55d2….eeg` |
| resulting download | 50 MB `.eeg` object → `*_channels.tsv` |

Every one of the 257 runs ended up with the binary payload sitting on `*_channels.tsv`, no `.eeg` anywhere, and the tree unreadable by MNE.

`skip_existing=True` does not protect the correct sidecar. It treats a size mismatch against the remote object as a stale local file and unlinks it:

```python
if dest.exists():
    if skip_existing:
        if remote_size is None or dest.stat().st_size == remote_size:
            continue
    dest.unlink(missing_ok=True)
```

107 bytes != 50,400,000, so the good `channels.tsv` is deleted and overwritten. The post-download size check then passes, because the bytes do match the object that was requested — nothing ever reports an error.

## Fix

`_resolve_nemar_uris` now returns `(uri, destination)` pairs, so a URI cannot be separated from its destination. `EEGDashRaw` gains `_dep_downloads` as the work list handed to `download_files`; `_dep_uris` is unchanged for the `s3`/`https` backends. Both zips that pair keys with destinations are now `strict=True`, so a future desync raises instead of silently shifting.

## Type of change

Bug fix (non-breaking). `_resolve_nemar_uris` is private and has a single call site.

## Testing performed

- New regression tests, each verified to fail on `develop` and pass with the fix:
  - `test_resolve_nemar_uris_pairs_each_uri_with_its_own_destination` — the BrainVision shape above.
  - `test_resolve_nemar_uris_rejects_misaligned_keys_and_dests` — desynced inputs raise.
  - `test_nemar_download_pairs_annex_object_with_its_own_destination` — end-to-end through `_download_required_files`, asserting what `download_files` actually receives. On `develop` it fails with the production symptom: `('…/objects/SHA256E-s2--d.eeg', PosixPath('…_channels.tsv'))`.
- `test_resolve_nemar_uris_with_optional_sidecar_failure` encoded the old behaviour (a dropped dependency shifting the next URI onto its path) and is updated to assert the pairing.
- Full `tests/unit_tests`: **1081 passed, 8 skipped**. `tests/functional`: **16 passed**.
- `ruff check` and `ruff format --check` clean repo-wide (v0.14.10, matching `.pre-commit-config.yaml`); `codespell` clean.
- Real end-to-end download of `nm000182` `sub-000` `run-001` with the patch:

```
         107  text    sub-000_task-MachineLearningEEG_run-001_channels.tsv
      41,113  text    sub-000_task-MachineLearningEEG_run-001_events.tsv
  42,120,000  BINARY  sub-000_task-MachineLearningEEG_run-001_ieeg.eeg
      25,652  text    sub-000_task-MachineLearningEEG_run-001_ieeg.vmrk
```

`mne.io.read_raw_brainvision` then loads it: 1 channel `LMacro_01`, 5000 Hz, 10,530,000 samples. Before the fix, `channels.tsv` was 42,120,000 bytes of float32 and no `.eeg` existed.

## Notes for reviewers

Anyone who downloaded a BrainVision NEMAR dataset with an affected version has a corrupt cache that this fix will not repair, since `skip_existing` sees a `channels.tsv` whose size matches the `.eeg` object. Those caches need clearing.

Adjacent issue left out to keep this focused, happy to send either as a follow-up:

`_COMPANION_FILES[".vhdr"] = [".eeg", ".vmrk", ".dat"]` is a speculative superset. BrainVision's binary is `.eeg` **or** `.dat`, never both, so one entry is always a phantom that 404s — on `nm000182` that is `..._ieeg.dat`. Harmless now that a dropped entry no longer shifts anything, but it means a guaranteed failed resolution and a warning per record. Deriving it from the `.vhdr` `DataFile=` header would be exact.