### PR TITLE
fix(dataset): resume companions after interrupted NEMAR downloads

### DIFF
--- a/eegdash/dataset/base.py
+++ b/eegdash/dataset/base.py
@@ -373,16 +373,18 @@ def _resolve_nemar_uris(
     if not (base and raw_key and dataset_id):
         return None, []
 
-    stored_key, stored_sidecar = _nemar_fast_paths(storage, raw_key)
-    raw_uri = _resolve_one_nemar_entry(
-        dataset_id=dataset_id,
-        relpath=raw_key,
-        base=base,
-        dest=raw_dest,
-        stored_key=stored_key,
-        stored_sidecar=stored_sidecar,
-        is_required=True,
-    )
+    raw_uri = None
+    if not raw_dest.exists():
+        stored_key, stored_sidecar = _nemar_fast_paths(storage, raw_key)
+        raw_uri = _resolve_one_nemar_entry(
+            dataset_id=dataset_id,
+            relpath=raw_key,
+            base=base,
+            dest=raw_dest,
+            stored_key=stored_key,
+            stored_sidecar=stored_sidecar,
+            is_required=True,
+        )
 
     dep_downloads: list[tuple[str, Path]] = []
     for dep_key, dep_dest in zip(dep_keys, dep_dests, strict=True):
@@ -694,9 +696,7 @@ class EEGDashRaw(RawDataset):
         # disk.
         dep_keys = (self.record.get("storage") or {}).get("dep_keys") or []
         deferred_nemar_deps = (
-            self._storage_backend == "nemar"
-            and self.filecache.suffix.lower() == ".set"
-            and (self._raw_uri is not None or not self.filecache.exists())
+            self._storage_backend == "nemar" and self.filecache.suffix.lower() == ".set"
         )
         if (
             self._raw_uri is None
@@ -803,7 +803,8 @@ class EEGDashRaw(RawDataset):
                 selected = [
                     (key, dest)
                     for key, dest in zip(dep_keys, self._dep_paths, strict=True)
-                    if not (embedded_samples and dest.suffix.lower() == ".fdt")
+                    if not dest.exists()
+                    and not (embedded_samples and dest.suffix.lower() == ".fdt")
                 ]
                 _, self._dep_downloads = _resolve_nemar_uris(
                     self.record,

--- a/tests/unit_tests/dataset/test_base.py
+++ b/tests/unit_tests/dataset/test_base.py
@@ -2894,3 +2894,70 @@ def test_nemar_set_resolves_dependencies_after_primary(tmp_path, primary_mode):
     assert resolver.call_args.kwargs["dep_dests"] == [sidecar]
     assert dependencies.call_args.args[0] == [(sidecar_uri, sidecar)]
     assert acquire.call_count == (2 if primary_mode == "retry" else 0)
+
+
+@pytest.mark.parametrize("embedded", [False, True])
+@pytest.mark.parametrize("metadata_cached", [False, True])
+def test_fresh_nemar_set_retries_only_missing_dependencies(
+    tmp_path, embedded, metadata_cached
+):
+    """A process restart resumes companions without fetching cached or embedded data."""
+    import scipy.io
+
+    relative = "sub-01/eeg/sub-01_task-rest_eeg.set"
+    overrides = {
+        "dataset": "nm000001",
+        "storage": {
+            "backend": "nemar",
+            "base": "s3://nemar/nm000001",
+            "raw_key": relative,
+            "dep_keys": [
+                relative.replace(".set", suffix) for suffix in (".fdt", ".json")
+            ],
+        },
+    }
+    interrupted = _make_s3_raw(tmp_path, ".set", overrides)
+    interrupted.filecache.parent.mkdir(parents=True, exist_ok=True)
+    scipy.io.savemat(
+        interrupted.filecache,
+        {
+            "EEG": {
+                "data": [[1.0, -1.0]]
+                if embedded
+                else interrupted.filecache.with_suffix(".fdt").name
+            }
+        },
+    )
+    if metadata_cached:
+        interrupted.filecache.with_suffix(".json").write_text("{}")
+    restarted = _make_s3_raw(tmp_path, ".set", overrides)
+    assert restarted._raw_uri is None
+
+    def download(files, **kwargs):
+        for _, destination in files:
+            destination.write_bytes(b"cached companion")
+
+    with (
+        patch(
+            "eegdash.dataset.base._resolve_one_nemar_entry",
+            return_value="s3://nemar/companion",
+        ) as resolve,
+        patch("eegdash.dataset.base.downloader.get_s3_filesystem"),
+        patch("eegdash.dataset.base.downloader.download_s3_file") as primary,
+        patch("eegdash.dataset.base.downloader.download_files", side_effect=download),
+        patch.object(restarted, "_fetch_nemar_root_metadata"),
+    ):
+        restarted._download_required_files()
+        expected = set()
+        if not embedded:
+            expected.add(restarted.filecache.with_suffix(".fdt"))
+        if not metadata_cached:
+            expected.add(restarted.filecache.with_suffix(".json"))
+        assert {call.kwargs["dest"] for call in resolve.call_args_list} == expected
+        primary.assert_not_called()
+        assert all(path.exists() for path in expected)
+        resolve.reset_mock()
+        # Even stale FDT catalogue entries must not trigger another request.
+        restarted._download_required_files()
+        resolve.assert_not_called()
+        primary.assert_not_called()


### PR DESCRIPTION
A restarted loader skipped all NEMAR dependency downloads when the primary `.set` was already cached. An interruption after acquiring that file could therefore leave an external `.fdt` or event/channel sidecar permanently missing.

Inspect cached NEMAR `.set` files too, resolve only missing dependencies, and preserve the embedded-data exclusion. The resolver reuses an existing primary file instead of resolving/downloading it again.

Validation: regression cases cover new loader instances with embedded/external data and present/missing metadata, plus a second cached load with no repeated file resolution. A real cached nm000118 recording reopened successfully after removing its event sidecar from an isolated cache; the sidecar was restored. Dataset/downloader tests and pre-commit passed.

Addresses the follow-up review on #415: https://github.com/eegdash/EEGDash/pull/415#discussion_r3982126132
