### PR TITLE
fix(docs): execute the full tutorial gallery in CI

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -114,11 +114,9 @@ jobs:
         run: python -m pytest -q tests/unit_tests/test_eeg2026_gallery.py
 
       - name: Create Docs
-        env:
-          # Execute ~32 MB SSVEP/imagery (including Track 2) plus ~24 MB pose.
-          # Task-specific HBN, P300 and challenge sources are rendered here;
-          # run the default full gallery separately with their larger datasets.
-          EEGDASH_GALLERY_FILENAME_PATTERN: '/(?:plot_(?:0[0-2]|1[0-3]|4[0-2]|5[0-5])_[^/]+|how_to_[^/]+|tutorial_track_2_bci|tutorial_track_4_emg_to_pose)\.py$'
+        # Full gallery (~1.5 GB of recordings, cached above). A narrower
+        # EEGDASH_GALLERY_FILENAME_PATTERN silently renders the excluded
+        # tutorials without any output on eegdash.org (#420).
         run: |
           cd docs
           make html

--- a/examples/applied/project_pfactor_deep.py
+++ b/examples/applied/project_pfactor_deep.py
@@ -213,7 +213,9 @@ for fold, (train, test) in enumerate(
     train_loader = DataLoader(
         TensorDataset(
             torch.from_numpy(X[train]),
-            torch.from_numpy((y[train] - target_mean) / target_scale),
+            torch.from_numpy(
+                ((y[train] - target_mean) / target_scale).astype(np.float32)
+            ),
         ),
         batch_size=16,
         shuffle=True,


### PR DESCRIPTION
## Summary

Closes #420.

- **`.github/workflows/doc.yaml`** — drop the `EEGDASH_GALLERY_FILENAME_PATTERN` override added in #411. It left 19 gallery scripts (`plot_20/21/30/70–74`, `eeg2025/*`, `eeg2026` tracks 1 & 3, every `applied/project_*`, `hpc/*`) unexecuted, so eegdash.org served them with **no output at all** (checked the live pages: zero `sphx-glr-script-out` blocks). The "run the full gallery separately" the comment referred to never existed. `conf.py`'s default pattern already covers every script.
- **`examples/applied/project_pfactor_deep.py`** — cast the standardized regression targets to `float32`; once executed it failed with `RuntimeError: Found dtype Double but expected Float`.

## Test plan

- [x] Ran all 19 previously-excluded scripts locally against `develop` with a cold cache: 19/19 exit 0 (after the float32 fix), ~7 min wall total, ~1.5 GB of recordings (`ds005505` 614 MB, `ds005514` 291 MB, `nm000232` 273 MB, rest < 160 MB each).
- [x] Also ran the three scripts changed by #418 (`project_eyes_open_closed_cnn`, `project_face_familiarity`, `plot_73_finetune_pretrained_model`): exit 0.
- [ ] Docs CI on this PR renders every tutorial with output; watch the job duration on the first (cold-cache) run.
