### PR TITLE
fix: resolve NeuroAI pretraining handoff and unnecessary FDT warnings

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -23,6 +23,7 @@ import filelock
 import mne.io.ctf.info as ctf_info
 import mne_bids
 import nemar
+import numpy as np
 from mne.io import BaseRaw
 from mne_bids import BIDSPath
 
@@ -38,6 +39,7 @@ from .exceptions import DataIntegrityError, StorageAccessError
 from .io import (
     _ANNEX_KEY_RE,
     _convert_time_with_numeric_dash,
+    _eeglab_load_first_eeg,
     _ensure_coordsystem_symlink,
     _fix_negative_annotation_durations,
     _generate_coordsystem_json,
@@ -690,37 +692,34 @@ class EEGDashRaw(RawDataset):
         # the keys lazily (and only when the file isn't already cached)
         # so that we don't hit GitHub raw for files that are already on
         # disk.
+        dep_keys = (self.record.get("storage") or {}).get("dep_keys") or []
+        deferred_nemar_deps = (
+            self._storage_backend == "nemar"
+            and self.filecache.suffix.lower() == ".set"
+            and (self._raw_uri is not None or not self.filecache.exists())
+        )
         if (
             self._raw_uri is None
             and self._storage_backend == "nemar"
             and not self.filecache.exists()
         ):
-            dep_keys = (self.record.get("storage") or {}).get("dep_keys") or []
             self._raw_uri, self._dep_downloads = _resolve_nemar_uris(
                 self.record,
                 raw_dest=self.filecache,
-                dep_keys=list(dep_keys),
-                dep_dests=list(self._dep_paths),
+                dep_keys=[] if deferred_nemar_deps else list(dep_keys),
+                dep_dests=[] if deferred_nemar_deps else list(self._dep_paths),
             )
 
-        if self._raw_uri is not None:
+        if self._raw_uri is not None or deferred_nemar_deps:
             filesystem = downloader.get_s3_filesystem(
                 max_concurrency=self._max_concurrency
             )
 
-            # Download deps first (sidecars, companions), then raw.
-            # skip_missing=True because dep_keys may include companion files
-            # that don't exist on S3 (e.g., .fdt listed but never uploaded).
-            downloader.download_files(
-                self._dep_downloads,
-                filesystem=filesystem,
-                skip_existing=True,
-                skip_missing=True,
-            )
             try:
-                downloader.download_s3_file(
-                    self._raw_uri, self.filecache, filesystem=filesystem
-                )
+                if self._raw_uri is not None:
+                    downloader.download_s3_file(
+                        self._raw_uri, self.filecache, filesystem=filesystem
+                    )
             except FileNotFoundError:
                 raw_key = (self.record.get("storage") or {}).get("raw_key", "")
                 if self._storage_backend == "nemar" and self._download_nemar_data_file(
@@ -789,9 +788,45 @@ class EEGDashRaw(RawDataset):
                 else:
                     raise
 
+            # Some catalogue records list an .fdt even though EEG.data contains
+            # the samples. Inspect the acquired .set before requesting companions.
+            embedded_samples = False
+            if self.filecache.suffix.lower() == ".set":
+                eeg = _eeglab_load_first_eeg(self.filecache)
+                data = np.asarray(eeg.get("data")) if eeg is not None else None
+                embedded_samples = (
+                    data is not None
+                    and data.size > 0
+                    and np.issubdtype(data.dtype, np.number)
+                )
+            if deferred_nemar_deps:
+                selected = [
+                    (key, dest)
+                    for key, dest in zip(dep_keys, self._dep_paths, strict=True)
+                    if not (embedded_samples and dest.suffix.lower() == ".fdt")
+                ]
+                _, self._dep_downloads = _resolve_nemar_uris(
+                    self.record,
+                    raw_dest=self.filecache,
+                    dep_keys=[key for key, _ in selected],
+                    dep_dests=[dest for _, dest in selected],
+                )
+            dependencies = [
+                (uri, dest)
+                for uri, dest in self._dep_downloads
+                if not (embedded_samples and dest.suffix.lower() == ".fdt")
+            ]
+            downloader.download_files(
+                dependencies,
+                filesystem=filesystem,
+                skip_existing=True,
+                skip_missing=True,
+            )
+
             # Auto-discover and download companion files (.fdt, .eeg, .vmrk)
             # that may not have been included in dep_keys.
-            self._download_companion_files(filesystem)
+            if not embedded_samples:
+                self._download_companion_files(filesystem)
             if self._storage_backend == "nemar":
                 self._fetch_nemar_root_metadata()
 

--- a/examples/tutorials/70_transfer_foundation/plot_74_neuroai_interop.py
+++ b/examples/tutorials/70_transfer_foundation/plot_74_neuroai_interop.py
@@ -256,3 +256,37 @@ plt.show()
 #
 # Related data-boundary example: `Braindecode training on MNE epochs
 # <https://braindecode.org/stable/auto_examples/model_building/plot_basic_training_epochs.html>`_.
+
+# %%
+# Continue to self-supervised pretraining
+# ---------------------------------------
+#
+# Follow NeuroAI's `Training a model: masked prediction on EEG
+# <https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/plot_pretrain_mae.html>`_
+# for a worked pretraining loop, checkpoint export and downstream evaluation.
+# Masked prediction reconstructs hidden portions of recorded EEG; the imagery
+# labels above are not reconstruction targets.
+#
+# 1. Follow the guide's installation instructions for the repository's
+#    ``ssl_example`` project and its training dependencies. From its
+#    ``neuraltrain-repo`` directory, start with the real-data debug run:
+#
+#    .. code-block:: console
+#
+#       python -m ssl_example.grids.test_run
+#
+# 2. Configure the studies, subject splits and data/cache/output paths before
+#    using the guide's download and full-training commands. Its default corpus
+#    needs roughly 1.1 TB; the debug run uses a small real MNE recording.
+#
+# 3. Use the printed ``encoder.ckpt`` path in the guide's downstream evaluation
+#    command. Match the encoder configuration and preprocessing to pretraining;
+#    a reconstruction loss alone does not establish decoding performance.
+#
+# Adapting this conversion requires more than passing ``loader`` to that script.
+# Here batches contain ``eeg`` at 250 Hz, with 500 samples and stimulus anchors.
+# The guide constructs ``input`` batches, channel positions and recording-strided
+# windows at 120 Hz for its patch encoder. Adapt its study/extractor configuration
+# to the acquired recordings, retain subject-level separation, and verify the
+# resulting batch contract before training. The NPZ is a voltage export, not a
+# pretrained checkpoint or a registered NeuroAI study.

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -2767,3 +2767,130 @@ def test_load_raw_direct_ctf_calls_read_raw_ctf(tmp_path):
 
     mock_reader.assert_called_once_with(str(ds_path), preload=False, verbose="ERROR")
     assert result is mock_raw
+
+
+@pytest.mark.parametrize("backend", ["s3", "nemar"])
+@pytest.mark.parametrize("declared", [False, True])
+@pytest.mark.parametrize("embedded", [False, True])
+def test_set_download_checks_samples_before_fdt(tmp_path, declared, embedded, backend):
+    """Numeric EEG.data needs no .fdt, even with stale catalogue/datfile entries."""
+    import scipy.io
+
+    ds = _make_s3_raw(tmp_path, ".set")
+    sidecar = ds.filecache.with_suffix(".json")
+    fdt = ds.filecache.with_suffix(".fdt")
+    ds._dep_downloads = [(ds._raw_uri.replace(".set", ".json"), sidecar)]
+    if declared:
+        fdt_uri = ds._raw_uri.replace(".set", ".fdt")
+        ds._dep_downloads.append((fdt_uri, fdt))
+        ds.record["storage"]["dep_keys"] = [
+            ds.record["bids_relpath"].replace(".set", ".fdt")
+        ]
+
+    raw_uri = ds._raw_uri
+    selected = [
+        (uri, dest) for uri, dest in ds._dep_downloads if dest != fdt or not embedded
+    ]
+    if backend == "nemar":
+        ds._storage_backend = "nemar"
+        ds._raw_uri = None
+        ds.record["storage"]["dep_keys"] = [
+            str(dest.relative_to(ds.bids_root)) for _, dest in ds._dep_downloads
+        ]
+        ds._dep_paths = [dest for _, dest in ds._dep_downloads]
+
+    def acquire_primary(uri, destination, **kwargs):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        scipy.io.savemat(
+            destination,
+            {
+                "EEG": {
+                    "data": [[1.0, -1.0]] if embedded else fdt.name,
+                    "datfile": fdt.name,
+                }
+            },
+        )
+
+    with (
+        patch(
+            "eegdash.dataset.base._resolve_nemar_uris",
+            side_effect=[(raw_uri, []), (raw_uri, selected)],
+        ) as resolve,
+        patch.object(ds, "_fetch_nemar_root_metadata"),
+        patch("eegdash.dataset.base.downloader.get_s3_filesystem"),
+        patch(
+            "eegdash.dataset.base.downloader.download_s3_file",
+            side_effect=acquire_primary,
+        ),
+        patch(
+            "eegdash.dataset.base.downloader.download_files"
+        ) as download_dependencies,
+        patch.object(ds, "_download_companion_files") as discover,
+    ):
+        ds._download_required_files()
+
+    destinations = [dest for _, dest in download_dependencies.call_args.args[0]]
+    assert sidecar in destinations
+    assert (fdt in destinations) == (declared and not embedded)
+    assert discover.call_count == (0 if embedded else 1)
+    if backend == "nemar":
+        assert resolve.call_args_list[0].kwargs["dep_keys"] == []
+        resolved_paths = resolve.call_args_list[1].kwargs["dep_dests"]
+        assert (fdt in resolved_paths) == (declared and not embedded)
+
+
+@pytest.mark.parametrize("primary_mode", ["retry", "resolved_to_disk"])
+def test_nemar_set_resolves_dependencies_after_primary(tmp_path, primary_mode):
+    """Deferred sidecars survive retries and direct-to-disk primary resolution."""
+    import scipy.io
+
+    ds = _make_s3_raw(tmp_path, ".set")
+    raw_uri = ds._raw_uri
+    ds._storage_backend = "nemar"
+    ds._raw_uri = None
+    sidecar = ds.filecache.with_suffix(".json")
+    sidecar_uri = raw_uri.replace(".set", ".json")
+    ds._dep_paths = [sidecar]
+    ds.record["storage"]["dep_keys"] = [str(sidecar.relative_to(ds.bids_root))]
+
+    def write_primary():
+        ds.filecache.parent.mkdir(parents=True, exist_ok=True)
+        scipy.io.savemat(ds.filecache, {"EEG": {"data": "recording.fdt"}})
+
+    def resolve(record, raw_dest, dep_keys, dep_dests):
+        if not dep_keys:
+            assert not raw_dest.exists()
+            if primary_mode == "resolved_to_disk":
+                write_primary()
+                return None, []
+            return raw_uri, []
+        assert raw_dest.exists(), "Dependencies must wait for the primary file"
+        assert dep_dests == [sidecar]
+        return None, [(sidecar_uri, sidecar)]
+
+    def acquire_primary(uri, destination, **kwargs):
+        assert uri == raw_uri and destination == ds.filecache
+        write_primary()
+
+    with (
+        patch(
+            "eegdash.dataset.base._resolve_nemar_uris", side_effect=resolve
+        ) as resolver,
+        patch("eegdash.dataset.base.downloader.get_s3_filesystem"),
+        patch("eegdash.dataset.base.downloader.download_s3_file") as acquire,
+        patch("eegdash.dataset.base.downloader.download_files") as dependencies,
+        patch.object(ds, "_download_companion_files"),
+        patch.object(ds, "_fetch_nemar_root_metadata"),
+    ):
+        if primary_mode == "retry":
+            acquire.side_effect = TimeoutError("temporary primary-file outage")
+            with pytest.raises(TimeoutError, match="temporary primary-file outage"):
+                ds._download_required_files()
+            dependencies.assert_not_called()
+            acquire.side_effect = acquire_primary
+        ds._download_required_files()
+
+    assert resolver.call_count == 2
+    assert resolver.call_args.kwargs["dep_dests"] == [sidecar]
+    assert dependencies.call_args.args[0] == [(sidecar_uri, sidecar)]
+    assert acquire.call_count == (2 if primary_mode == "retry" else 0)


### PR DESCRIPTION
Fixes #413
Fixes #414

The NeuroAI conversion tutorial stopped before explaining how to start pretraining. It now links to the maintained masked-prediction guide, gives its real-data debug command, and explains how its input keys, sampling, geometry and split requirements differ from the exported loader.

EEGLAB recordings with embedded samples previously triggered a failed download and warning for a speculative `.fdt`. The loader now inspects the acquired `.set` using the existing reader, excludes unnecessary `.fdt` dependencies and discovery, and preserves external-data handling. NEMAR companion resolution is deferred until that inspection, including retries after a primary download failure.

Validation: the exact recording reported in #414 loaded from a fresh cache (129 channels, 181,389 samples at 500 Hz) without an `.fdt` request or warning. The NeuroAI example ran on real EEG, and its focused Sphinx build passed with warnings treated as errors. Dataset/downloader tests and pre-commit checks passed, with regression coverage for embedded/external storage and both download backends.
